### PR TITLE
MOTECH-1860 Bumped external dependencies tag to r030

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <jasmine.server.port>8234</jasmine.server.port>
 
-        <external.dependency.release.tag>r029</external.dependency.release.tag>
+        <external.dependency.release.tag>r030</external.dependency.release.tag>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <modules.root.dir>${basedir}</modules.root.dir>
         <jdk.version>1.7</jdk.version>


### PR DESCRIPTION
The new external osgi bundles release contains OSGified
POI OOXML Schemas bundle, that is required to make POI
library work in OSGi environment.