### PR TITLE
MOTECH-1894: Filter in the task history

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/repository/TaskActivitiesDataService.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/repository/TaskActivitiesDataService.java
@@ -48,7 +48,6 @@ public interface TaskActivitiesDataService extends MotechDataService<TaskActivit
      * @param activityTypes the set of activity types
      * @return the count of matching task activities
      */
-    @Lookup(name = "Count by Task and Activity Types")
     long countByTaskAndActivityTypes(@LookupField(name = TASK) final Long task,
                                      @LookupField(name = ACTIVITY_TYPE) final Set<TaskActivityType> activityTypes);
 

--- a/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
@@ -1382,7 +1382,10 @@
 
     controllers.controller('TasksLogCtrl', function ($scope, Tasks, Activities, $routeParams, $filter) {
         var data, task;
+
         $scope.taskId = $routeParams.taskId;
+        $scope.activityTypes = ['All', 'Warning', 'Success', 'Error'];
+        $scope.selectedActivityType = 'All';
 
         innerLayout({
             spacing_closed: 30,
@@ -1419,13 +1422,31 @@
             });
         }
 
+        $scope.changeActivityTypeFilter = function () {
+            $('#taskHistoryTable').jqGrid('setGridParam', {
+                page: 1,
+                postData: {
+                    activityType: ($scope.selectedActivityType === 'All') ? '' : $scope.selectedActivityType.toUpperCase()
+                }}).trigger('reloadGrid');
+        };
+
+        $scope.refresh = function () {
+            $("#taskHistoryTable").trigger('reloadGrid');
+        };
+
         $scope.clearHistory = function () {
             motechConfirm('task.history.confirm.clearHistory', 'task.history.confirm.clear',function (r) {
                 if (!r) {
                     return;
                 }
-                Activities.remove({taskId: $routeParams.taskId});
-                $("#taskHistoryTable").trigger('reloadGrid');
+                blockUI();
+                Activities.remove({taskId: $routeParams.taskId}, function () {
+                     $scope.refresh();
+                     unblockUI();
+                 }, function (response) {
+                     unblockUI();
+                     handleResponse('task.header.error', 'task.history.deleteError', response);
+                 });
             });
         };
     });

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -18,7 +18,7 @@
                     return;
                 }
 
-                var elem = angular.element(element), k, rows, activity, message, date;
+                var elem = angular.element(element), k, rows, activity, message, date, stackTraceElement;
 
                 elem.jqGrid({
                     url: '../tasks/api/activity/' + scope.taskId,
@@ -44,7 +44,12 @@
                         index: 'date',
                         sortable: false,
                         width: 80
-                    }],
+                    }, {
+                       name: 'stackTraceElement',
+                       index: 'stackTraceElement',
+                       sortable: false,
+                       hidden: true
+                   }],
                     pager: '#' + attrs.taskHistoryGrid,
                     viewrecords: true,
                     gridComplete: function () {
@@ -70,7 +75,6 @@
                         for (k = 0; k < rows.length; k+=1) {
                             activity = $("#taskHistoryTable").getCell(rows[k],"activityType").toLowerCase();
                             message = $("#taskHistoryTable").getCell(rows[k],"message");
-                            date = $("#taskHistoryTable").getCell(rows[k],"date");
                             if (activity !== undefined) {
                                 if (activity === 'success') {
                                     $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType','<img src="../tasks/img/icon-ok.png" class="recent-activity-task-img"/>','ok',{ },'');
@@ -80,7 +84,16 @@
                                     $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType','<img src="../tasks/img/icon-exclamation.png" class="recent-activity-task-img"/>','ok',{ },'');
                                 }
                             }
-                            if (message !== undefined) {
+
+                            stackTraceElement = $("#taskHistoryTable").getCell(rows[k],"stackTraceElement");
+                            if (message !== undefined && activity === 'error' && stackTraceElement !== undefined && stackTraceElement !== null) {
+                                $("#taskHistoryTable").jqGrid('setCell',rows[k],'message',
+                                    '<p class="wrap-paragraph">' + scope.msg(message) +
+                                    '&nbsp;&nbsp;<span class="label label-danger pointer" data-toggle="collapse" data-target="#stackTraceElement' + k + '">' +
+                                    scope.msg('task.button.showStackTrace') + '</span></p>' +
+                                    '<pre id="stackTraceElement' + k + '" class="collapse">' + stackTraceElement + '</pre>'
+                                    ,'ok',{ },'');
+                            } else if (message !== undefined) {
                                 $("#taskHistoryTable").jqGrid('setCell',rows[k],'message',scope.msg(message),'ok',{ },'');
                             }
                         }

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/history.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/history.html
@@ -48,7 +48,11 @@
                 </div>
             </div>
             <div class="clearfix"></div><div class="margin-before2"></div>
-
+            <div class="form-group form-inline inside">
+                <label >{{msg('task.header.filterActivity')}}</label>
+                <select class="form-control input-auto" ng-model="selectedActivityType" ng-change="changeActivityTypeFilter()" ng-options="activity for activity in activityTypes"></select>
+                <a class="btn btn-default" ng-click="refresh()"><i class="fa fa-refresh"></i>&nbsp;{{msg('admin.refresh')}}</a>
+            </div>
             <div id="outsideTaskHistoryTable" class="overrideJqgridTable">
                 <table id="taskHistoryTable" task-history-grid="pageTaskHistoryTable"></table>
                 <div id="pageTaskHistoryTable"></div>


### PR DESCRIPTION
Now user can filter task activity by the type (warning, error, Success). When type is ERROR user
have possibility to display stack trace. This commit also removes Lookup annotation from
countByTaskAndActivityTypes method to avoid error in the log.