### PR TITLE
MOTECH-1889 Update Install Documentation to set CATALINA_OPTS memory

### DIFF
--- a/docs/source/get_started/install.sh
+++ b/docs/source/get_started/install.sh
@@ -10,7 +10,7 @@ sudo apt-get update
 sudo apt-get install -y tomcat7
 sudo service tomcat7 stop
 sudo apt-get install -y activemq mysql-server
-sudo sed -i '2iCATALINA_OPTS="-Xms512m -Xmx512m"' /usr/share/tomcat7/bin/catalina.sh
+echo 'CATALINA_OPTS="-Xms512m -Xmx512m"' | sudo tee --append /usr/share/tomcat7/bin/setenv.sh
 sudo chown -R tomcat7:tomcat7 /var/lib/tomcat7/ /usr/share/tomcat7/
 sudo ln -s /etc/activemq/instances-available/main /etc/activemq/instances-enabled/main
 sudo sed -e 's/<broker /<broker schedulerSupport="true" /' -i /etc/activemq/instances-enabled/main/activemq.xml

--- a/docs/source/get_started/install.sh
+++ b/docs/source/get_started/install.sh
@@ -10,6 +10,7 @@ sudo apt-get update
 sudo apt-get install -y tomcat7
 sudo service tomcat7 stop
 sudo apt-get install -y activemq mysql-server
+sudo sed -i '2iCATALINA_OPTS="-Xms512m -Xmx512m"' /usr/share/tomcat7/bin/catalina.sh
 sudo chown -R tomcat7:tomcat7 /var/lib/tomcat7/ /usr/share/tomcat7/
 sudo ln -s /etc/activemq/instances-available/main /etc/activemq/instances-enabled/main
 sudo sed -e 's/<broker /<broker schedulerSupport="true" /' -i /etc/activemq/instances-enabled/main/activemq.xml

--- a/docs/source/get_started/installing.rst
+++ b/docs/source/get_started/installing.rst
@@ -28,11 +28,16 @@ Install and Configure Dependencies
 
 			MySQL is going to ask you for a root password. You have to input it twice. Remember it because we'll use this later.
 
-	#. Change the ownership of the tomcat7 directories
+	#. Change memory allocation for catalina when it starts and the ownership of the tomcat7 directories
+
+		..note::
+
+		#Note, you can change the memory allocation to anything, but we recommend at least 512m.
 
 		.. code-block:: bash
 
 			sudo service tomcat7 stop
+			sudo sed -i '2iCATALINA_OPTS="-Xms512m -Xmx512m"' /usr/share/tomcat7/bin/catalina.sh
 			sudo chown -R tomcat7:tomcat7 /var/lib/tomcat7/ /usr/share/tomcat7/
 
 

--- a/docs/source/get_started/installing.rst
+++ b/docs/source/get_started/installing.rst
@@ -37,7 +37,7 @@ Install and Configure Dependencies
 		.. code-block:: bash
 
 			sudo service tomcat7 stop
-			sudo sed -i '2iCATALINA_OPTS="-Xms512m -Xmx512m"' /usr/share/tomcat7/bin/catalina.sh
+			echo 'CATALINA_OPTS="-Xms512m -Xmx512m"' | sudo tee --append /usr/share/tomcat7/bin/setenv.sh
 			sudo chown -R tomcat7:tomcat7 /var/lib/tomcat7/ /usr/share/tomcat7/
 
 


### PR DESCRIPTION
This was [recommended by Rob](https://applab.atlassian.net/browse/MOTECH-1889?focusedCommentId=69614&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-69614) because I was getting out of memory errors on MDS Entity creation. The minimum recommended setting is 512MB for CATALINA_OPTS.