### PR TITLE
MOTECH-1844 Fixed MDS Data browser for lazy loaded fields

### DIFF
--- a/platform/mds/mds-web/pom.xml
+++ b/platform/mds/mds-web/pom.xml
@@ -73,6 +73,9 @@
                         <Resource-Path>mds/resources</Resource-Path>
                         <Blueprint-Enabled>true</Blueprint-Enabled>
                         <Import-Package>
+                            net.sf.cglib.core,
+                            net.sf.cglib.proxy,
+                            net.sf.cglib.reflect,
                             org.aopalliance.aop,
                             org.eclipse.gemini.blueprint.config,
                             org.motechproject.mds.javassist,

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/util/RelationshipDisplayUtil.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/util/RelationshipDisplayUtil.java
@@ -1,0 +1,48 @@
+package org.motechproject.mds.web.util;
+
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.util.Constants;
+import org.motechproject.mds.util.PropertyUtil;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The <code>RelationshipDisplayUtil</code> class contains helper methods,
+ * responsible for parsing and adjusting the objects to be suitable for view on UI.
+ */
+@Component
+public class RelationshipDisplayUtil {
+
+    /**
+     * Parses the passed Java object, by setting any relationship fields to null. This is used
+     * to avoid exceptions for possible lazy loaded fields accessed outside of the transaction.
+     * The relationship fields are discovered based on the field metadata.
+     * Invoking this method in a transaction will fail and throw an exception.
+     *
+     * @param value java object or a collection of objects to remove relationship from
+     * @param fields field definitions of the given object
+     * @return java object or a collection of objects with relationship fields set to null
+     */
+    @Transactional(propagation = Propagation.NEVER)
+    public Object breakDeepRelationChainForDisplay(Object value, List<FieldDto> fields) {
+        boolean isCollection = value instanceof Collection;
+
+        // Set any relationship fields to null
+        for (FieldDto fieldDto : fields) {
+            if (fieldDto.getMetadata(Constants.MetadataKeys.RELATED_CLASS) != null && isCollection) {
+                for (Object instance : (Collection) value) {
+                    PropertyUtil.safeSetProperty(instance, fieldDto.getBasic().getName(), null);
+                }
+            } else if (fieldDto.getMetadata(Constants.MetadataKeys.RELATED_CLASS) != null && !isCollection) {
+                PropertyUtil.safeSetProperty(value, fieldDto.getBasic().getName(), null);
+            }
+        }
+
+        return value;
+    }
+
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/RelationshipDisplayUtilTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/RelationshipDisplayUtilTest.java
@@ -1,0 +1,124 @@
+package org.motechproject.mds.web.util;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.util.Constants;
+import org.motechproject.mds.web.util.mock.Car;
+import org.motechproject.mds.web.util.mock.Driver;
+import org.motechproject.mds.web.util.mock.Factory;
+import org.motechproject.mds.web.util.mock.Location;
+import org.motechproject.mds.web.util.mock.Manufacturer;
+import org.motechproject.mds.web.util.mock.SafetyPolicy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RelationshipDisplayUtilTest {
+
+    private Car car;
+    private RelationshipDisplayUtil displayUtil = new RelationshipDisplayUtil();
+
+    @Before
+    public void setUp() {
+        car = prepareTestObject();
+    }
+
+    @Test
+    public void shouldRemoveDeeperRelationshipsFromJavaObject() {
+        Object actual = displayUtil.breakDeepRelationChainForDisplay(car.getManufacturer(), prepareFieldDefinitionsForManufacturer());
+        Manufacturer parsed = (Manufacturer) actual;
+
+        // Non-relationship field should be left untouched
+        assertEquals(car.getManufacturer().getName(), parsed.getName());
+
+        // Relationship fields should be set to null, no matter if it is single object or collection
+        assertNull(parsed.getFactories());
+        assertNull(parsed.getSafetyPolicy());
+    }
+
+    @Test
+    public void shouldRemoveDeeperRelationshipFromCollectionOfJavaObjects() {
+        List<Factory> factories = car.getManufacturer().getFactories();
+
+        Object actual = displayUtil.breakDeepRelationChainForDisplay(factories, prepareFieldDefinitionsForFactory());
+        List<Factory> parsed = (List<Factory>) actual;
+
+        // The number of items in the passed collection should never change
+        assertEquals(factories.size(), parsed.size());
+
+        Factory parsed1 = parsed.get(0);
+        Factory parsed2 = parsed.get(1);
+
+        // Non-relationship field should be left untouched
+        assertEquals(factories.get(0).getName(), parsed1.getName());
+        assertEquals(factories.get(1).getName(), parsed2.getName());
+
+        // Relationship fields should be set to null, no matter if it is single object or collection
+        assertNull(parsed1.getLocation());
+        assertNull(parsed2.getLocation());
+    }
+
+    private List<FieldDto> prepareFieldDefinitionsForManufacturer() {
+        List<FieldDto> fields = new ArrayList<>();
+
+        FieldDto name = new FieldDto("name", "Name", null);
+
+        FieldDto factories = new FieldDto("factories", "Factories", null);
+        factories.addMetadata(new MetadataDto(Constants.MetadataKeys.RELATED_CLASS, "Factory"));
+
+        FieldDto safetyPolicy = new FieldDto("safetyPolicy", "Safety policy", null);
+        safetyPolicy.addMetadata(new MetadataDto(Constants.MetadataKeys.RELATED_CLASS, "SafetyPolicy"));
+
+        fields.add(name);
+        fields.add(factories);
+        fields.add(safetyPolicy);
+
+        return fields;
+    }
+
+    private List<FieldDto> prepareFieldDefinitionsForFactory() {
+        List<FieldDto> fields = new ArrayList<>();
+
+        FieldDto name = new FieldDto("name", "Name", null);
+
+        FieldDto location = new FieldDto("location", "Location", null);
+        location.addMetadata(new MetadataDto(Constants.MetadataKeys.RELATED_CLASS, "Location"));
+
+        fields.add(name);
+        fields.add(location);
+
+        return fields;
+    }
+
+    private Car prepareTestObject() {
+        Car car = new Car("Meriva");
+        Manufacturer manufacturer = new Manufacturer("Opel");
+
+        Location location = new Location("Eisenach", "99817");
+        Location location2 = new Location("Luton", "LU6");
+
+        SafetyPolicy policy = new SafetyPolicy(manufacturer, "DO read the manual before turning the engine on!");
+        manufacturer.setSafetyPolicy(policy);
+
+        Factory factory = new Factory("First Factory");
+        factory.setLocation(location);
+        Factory factory2 = new Factory("Second Factory");
+        factory2.setLocation(location2);
+
+        manufacturer.setFactories(Arrays.asList(factory, factory2));
+
+        Driver driver = new Driver("Peeta M.", new DateTime(2095, 6, 27, 10, 35));
+
+        car.setManufacturer(manufacturer);
+        car.setDriver(driver);
+
+        return car;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Car.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Car.java
@@ -1,0 +1,36 @@
+package org.motechproject.mds.web.util.mock;
+
+public class Car {
+
+    private String name;
+    private Manufacturer manufacturer;
+    private Driver driver;
+
+    public Car(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Driver getDriver() {
+        return driver;
+    }
+
+    public void setDriver(Driver driver) {
+        this.driver = driver;
+    }
+
+    public Manufacturer getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(Manufacturer manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Driver.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Driver.java
@@ -1,0 +1,30 @@
+package org.motechproject.mds.web.util.mock;
+
+import org.joda.time.DateTime;
+
+public class Driver {
+
+    private String name;
+    private DateTime dateOfBirth;
+
+    public Driver(String name, DateTime dateOfBirth) {
+        this.name = name;
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public DateTime getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(DateTime dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Factory.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Factory.java
@@ -1,0 +1,27 @@
+package org.motechproject.mds.web.util.mock;
+
+public class Factory {
+
+    private String name;
+    private Location location;
+
+    public Factory(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Location.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Location.java
@@ -1,0 +1,28 @@
+package org.motechproject.mds.web.util.mock;
+
+public class Location {
+
+    private String city;
+    private String postalCode;
+
+    public Location(String city, String postalCode) {
+        this.city = city;
+        this.postalCode = postalCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+        this.postalCode = postalCode;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Manufacturer.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/Manufacturer.java
@@ -1,0 +1,38 @@
+package org.motechproject.mds.web.util.mock;
+
+import java.util.List;
+
+public class Manufacturer {
+
+    private String name;
+    private List<Factory> factories;
+    private SafetyPolicy safetyPolicy;
+
+    public Manufacturer(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SafetyPolicy getSafetyPolicy() {
+        return safetyPolicy;
+    }
+
+    public void setSafetyPolicy(SafetyPolicy safetyPolicy) {
+        this.safetyPolicy = safetyPolicy;
+    }
+
+    public List<Factory> getFactories() {
+        return factories;
+    }
+
+    public void setFactories(List<Factory> factories) {
+        this.factories = factories;
+    }
+}

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/SafetyPolicy.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/util/mock/SafetyPolicy.java
@@ -1,0 +1,28 @@
+package org.motechproject.mds.web.util.mock;
+
+public class SafetyPolicy {
+
+    private Manufacturer manufacturer;
+    private String text;
+
+    public SafetyPolicy(Manufacturer manufacturer, String text) {
+        this.manufacturer = manufacturer;
+        this.text = text;
+    }
+
+    public Manufacturer getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(Manufacturer manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}


### PR DESCRIPTION
This commit fixes issues viewing instances that have
lazy loaded fields. The Spring controller attempted to
access these fields during serialization to json, what
resulted in JDO exception, due to accessing lazy loaded
fields outside a transaction. The relationships now
have their related fields set to null for display.