### PR TITLE
MOTECH-1861: Prevent mds-web from timing out

### DIFF
--- a/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/BundleType.java
+++ b/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/BundleType.java
@@ -69,7 +69,7 @@ public enum BundleType {
             return BundleType.FRAGMENT_BUNDLE;
         } else if (symbolicName == null || PlatformConstants.PAX_IT_SYMBOLIC_NAME.equals(symbolicName)) {
             return BundleType.THIRD_PARTY_BUNDLE;
-        } else if (symbolicName.startsWith(PlatformConstants.MDS_BUNDLE_PREFIX)) {
+        } else if (symbolicName.equals(PlatformConstants.MDS_BUNDLE_NAME)) {
             return BundleType.MDS_BUNDLE;
         } else if (symbolicName.equals(PlatformConstants.SECURITY_SYMBOLIC_NAME)) {
             return BundleType.WS_BUNDLE;

--- a/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/PlatformConstants.java
+++ b/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/PlatformConstants.java
@@ -8,7 +8,7 @@ public final class PlatformConstants {
     public static final String HTTP_BRIDGE_BUNDLE = "org.apache.felix.http.bridge";
     public static final String FELIX_FRAMEWORK_BUNDLE = "org.apache.felix.framework";
     public static final String MDS_ENTITIES_BUNDLE = "org.motechproject.motech-platform-dataservices-entities";
-    public static final String MDS_BUNDLE_PREFIX = "org.motechproject.motech-platform-dataservices";
+    public static final String MDS_BUNDLE_NAME = "org.motechproject.motech-platform-dataservices";
 
     public static final String SECURITY_SYMBOLIC_NAME = "org.motechproject.motech-platform-web-security";
     public static final String SERVER_SYMBOLIC_NAME = "org.motechproject.motech-platform-server-bundle";

--- a/platform/osgi-platform/src/test/java/org/motechproject/server/osgi/BundleTypeTest.java
+++ b/platform/osgi-platform/src/test/java/org/motechproject/server/osgi/BundleTypeTest.java
@@ -38,7 +38,7 @@ public class BundleTypeTest {
 
     @Test
     public void shouldRecognizeMdsBundle() {
-        when(bundle.getSymbolicName()).thenReturn(PlatformConstants.MDS_BUNDLE_PREFIX);
+        when(bundle.getSymbolicName()).thenReturn(PlatformConstants.MDS_BUNDLE_NAME);
         assertEquals(BundleType.MDS_BUNDLE, BundleType.forBundle(bundle));
     }
 


### PR DESCRIPTION
Mds web was treated as an mds bundle, so it would stop
concurrently with mds. From now on it is treated as a regular
platform bundle.