### PR TITLE
MOTECH-1881: Schema editor saving an entity does not refresh the view

### DIFF
--- a/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
@@ -1912,6 +1912,8 @@
                     $scope.selectedEntity.modified = false;
                     $scope.selectedEntity.outdated = false;
                     $scope.fields = Entities.getFields(pre, successCallback);
+                    $scope.newField = {};
+                    $scope.tryToCreate = false;
                 },
                 errorCallback = function (data) {
                     $scope.setErrorFromData(data);


### PR DESCRIPTION
Now after saving changes, field which wasn't added is empty.