### PR TITLE
Removed checks for Tomcat processes

### DIFF
--- a/platform/server-war-test/pom.xml
+++ b/platform/server-war-test/pom.xml
@@ -102,25 +102,6 @@
                 <plugins>
 
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>POST IT - check if tomcat is stopped</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${basedir}/tomcat-shutdown.sh</executable>
-                                    <workingDirectory>${basedir}</workingDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
                         <groupId>com.googlecode.t7mp</groupId>
                         <artifactId>maven-t7-plugin</artifactId>
                         <version>0.9.16</version>

--- a/platform/server/pom.xml
+++ b/platform/server/pom.xml
@@ -348,24 +348,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>POST IT - check if tomcat is stopped</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>${basedir}/tomcat-shutdown.sh</executable>
-                                    <workingDirectory>${basedir}</workingDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>com.googlecode.t7mp</groupId>
                         <artifactId>maven-t7-plugin</artifactId>
                         <version>0.9.16</version>


### PR DESCRIPTION
I am removing this for now, since with multiple builds running
this can incorectly stop the server or read it as running.
If we have leftover Tomcat processes, we will get to know about it
sooner or later on the CI. In the future we might consider
comming up with a more sophisticated check.