### PR TITLE
MOTECH-1930: Remove the dependency on FWC and documented how to use it

### DIFF
--- a/docs/source/deployment/felix_webconsole.rst
+++ b/docs/source/deployment/felix_webconsole.rst
@@ -1,0 +1,32 @@
+===================================
+Using Felix Web Console with MOTECH
+===================================
+
+.. contents:: Table of Contents
+   :depth: 2
+
+Overview
+========
+
+MOTECH is built on top of the `Felix OSGi Framework <http://felix.apache.org/>`_. Thanks to this, users can install the Felix Web Console
+on their installations and then use it for monitoring the server.
+
+Benefits of using the Web Console
+=================================
+
+The Felix Web Console allows viewing details of all bundles installed in the System. It also allows installing and
+uninstalling modules. Generally speaking the only benefit of using the web console over the Motech Admin module
+is that it gives access to bundles that are not MOTECH modules - for example third party libraries such as Spring.
+More information on the Web Console can be found here: http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html
+
+Installation
+============
+
+The Web Console can be installed by simply downloading it from the `Felix Downloades Page<http://felix.apache.org/downloads.cgi>`_ into the
+*~/.motech/bundles* directory belonging to the user running MOTECH. The console should become active after starting MOTECH.
+
+Accessing the Console
+=====================
+
+The console should be available after appending *module/system/console* to your MOTECH server url. The default login
+is admin/admin. Refer to the `Web Console Documentation<http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html>`_ for ways to change it.

--- a/docs/source/deployment/felix_webconsole.rst
+++ b/docs/source/deployment/felix_webconsole.rst
@@ -14,19 +14,19 @@ on their installations and then use it for monitoring the server.
 Benefits of using the Web Console
 =================================
 
-The Felix Web Console allows viewing details of all bundles installed in the System. It also allows installing and
-uninstalling modules. Generally speaking the only benefit of using the web console over the Motech Admin module
+The Felix Web Console allows viewing details of all bundles installed in the system. It also allows installing and
+uninstalling modules. Generally speaking the only benefit of using the web console over the MOTECH Admin module
 is that it gives access to bundles that are not MOTECH modules - for example third party libraries such as Spring.
-More information on the Web Console can be found here: http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html
+More information on the Web Console can be found in the `Web Console Documentation <http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html>`_.
 
 Installation
 ============
 
-The Web Console can be installed by simply downloading it from the `Felix Downloades Page<http://felix.apache.org/downloads.cgi>`_ into the
+The Web Console can be installed by simply downloading it from the `Felix Downloads Page<http://felix.apache.org/downloads.cgi>`_ into the
 *~/.motech/bundles* directory belonging to the user running MOTECH. The console should become active after starting MOTECH.
 
 Accessing the Console
 =====================
 
 The console should be available after appending *module/system/console* to your MOTECH server url. The default login
-is admin/admin. Refer to the `Web Console Documentation<http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html>`_ for ways to change it.
+is admin/admin. Refer to the `Web Console Documentation <http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html>`_ for ways to change it.

--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -7,3 +7,4 @@ Deployment
 
     sticky_session_apache
     multibyte_characters
+    felix_webconsole

--- a/packaging/deb/pom.xml
+++ b/packaging/deb/pom.xml
@@ -106,10 +106,6 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.shell</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.webconsole</artifactId>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/packaging/rpm/pom.xml
+++ b/packaging/rpm/pom.xml
@@ -105,11 +105,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.webconsole</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.eventadmin</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/platform/server/pom.xml
+++ b/platform/server/pom.xml
@@ -186,10 +186,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.webconsole</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.eventadmin</artifactId>
         </dependency>
         <!-- Mysql jdbc -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <felix.eventadmin.version>1.3.2</felix.eventadmin.version>
         <felix.scr.version>1.8.2</felix.scr.version>
         <felix.shell.version>1.4.3</felix.shell.version>
-        <felix.webconsole.version>4.2.2</felix.webconsole.version>
 
         <spring.version>3.1.0.RELEASE</spring.version>
         <spring.security.version>${spring.version}</spring.security.version>
@@ -424,11 +423,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.shell</artifactId>
                 <version>${felix.shell.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.webconsole</artifactId>
-                <version>${felix.webconsole.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
* Documented how to install and use the Felix Web Console
* Removed it from Motech, since it is a security hazard by default