### PR TITLE
MOTECH-1411: JDK for Motech set to 1.8 + java.time support for MDS

### DIFF
--- a/docs/source/get_started/model_data/model_data.rst
+++ b/docs/source/get_started/model_data/model_data.rst
@@ -1090,12 +1090,20 @@ MDS supports multiple types
 |           |java.util.Date          |datetime       |timestamp with      |A type representing the java.util.Date.     |
 |           |                        |               |time zone           |Only available for DDE.                     |
 +-----------+------------------------+---------------+--------------------+--------------------------------------------+
-|Date       |org.joda.time.LocalDate |date           |date                |A type representing the LocalDate class     |
+|           |org.joda.time.LocalDate |date           |date                |A type representing the LocalDate class     |
 |           |                        |               |                    |from the Joda library. Does not represent   |
+|           |                        |               |                    |time, only date. Only available for DDE.    |
++-----------+------------------------+---------------+--------------------+--------------------------------------------+
+|           |org.joda.time.DateTime  |datetime       |timestamp with      |A type representing the DateTime class      |
+|           |                        |               |time zone           |from the Joda library. Only available for   |
+|           |                        |               |                    |DDE.                                        |
++-----------+------------------------+---------------+--------------------+--------------------------------------------+
+|Date       |java.time.LocalDate     |date           |date                |A type representing the LocalDate class     |
+|           |                        |               |                    |from Java8 time API. Does not represent     |
 |           |                        |               |                    |time, only date.                            |
 +-----------+------------------------+---------------+--------------------+--------------------------------------------+
-|DateTime   |org.joda.time.DateTime  |datetime       |timestamp with      |A type representing the DateTime class      |
-|           |                        |               |time zone           |from the Joda library.                      |
+|DateTime   |java.time.LocalDateTime |datetime       |timestamp with      |A type representing the LocalDateTime class |
+|           |                        |               |time zone           |from Java8 time API.                        |
 +-----------+------------------------+---------------+--------------------+--------------------------------------------+
 |Decimal    |java.lang.Double        |double         |double precision    |A decimal field number.                     |
 +-----------+------------------------+---------------+--------------------+--------------------------------------------+

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/AvailableController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/AvailableController.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.web.controller;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.joda.time.DateTime;
 import org.motechproject.mds.domain.Relationship;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.service.TypeService;
@@ -46,6 +47,10 @@ public class AvailableController extends MdsController {
         list.remove(typeService.findType(Long.class));
         list.remove(typeService.findType(Date.class));
         list.remove(typeService.findType(Relationship.class));
+
+        //The DateTime and LocalDate types from Joda are available for DDEs exclusively
+        list.remove(typeService.findType(DateTime.class));
+        list.remove(typeService.findType(org.joda.time.LocalDate.class));
 
         // TextArea type is available only from UI
         TypeDto textAreaType = new TypeDto();

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
@@ -33,6 +33,7 @@ import org.motechproject.mds.filter.Filters;
 import org.motechproject.mds.helper.DataServiceHelper;
 import org.motechproject.mds.helper.MdsBundleHelper;
 import org.motechproject.mds.lookup.LookupExecutor;
+import org.motechproject.mds.query.InMemoryQueryFilter;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.HistoryService;
@@ -42,7 +43,6 @@ import org.motechproject.mds.service.TypeService;
 import org.motechproject.mds.service.impl.history.HistoryTrashClassHelper;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
-import org.motechproject.mds.query.InMemoryQueryFilter;
 import org.motechproject.mds.util.MDSClassLoader;
 import org.motechproject.mds.util.MemberUtil;
 import org.motechproject.mds.util.PropertyUtil;
@@ -69,6 +69,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -909,6 +912,12 @@ public class InstanceServiceImpl implements InstanceService {
             parsedValue = ((Time) parsedValue).timeStr();
         } else if (parsedValue instanceof LocalDate) {
             parsedValue = parsedValue.toString();
+        } else if (parsedValue instanceof java.time.LocalDate) {
+            parsedValue = parsedValue.toString();
+        } else if (parsedValue instanceof LocalDateTime) {
+            //Using ZonedDateTime for retrieving timezone
+            ZonedDateTime zonedDateTime = ZonedDateTime.of((LocalDateTime) parsedValue, ZoneOffset.systemDefault());
+            parsedValue = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm xxxx").format(zonedDateTime);
         } else if (relatedFieldMetadata != null) {
             parsedValue = removeCircularRelations(parsedValue, relatedFieldMetadata.getValue());
         }

--- a/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
@@ -949,7 +949,8 @@
         */
         $scope.filterableTypes = [
             "mds.field.combobox", "mds.field.boolean", "mds.field.date",
-            "mds.field.datetime", "mds.field.localDate"
+            "mds.field.datetime", "mds.field.localDate", "mds.field.date8",
+            "mds.field.datetime8"
         ];
 
         $scope.relationshipClasses = [{
@@ -3914,7 +3915,7 @@
         };
 
         $scope.isDateField = function(field) {
-            return field.type.typeClass === "org.joda.time.LocalDate";
+            return field.type.typeClass === "org.joda.time.LocalDate" || field.type.typeClass === "java.time.LocalDate";
         };
 
         $scope.isTextArea = function (field) {
@@ -4029,7 +4030,7 @@
             var type = field.type.typeClass;
             if (type === "java.lang.Boolean") {
                 return ['ALL', 'YES', 'NO'];
-            } else if (type === "java.util.Date" || type === "org.joda.time.DateTime" || type === "org.joda.time.LocalDate") {
+            } else if (type === "java.util.Date" || type === "org.joda.time.DateTime" || type === "org.joda.time.LocalDate" || type === "java.time.LocalDateTime" || type === "java.time.LocalDate") {
                 return ['ALL', 'TODAY', 'PAST_7_DAYS', 'THIS_MONTH', 'THIS_YEAR'];
             } else if (type === "java.util.List") {
                 return  ['ALL'].concat($scope.getComboboxValues(field.settings));
@@ -4084,9 +4085,9 @@
                 value = "boolean";
             } else if (field.className === "java.util.Collection") {
                 value = "list";
-            } else if (field.className === "org.joda.time.DateTime" || field.className === "java.util.Date") {
+            } else if (field.className === "org.joda.time.DateTime" || field.className === "java.util.Date" || field.className === "java.time.LocalDateTime") {
                 value = "datetime";
-            } else if (field.className === "org.joda.time.LocalDate") {
+            } else if (field.className === "org.joda.time.LocalDate" || field.className === "java.time.LocalDate") {
                 value = "date";
             }
 
@@ -4222,7 +4223,7 @@
         };
 
         $scope.typeIsDate = function (type) {
-            return type === "java.util.Date" || type === "org.joda.time.DateTime" || type === "org.joda.time.LocalDate";
+            return type === "java.util.Date" || type === "org.joda.time.DateTime" || type === "org.joda.time.LocalDate" || type === "java.time.LocalDateTime" || type === "java.time.LocalDate";
         };
 
         $scope.typeIsTime = function (type) {

--- a/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
+++ b/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
@@ -128,8 +128,10 @@ mds.form.label.nonDisplayable=Hidden in Data Browser
 #Default fields name
 mds.field.boolean=Boolean
 mds.field.combobox=Combobox
-mds.field.date=Date
-mds.field.datetime=DateTime
+mds.field.date=Date Joda
+mds.field.date8=Date
+mds.field.datetime=DateTime Joda
+mds.field.datetime8=DateTime
 mds.field.decimal=Decimal
 mds.field.integer=Integer
 mds.field.string=String

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-basic-defaultValue-date8.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-basic-defaultValue-date8.html
@@ -1,0 +1,2 @@
+<input date-validity default-field-name-valid="{{field.basic.name}}" ng-class="{'has-error': {{field.basic.name}}.$invalid}" class="form-control input-xlarge-fluid" type="text" ng-model="field.basic.defaultValue" ng-change="dateDefaultValueChange(field.basic.defaultValue, {{field.id}})" mds-field-id="{{field.id}}" ng-readonly="field.readOnly" mds-date-picker>
+<span class="form-hint" ng-show="{{field.basic.name}}.$error.date">{{msg('mds.error.incorrectDate')}}</span>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-basic-defaultValue-datetime8.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-basic-defaultValue-datetime8.html
@@ -1,0 +1,3 @@
+<input date-time-validity default-field-name-valid="{{field.basic.name}}" class="form-control input-xlarge-fluid" type="text" ng-model="field.basic.defaultValue" mds-auto-save-field-change mds-field-id="{{field.id}}"
+       ng-class="{'has-error': {{field.basic.name}}.$invalid}" ng-readonly="field.readOnly" mds-datetime-picker>
+<span class="form-hint" ng-show="{{field.basic.name}}.$error.datetime && !{{field.basic.name}}.$pristine">{{msg('mds.error.incorrectDate')}}</span>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-edit-Value-date8.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-edit-Value-date8.html
@@ -1,0 +1,2 @@
+<input date-validity ng-required="{{field.required}}" class="form-control input-xlarge-fluid" ng-model="field.value" type="text" placeholder="{{field.placeholder}}" mds-field-id="{{field.id}}" mds-date-picker ng-readonly="shouldHideEdition(field)">
+<span class="form-hint" ng-show="{{field.name}}.$error.date && !{{field.name}}.$pristine">{{msg('mds.error.incorrectDate')}}</span>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-edit-Value-datetime8.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/field-edit-Value-datetime8.html
@@ -1,0 +1,2 @@
+<input date-time-validity ng-required="{{field.required}}" class="form-control input-xlarge-fluid" type="text" ng-model="field.value" placeholder="{{field.placeholder}}" mds-field-id="{{field.id}}" mds-datetime-picker ng-readonly="shouldHideEdition(field)">
+<span class="form-hint" ng-show="{{field.name}}.$error.datetime && !{{field.name}}.$pristine">{{msg('mds.error.incorrectDate')}}</span>

--- a/platform/mds/mds/pom.xml
+++ b/platform/mds/mds/pom.xml
@@ -111,6 +111,10 @@
             <artifactId>datanucleus-jodatime</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-java8</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.flyway</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/annotations/internal/UIFilterableProcessor.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/annotations/internal/UIFilterableProcessor.java
@@ -25,7 +25,9 @@ import static org.motechproject.mds.dto.TypeDto.BOOLEAN;
 import static org.motechproject.mds.dto.TypeDto.DATE;
 import static org.motechproject.mds.dto.TypeDto.DATETIME;
 import static org.motechproject.mds.dto.TypeDto.COLLECTION;
+import static org.motechproject.mds.dto.TypeDto.DATETIME8;
 import static org.motechproject.mds.dto.TypeDto.LOCAL_DATE;
+import static org.motechproject.mds.dto.TypeDto.LOCAL_DATE8;
 import static org.motechproject.mds.util.Constants.AnnotationFields.NAME;
 
 /**
@@ -39,7 +41,7 @@ import static org.motechproject.mds.util.Constants.AnnotationFields.NAME;
 @Component
 class UIFilterableProcessor extends AbstractListProcessor<UIFilterable, String> {
     private static final Logger LOGGER = LoggerFactory.getLogger(UIFilterableProcessor.class);
-    private static final TypeDto[] SUPPORT_TYPES = {BOOLEAN, DATE, DATETIME, LOCAL_DATE, COLLECTION};
+    private static final TypeDto[] SUPPORT_TYPES = {BOOLEAN, DATE, DATETIME, LOCAL_DATE, COLLECTION, LOCAL_DATE8, DATETIME8};
 
     private TypeService typeService;
     private Class clazz;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
@@ -10,6 +10,7 @@ import org.joda.time.LocalDate;
 import org.joda.time.Period;
 import org.motechproject.commons.date.model.Time;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class TypeDto {
     );
 
     /**
-     * Constant <code>DATE</code> is a representation of the MDS Date type.
+     * Constant <code>DATE</code> is a representation of the MDS Joda Date type.
      */
     public static final TypeDto DATE = new TypeDto(
             "mds.field.date", "mds.field.description.date", "date", Date.class.getName()
@@ -84,10 +85,17 @@ public class TypeDto {
     );
 
     /**
-     * Constant <code>DATETIME</code> is a representation of the MDS DateTime type.
+     * Constant <code>DATETIME</code> is a representation of the MDS Joda DateTime type.
      */
     public static final TypeDto DATETIME = new TypeDto(
             "mds.field.datetime", "mds.field.description.datetime", "datetime", DateTime.class.getName()
+    );
+
+    /**
+     * Constant <code>DATETIME8</code> is a representation of the MDS Java8 DateTime type.
+     */
+    public static final TypeDto DATETIME8 = new TypeDto(
+            "mds.field.datetime8", "mds.field.description.datetime", "datetime", LocalDateTime.class.getName()
     );
 
     /**
@@ -109,6 +117,13 @@ public class TypeDto {
      */
     public static final TypeDto LOCAL_DATE = new TypeDto(
             "mds.field.localDate", "mds.field.description.localDate", "localDate", LocalDate.class.getName()
+    );
+
+    /**
+     * Constant <code>LOCAL_DATE8</code> is a representation of the MDS Java8 LocalDate type.
+     */
+    public static final TypeDto LOCAL_DATE8 = new TypeDto(
+            "mds.field.localDate8", "mds.field.description.localDate", "localDate", java.time.LocalDate.class.getName()
     );
 
     /**

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/JavassistUtil.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/JavassistUtil.java
@@ -116,7 +116,7 @@ public final class JavassistUtil {
             try {
                 ctClass.removeField(field);
             } catch (NotFoundException e) {
-                throw new IllegalStateException("Field was removed from class before we could do it - possible concurrency issue");
+                throw new IllegalStateException("Field was removed from class before we could do it - possible concurrency issue", e);
             }
         }
     }
@@ -127,7 +127,7 @@ public final class JavassistUtil {
             try {
                 ctClass.removeField(field);
             } catch (NotFoundException e) {
-                throw new IllegalStateException("Field was removed from class before we could do it - possible concurrency issue");
+                throw new IllegalStateException("Field was removed from class before we could do it - possible concurrency issue", e);
             }
         }
     }
@@ -174,7 +174,7 @@ public final class JavassistUtil {
             try {
                 ctClass.removeMethod(method);
             } catch (NotFoundException e) {
-                throw new IllegalStateException("Method was removed from class before we could do it - possible concurrency issue");
+                throw new IllegalStateException("Method was removed from class before we could do it - possible concurrency issue", e);
             }
         }
     }
@@ -185,7 +185,7 @@ public final class JavassistUtil {
             try {
                 ctClass.removeMethod(method);
             } catch (NotFoundException e) {
-                throw new IllegalStateException("Method was removed from class before we could do it - possible concurrency issue");
+                throw new IllegalStateException("Method was removed from class before we could do it - possible concurrency issue", e);
             }
         }
     }

--- a/platform/mds/mds/src/main/resources/db/migration/default/V42__MOTECH-1411.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V42__MOTECH-1411.sql
@@ -1,0 +1,3 @@
+-- add support for java.time API
+INSERT INTO Type VALUES (21, "mds.field.description.datetime", "mds.field.datetime8", "datetime", "java.time.LocalDateTime");
+INSERT INTO Type VALUES (22, "mds.field.description.localDate", "mds.field.date8", "localDate", "java.time.LocalDate");

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V42__MOTECH-1411.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V42__MOTECH-1411.sql
@@ -1,0 +1,3 @@
+-- add support for java.time API
+INSERT INTO Type VALUES (21, "mds.field.description.datetime", "mds.field.datetime8", "datetime", "java.time.LocalDateTime");
+INSERT INTO Type VALUES (22, "mds.field.description.localDate", "mds.field.date8", "localDate", "java.time.LocalDate");

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/EntityBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/EntityBuilderTest.java
@@ -31,6 +31,7 @@ import javax.jdo.annotations.Unique;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -79,7 +80,8 @@ public class EntityBuilderTest {
                 field("time", Time.class), field("str", String.class), field("dec", Double.class),
                 field("bool", Boolean.class), field("date", Date.class), field("dt", DateTime.class),
                 field("ld", LocalDate.class), field("locale", Locale.class), enumListField, field("CapitalizedName", String.class),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true),
+                field("jd", java.time.LocalDate.class), field("jdt", LocalDateTime.class)));
 
         Class<?> clazz = buildClass();
 
@@ -93,6 +95,8 @@ public class EntityBuilderTest {
         assertField(clazz, "dt", DateTime.class);
         assertField(clazz, "ld", LocalDate.class);
         assertField(clazz, "locale", Locale.class);
+        assertField(clazz, "jd", java.time.LocalDate.class);
+        assertField(clazz, "jdt", LocalDateTime.class);
         // should use uncapitalized version
         assertField(clazz, "capitalizedName", String.class);
     }
@@ -102,12 +106,15 @@ public class EntityBuilderTest {
         final Date date = new Date();
         final DateTime dateTime = DateUtil.now();
         final LocalDate localDate = DateUtil.now().plusYears(1).toLocalDate();
+        final LocalDateTime javaLocalDateTime = LocalDateTime.now().plusDays(1);
+        final java.time.LocalDate javaLocalDate = java.time.LocalDate.now().plusDays(1);
 
         when(entity.getFields()).thenReturn(asList(field("count", Integer.class, 1),
                 field("time", Time.class, new Time(10, 10)), field("str", String.class, "defStr"),
                 field("dec", Double.class, 3.1), field("bool", Boolean.class, (Object) true),
                 field("date", Date.class, date), field("dt", DateTime.class, dateTime),
                 field("ld", LocalDate.class, localDate), field("locale", Locale.class, Locale.CANADA_FRENCH),
+                field("jd", java.time.LocalDate.class, javaLocalDate), field("jdt", LocalDateTime.class, javaLocalDateTime),
                 field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true)));
 
         Class<?> clazz = buildClass();
@@ -122,6 +129,8 @@ public class EntityBuilderTest {
         assertField(clazz, "dt", DateTime.class, dateTime);
         assertField(clazz, "ld", LocalDate.class, localDate);
         assertField(clazz, "locale", Locale.class, Locale.CANADA_FRENCH);
+        assertField(clazz, "jd", java.time.LocalDate.class, javaLocalDate);
+        assertField(clazz, "jdt", LocalDateTime.class, javaLocalDateTime);
     }
 
     @Test
@@ -156,7 +165,8 @@ public class EntityBuilderTest {
                 field("bool", Boolean.class), field("date", Date.class),
                 field("dt", DateTime.class), field("list", List.class),
                 field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true),
-                field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+                field(MODIFIED_BY_FIELD_NAME, String.class, true),
+                field("jd", java.time.LocalDate.class), field("jld", LocalDateTime.class)));
 
         when(entity.getField("id")).thenReturn(field("id", Long.class));
 
@@ -175,6 +185,8 @@ public class EntityBuilderTest {
         assertField(clazz, "bool", Boolean.class);
         assertField(clazz, "date", Date.class);
         assertField(clazz, "dt", DateTime.class);
+        assertField(clazz, "jd", java.time.LocalDate.class);
+        assertField(clazz, "jld", LocalDateTime.class);
         assertField(clazz, "list", List.class);
     }
 

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
@@ -69,6 +69,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -112,8 +114,10 @@ public class MdsBundleIT extends BasePaxIT {
     private static final Map<String, TestClass> TEST_MAP = new HashMap<>();
     private static final Map<String, TestClass> TEST_MAP2 = new HashMap<>();
     private static final DateTime NOW = DateUtil.now().secondOfMinute().roundFloorCopy();
+    private static final LocalDateTime JAVA_NOW = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
     private static final DateTime YEAR_LATER = NOW.plusYears(1);
     private static final LocalDate LD_NOW = NOW.toLocalDate();
+    private static final java.time.LocalDate JAVA_LD_NOW = JAVA_NOW.toLocalDate();
     private static final LocalDate LD_YEAR_AGO = LD_NOW.minusYears(1);
     private static final Date DATE_NOW = NOW.toDate();
     private static final Date DATE_TOMORROW = NOW.plusDays(1).toDate();
@@ -292,19 +296,24 @@ public class MdsBundleIT extends BasePaxIT {
 
         updateInstance(instance, true, "trueNow", "trueNowCp", new ArrayList(asList("1", "2", "3")),
                        NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"),
+                       JAVA_LD_NOW, JAVA_NOW);
         updateInstance(instance2, true, "trueInRange", "trueInRangeCp", new ArrayList(asList("2", "4")),
                        NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(loadedClass, "two"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(loadedClass, "two"),
+                       JAVA_LD_NOW.plusDays(1), JAVA_NOW.plusHours(1));
         updateInstance(instance3, false, "falseInRange", "falseInRangeCp", null,
                        NOW.plusHours(2), LD_NOW.plusDays(1), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(loadedClass, "three"));
+                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(loadedClass, "three"),
+                       JAVA_LD_NOW.plusDays(2), JAVA_NOW.plusHours(2));
         updateInstance(instance4, true, "trueOutOfRange", "trueOutOfRangeCp", null,
                        NOW.plusHours(3), LD_NOW.plusDays(10), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(loadedClass, "one"));
+                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(loadedClass, "one"),
+                       JAVA_LD_NOW.plusDays(3), JAVA_NOW.plusHours(3));
         updateInstance(instance5, true, "notInSet", "notInSetCp", null,
                        NOW.plusHours(4), LD_NOW, null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_2, MORNING_TIME, 4, toEnum(loadedClass, "two"));
+                       DATE_NOW, DOUBLE_VALUE_2, MORNING_TIME, 4, toEnum(loadedClass, "two"),
+                       JAVA_LD_NOW.plusDays(4), JAVA_NOW.plusHours(4));
 
         MethodUtils.invokeMethod(instance, "setSomeMap", TEST_MAP);
 
@@ -321,7 +330,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         assertInstance(retrieved, true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                 NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"));
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"),
+                JAVA_LD_NOW, JAVA_NOW);
 
         assertEquals(1, service.retrieveAll().size());
         service.create(instance2);
@@ -355,7 +365,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                        NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"),
+                       JAVA_LD_NOW, JAVA_NOW);
 
         // verify lookups
         if (usingLookupService) {
@@ -374,7 +385,8 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(4, resultList.size());
         assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                        NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"),
+                       JAVA_LD_NOW, JAVA_NOW);
 
         List<String> list = new ArrayList<>();
         list.add("2");
@@ -400,10 +412,12 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(2, resultList.size());
         assertInstance(resultList.get(0), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
                        NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"),
+                       JAVA_LD_NOW.plusDays(1), JAVA_NOW.plusHours(1));
         assertInstance(resultList.get(1), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                        NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"),
+                       JAVA_LD_NOW, JAVA_NOW);
 
         // usage of a custom operator
         if (usingLookupService) {
@@ -421,13 +435,16 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(3, resultList.size());
         assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                 NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"),
+                JAVA_LD_NOW, JAVA_NOW);
         assertInstance(resultList.get(1), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
                 NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"),
+                JAVA_LD_NOW.plusDays(1), JAVA_NOW.plusHours(1));
         assertInstance(resultList.get(2), false, "falseInRange", "falseInRangeCp", Collections.emptyList(),
                 NOW.plusHours(2), LD_NOW.plusDays(1), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(objClass, "three"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(objClass, "three"),
+                JAVA_LD_NOW.plusDays(2), JAVA_NOW.plusHours(2));
 
         // usage of matches, case sensitive and case insensitive
         String[] textsToSearch = { "true", "TRUE" };
@@ -453,13 +470,16 @@ public class MdsBundleIT extends BasePaxIT {
             assertEquals(3, resultList.size());
             assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                     NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"),
+                    JAVA_LD_NOW, JAVA_NOW);
             assertInstance(resultList.get(1), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
                     NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
+                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"),
+                    JAVA_LD_NOW.plusDays(1), JAVA_NOW.plusHours(1));
             updateInstance(resultList.get(2), true, "trueOutOfRange", "trueOutOfRangeCp", null,
                     NOW.plusHours(3), LD_NOW.plusDays(10), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "one"));
+                    DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "one"),
+                    JAVA_LD_NOW.plusDays(3), JAVA_NOW.plusHours(3));
         }
     }
 
@@ -474,14 +494,16 @@ public class MdsBundleIT extends BasePaxIT {
 
         updateInstance(retrieved, false, "anotherString", "anotherStringCp", new ArrayList(asList("4", "5")),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"),
+                JAVA_LD_NOW.plusDays(5), JAVA_NOW.plusHours(5));
 
         service.update(retrieved);
         Object updated = service.retrieveAll(QueryParams.descOrder("someDateTime")).get(0);
 
         assertInstance(updated, false, "anotherString", "anotherStringCp", asList("4", "5"),
                        YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"),
+                       JAVA_LD_NOW.plusDays(5), JAVA_NOW.plusHours(5));
     }
 
     private void verifyInstanceCreatingOrUpdating(Class<?> loadedClass) throws Exception {
@@ -492,7 +514,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         updateInstance(instance, false, "newInstance", "newInstance", new ArrayList(asList("1", "2", "3")),
                 NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"));
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"),
+                JAVA_LD_NOW.plusDays(6), JAVA_NOW.plusHours(6));
 
         service.createOrUpdate(instance);                           // using createOrUpdate() to create
 
@@ -506,7 +529,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         updateInstance(retrieved, false, "yetAnotherString", "yetAnotherStringCp", new ArrayList(asList("1", "2", "3")),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"),
+                JAVA_LD_NOW.plusDays(7), JAVA_NOW.plusHours(7));
 
         service.createOrUpdate(retrieved);                          // using createOrUpdate() to update
 
@@ -516,7 +540,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         assertInstance(updated, false, "yetAnotherString", "yetAnotherStringCp", asList("1", "2", "3"),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"),
+                JAVA_LD_NOW.plusDays(7), JAVA_NOW.plusHours(7));
 
         // Remove new object for the sake of other tests
         service.delete(updated);
@@ -574,7 +599,8 @@ public class MdsBundleIT extends BasePaxIT {
         Class objClass = result.get(0).getClass();
         assertInstance(result.get(0), false, "anotherString", "anotherStringCp", asList("4", "5"),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"),
+                JAVA_LD_NOW.plusDays(5), JAVA_NOW.plusHours(5));
 
         List<String> names = (List<String>) service.executeSQLQuery(new SqlQueryExecution<List<String>>() {
             @Override
@@ -622,7 +648,8 @@ public class MdsBundleIT extends BasePaxIT {
 
         updateInstance(retrieved, false, "anotherString", "anotherStringCp", new ArrayList(asList("0", "35")),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "two"));
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "two"),
+                JAVA_LD_NOW.minusDays(1), JAVA_NOW.minusHours(1));
         service.update(retrieved);
 
         FieldDto comboboxField = entityService.findEntityFieldByName(entityId, "someList");
@@ -658,11 +685,12 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(2, list.size());
         assertInstance(list.get(0), false, "fromCsv", "Capital CSV", Collections.emptyList(), null, new LocalDate(2012, 10, 14),
                 null, new Period(2, 0, 0, 0, 0, 0, 0, 0), null, new DateTime(2014, 12, 2, 16, 13, 40, 120, DateTimeZone.UTC).toDate(),
-                null, new Time(20, 20), null, null);
+                null, new Time(20, 20), null, null, null, null);
         assertInstance(list.get(1), true, "fromCsv", "Capital CSV", new ArrayList(asList("one", "two")),
                 new DateTime(2014, 12, 2, 13, 10, 40, 120, DateTimeZone.UTC).withZone(DateTimeZone.getDefault()),
                 new LocalDate(2012, 10, 15), null, new Period(1, 0, 0, 0, 0, 0, 0, 0), null,
-                new DateTime(2014, 12, 2, 13, 13, 40, 120, DateTimeZone.UTC).toDate(), null, new Time(10, 30), null, null);
+                new DateTime(2014, 12, 2, 13, 13, 40, 120, DateTimeZone.UTC).toDate(), null, new Time(10, 30),
+                null, null, null, null);
     }
 
     private void verifyCsvImportIsOneTransaction() throws Exception {
@@ -738,6 +766,10 @@ public class MdsBundleIT extends BasePaxIT {
                 new FieldBasicDto("dateTime", "someDateTime"),
                 false, null));
         fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.DATETIME8,
+                new FieldBasicDto("someJavaDateTime", "someJavaDateTime"),
+                false, null));
+        fields.add(new FieldDto(null, entityDto.getId(),
                 TypeDto.MAP,
                 new FieldBasicDto("someMap", "someMap"),
                 false, Arrays.asList(
@@ -755,6 +787,10 @@ public class MdsBundleIT extends BasePaxIT {
         fields.add(new FieldDto(null, entityDto.getId(),
                 TypeDto.LOCAL_DATE,
                 new FieldBasicDto("someLocalDate", "someLocalDate"),
+                false, null));
+        fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.LOCAL_DATE8,
+                new FieldBasicDto("someJavaDate", "someJavaDate"),
                 false, null));
         fields.add(new FieldDto(null, entityDto.getId(),
                 TypeDto.DATE,
@@ -818,7 +854,7 @@ public class MdsBundleIT extends BasePaxIT {
         lookupFields = new ArrayList<>();
         lookupFields.add(new LookupFieldDto(null, "someString", LookupFieldType.VALUE,
                 Constants.Operators.MATCHES_CASE_INSENSITIVE));
-;       lookups.add(new LookupDto("With matches case insensitive", false, false, lookupFields, true, "matchesOperatorCI",
+        lookups.add(new LookupDto("With matches case insensitive", false, false, lookupFields, true, "matchesOperatorCI",
                 singletonList("someString")));
 
         entityService.addLookups(entityDto.getId(), lookups);
@@ -841,14 +877,16 @@ public class MdsBundleIT extends BasePaxIT {
     private void updateInstance(Object instance, Boolean boolField, String stringField, String capitalizedStrField, List listField,
                                 DateTime dateTimeField, LocalDate localDateField, Map map, Period period,
                                 Byte[] blob, Date dateField, Double decimalField, Time timeField, Integer intField,
-                                Object enumVal)
+                                Object enumVal, java.time.LocalDate javaDateField, LocalDateTime javaDateTimeField)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         PropertyUtils.setProperty(instance, "someBoolean", boolField);
         PropertyUtils.setProperty(instance, "someString", stringField);
         PropertyUtil.safeSetProperty(instance, "CapitalName", capitalizedStrField);
         PropertyUtils.setProperty(instance, "someList", listField);
         PropertyUtils.setProperty(instance, "someDateTime", dateTimeField);
+        PropertyUtils.setProperty(instance, "someJavaDateTime", javaDateTimeField);
         PropertyUtils.setProperty(instance, "someLocalDate", localDateField);
+        PropertyUtils.setProperty(instance, "someJavaDate", javaDateField);
         PropertyUtils.setProperty(instance, "someMap", map);
         PropertyUtils.setProperty(instance, "somePeriod", period);
         PropertyUtils.setProperty(instance, "someBlob", blob);
@@ -862,7 +900,7 @@ public class MdsBundleIT extends BasePaxIT {
     private void assertInstance(Object instance, Boolean boolField, String stringField, String capitalizedStrField, List listField,
                                 DateTime dateTimeField, LocalDate localDateField, Map map, Period period,
                                 Byte[] blob, Date dateField, Double decimalField, Time timeField, Integer intField,
-                                Object enumVal)
+                                Object enumVal, java.time.LocalDate javaDateField, LocalDateTime javaDateTimeField)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         assertNotNull(instance);
         assertEquals(boolField, PropertyUtils.getProperty(instance, "someBoolean"));
@@ -878,6 +916,8 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(timeField, PropertyUtils.getProperty(instance, "someTime"));
         assertEquals(intField, PropertyUtils.getProperty(instance, "someInt"));
         assertEquals(enumVal, PropertyUtils.getProperty(instance, "someEnum"));
+        assertEquals(javaDateField, PropertyUtils.getProperty(instance, "someJavaDate"));
+        assertEquals(javaDateTimeField, PropertyUtils.getProperty(instance, "someJavaDateTime"));
 
         // assert blob
         Object blobValue = service.getDetachedField(instance, "someBlob");

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/reposistory/AllTypesContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/reposistory/AllTypesContextIT.java
@@ -14,6 +14,7 @@ import org.motechproject.mds.domain.TypeValidation;
 import org.motechproject.mds.repository.AllTypes;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class AllTypesContextIT extends BaseIT {
-    private static final int START_NUMBER_OF_TYPES = 19;
+    private static final int START_NUMBER_OF_TYPES = 21;
 
     @Autowired
     private AllTypes allTypes;
@@ -65,6 +66,10 @@ public class AllTypesContextIT extends BaseIT {
                 null, null
         );
         assertType(
+                "mds.field.datetime8", "mds.field.description.datetime", LocalDateTime.class.getName(),
+                null, null
+        );
+        assertType(
                 "mds.field.decimal", "mds.field.description.decimal", Double.class.getName(),
                 asList("mds.form.label.precision", "mds.form.label.scale"), asList("mds.field.validation.minValue", "mds.field.validation.maxValue", "mds.field.validation.mustBeInSet", "mds.field.validation.cannotBeInSet")
         );
@@ -90,6 +95,10 @@ public class AllTypesContextIT extends BaseIT {
         );
         assertType(
                 "mds.field.date", "mds.field.description.localDate", LocalDate.class.getName(),
+                null, null
+        );
+        assertType(
+                "mds.field.date8", "mds.field.description.localDate", java.time.LocalDate.class.getName(),
                 null, null
         );
         assertType(

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/TypeServiceImplContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/TypeServiceImplContextIT.java
@@ -14,6 +14,7 @@ import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.service.TypeService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -25,7 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class TypeServiceImplContextIT extends BaseIT {
-    private static final int START_NUMBER_OF_TYPES = 19;
+    private static final int START_NUMBER_OF_TYPES = 21;
 
     @Autowired
     private TypeService typeService;
@@ -47,6 +48,7 @@ public class TypeServiceImplContextIT extends BaseIT {
         testFindType(Collection.class, Collection.class);
         testFindType(Date.class, Date.class);
         testFindType(DateTime.class, DateTime.class);
+        testFindType(LocalDateTime.class, LocalDateTime.class);
         testFindType(String.class, String.class);
         testFindType(Map.class, Map.class);
         testFindType(Period.class, Period.class);
@@ -54,6 +56,7 @@ public class TypeServiceImplContextIT extends BaseIT {
         testFindType(Byte[].class, Byte[].class);
         testFindType(Long.class, Long.class);
         testFindType(LocalDate.class, LocalDate.class);
+        testFindType(java.time.LocalDate.class, java.time.LocalDate.class);
         testFindType(Relationship.class, Relationship.class);
         testFindType(OneToManyRelationship.class, OneToManyRelationship.class);
         testFindType(OneToOneRelationship.class, OneToOneRelationship.class);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/csv/CsvImporterExporterTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/csv/CsvImporterExporterTest.java
@@ -155,7 +155,7 @@ public class CsvImporterExporterTest {
 
     @Test
     public void shouldExportInstancesFromTableAsCsv() {
-        when(mdsLookupService.findMany((any(String.class)), eq("lookup"), any(Map.class), any(QueryParams.class))).thenReturn(testInstances(IdMode.INCLUDE_ID));
+        when(mdsLookupService.<Record2>findMany((any(String.class)), eq("lookup"), any(Map.class), any(QueryParams.class))).thenReturn(testInstances(IdMode.INCLUDE_ID));
         StringWriter writer = new StringWriter();
 
         List<String> headers = Arrays.asList("ID", "Creator", "Owner", "Modified By", "Creation date", "Modification date",

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
@@ -16,6 +16,8 @@ import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.TypeHelper;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -135,6 +137,10 @@ public final class FieldTestHelper {
             return true;
         } else if (Locale.class.equals(clazz)) {
             return Locale.ENGLISH;
+        } else if (LocalDate.class.equals(clazz)) {
+            return LocalDate.now();
+        } else if (LocalDateTime.class.equals(clazz)) {
+            return LocalDateTime.now();
         } else {
             return clazz.newInstance();
         }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/util/TypeHelperTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/util/TypeHelperTest.java
@@ -8,6 +8,8 @@ import org.motechproject.commons.api.Range;
 import org.motechproject.commons.date.model.Time;
 import org.motechproject.commons.date.util.DateUtil;
 
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,6 +38,10 @@ public class TypeHelperTest {
         final DateTime dt2 = new DateTime(2009, 6, 7, 12, 11, 0, 0, DateTimeZone.forOffsetHours(1));
         final LocalDate ld = DateUtil.now().toLocalDate();
         final LocalDate ld2 = new LocalDate(2000, 8, 22);
+        final LocalDateTime ldt = LocalDateTime.now();
+        final LocalDateTime ldt2 = LocalDateTime.of(2015, 9, 1, 10, 15);
+        final java.time.LocalDate jld = java.time.LocalDate.now();
+        final java.time.LocalDate jld2 = java.time.LocalDate.of(1991, 5, 1);
 
         assertEquals(3, TypeHelper.parse(3, Integer.class));
 
@@ -45,6 +51,7 @@ public class TypeHelperTest {
 
         assertEquals(dt, TypeHelper.parse(dt.toString(), DateTime.class));
         assertEquals(dt.toDate(), TypeHelper.parse(dt.toString(), Date.class));
+
         assertEquals(DateUtil.setTimeZoneUTC(dt2),
                 DateUtil.setTimeZoneUTC((DateTime) TypeHelper.parse("2009-06-07 12:11 +01:00", DateTime.class)));
         assertEquals(dt2.toDate(), TypeHelper.parse("2009-06-07 12:11 +01:00", Date.class));
@@ -58,6 +65,16 @@ public class TypeHelperTest {
         assertEquals(ld2, TypeHelper.parse("2000-08-22", LocalDate.class));
         // TODO: do not send such values from the UI
         assertEquals(ld2, TypeHelper.parse("2000-08-22T23:00:00.000Z", LocalDate.class));
+
+        //java.time types cases
+        assertEquals(jld, TypeHelper.parse(jld, java.time.LocalDate.class));
+        assertEquals(jld, TypeHelper.parse(jld.toString(), java.time.LocalDate.class));
+        assertEquals(jld2, TypeHelper.parse("1991-05-01", java.time.LocalDate.class));
+
+        assertEquals(ldt, TypeHelper.parse(ldt, java.time.LocalDateTime.class));
+        assertEquals(ldt, TypeHelper.parse(ldt.toString(), java.time.LocalDateTime.class));
+        assertTrue(ldt2.equals(TypeHelper.parse("2015-09-01 10:15 ".concat(findServerOffset()),
+                java.time.LocalDateTime.class)));
     }
 
     @Test
@@ -226,5 +243,9 @@ public class TypeHelperTest {
         Map<String, String> mapFromUI = new LinkedHashMap<>();
         mapFromUI.put("val", value);
         return mapFromUI;
+    }
+
+    private String findServerOffset() {
+        return ZonedDateTime.now().getOffset().toString();
     }
 }

--- a/pmd.xml
+++ b/pmd.xml
@@ -7,64 +7,67 @@
 
     <description>MOTECH PMD ruleset</description>
 
-    <rule ref="rulesets/sunsecure.xml/MethodReturnsInternalArray">
+    <rule ref="rulesets/java/sunsecure.xml/MethodReturnsInternalArray">
         <priority>2</priority>
     </rule>
-    <rule ref="rulesets/sunsecure.xml/ArrayIsStoredDirectly">
+    <rule ref="rulesets/java/sunsecure.xml/ArrayIsStoredDirectly">
         <priority>2</priority>
     </rule>
 
-    <rule ref="rulesets/codesize.xml/NcssMethodCount">
+    <rule ref="rulesets/java/codesize.xml/NcssMethodCount">
         <properties>
             <property name="minimum" value="50"/>
         </properties>
     </rule>
 
-    <rule ref="rulesets/coupling.xml/LooseCoupling"/>
+    <rule ref="rulesets/java/coupling.xml/LooseCoupling"/>
 
-    <rule ref="rulesets/design.xml/ConstructorCallsOverridableMethod"/>
-    <rule ref="rulesets/design.xml/PreserveStackTrace"/>
-    <rule ref="rulesets/design.xml/SimplifyConditional"/>
-    <rule ref="rulesets/design.xml/UnnecessaryLocalBeforeReturn"/>
+    <rule ref="rulesets/java/design.xml/ConstructorCallsOverridableMethod"/>
+    <rule ref="rulesets/java/design.xml/PreserveStackTrace"/>
+    <rule ref="rulesets/java/design.xml/SimplifyConditional"/>
+    <rule ref="rulesets/java/design.xml/UnnecessaryLocalBeforeReturn"/>
 
-    <rule ref="rulesets/logging-java.xml/AvoidPrintStackTrace"/>
+    <rule ref="rulesets/java/logging-java.xml/AvoidPrintStackTrace"/>
 
-    <rule ref="rulesets/migrating.xml/IntegerInstantiation"/>
+    <rule ref="rulesets/java/migrating.xml/IntegerInstantiation"/>
 
-    <rule ref="rulesets/strictexception.xml/AvoidCatchingThrowable"/>
-    <rule ref="rulesets/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
-    <rule ref="rulesets/strictexception.xml/SignatureDeclareThrowsException"/>
+    <rule ref="rulesets/java/strictexception.xml/AvoidCatchingThrowable"/>
+    <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
+    <rule ref="rulesets/java/strictexception.xml/SignatureDeclareThrowsException"/>
 
-    <rule ref="rulesets/strings.xml/AvoidDuplicateLiterals"/>
-    <rule ref="rulesets/strings.xml/UseIndexOfChar"/>
+    <rule ref="rulesets/java/strings.xml/AvoidDuplicateLiterals"/>
+    <rule ref="rulesets/java/strings.xml/UseIndexOfChar"/>
 
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter"/>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable"/>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField"/>
+    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod"/>
 
-    <rule ref="rulesets/javabeans.xml/MissingSerialVersionUID"/>
+    <rule ref="rulesets/java/javabeans.xml/MissingSerialVersionUID"/>
 
     <rule name="DontImportInternal"
+          language="java"
           message="Avoid importing internal packages of any external libraries"
-          class="net.sourceforge.pmd.rules.XPathRule">
-    <description>
-        Avoid importing any internal package of any external libraries.
-    </description>
-    <properties>
-        <property name="xpath">
-            <value>
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Avoid importing any internal package of any external libraries.
+        </description>
+        <properties>
+            <property name="xpath">
+                <value>
                 <![CDATA[
                 //ImportDeclaration
                 [not(starts-with(Name/@Image, 'org.motechproject'))]
                 [contains(Name/@Image, '.internal.')]
                 ]]>
-            </value>
-        </property>
-    </properties>
-    <priority>3</priority>
+                </value>
+            </property>
+        </properties>
+        <priority>3</priority>
     </rule>
+
     <rule name="CommentedOutCode"
+          language="java"
           message="Avoid commeneted out code."
           class="CommentedOutCode">
         <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <external.dependency.release.tag>r029</external.dependency.release.tag>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <modules.root.dir>${basedir}</modules.root.dir>
-        <jdk.version>1.7</jdk.version>
+        <jdk.version>1.8</jdk.version>
 
         <felix.version>4.2.1</felix.version>
         <felix.http.version>2.2.0</felix.http.version>
@@ -637,6 +637,11 @@
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-jodatime</artifactId>
                 <version>4.0.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.datanucleus</groupId>
+                <artifactId>datanucleus-java8</artifactId>
+                <version>4.0.5</version>
             </dependency>
             <dependency>
                 <groupId>org.datanucleus</groupId>
@@ -1285,7 +1290,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>2.7.1</version>
+                <version>3.5</version>
                 <configuration>
                     <rulesets>
                         <ruleset>${modules.root.dir}/pmd.xml</ruleset>
@@ -1298,7 +1303,7 @@
                     <dependency>
                         <groupId>org.motechproject</groupId>
                         <artifactId>pmd-rules</artifactId>
-                        <version>0.2</version>
+                        <version>0.3</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -1668,7 +1673,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.5</version>
                 <configuration>
                     <xrefLocation>${project.reporting.outputDirectory}/../xref</xrefLocation>
                 </configuration>


### PR DESCRIPTION
* JDK for Motech is now 1.8 and requires Java8 to compile and run.
* Changed version of maven-pmd-plugin to 3.5 as old one didn't support JDK 1.8.
* MDS now supports LocalDateTime and LocalDate from java.time.
* DateTime and LocalDate from Joda are available for DDEs exclusively.
* Updated MDS documentation about avaliable types
* Adjusted some tests to cover new java.time types

Change-Id: I0a8363e87cb2ee35e839020b25e096f1271af85f