### PR TITLE
MOTECH-1806: Errors pointing to logs when a bean validation fails

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/ex/object/ObjectCreateException.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/ex/object/ObjectCreateException.java
@@ -2,6 +2,10 @@ package org.motechproject.mds.ex.object;
 
 import org.motechproject.mds.ex.MdsException;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.Set;
+
 /**
  * Signals that it was not possible to update object instance from the provided data.
  */
@@ -10,6 +14,17 @@ public class ObjectCreateException extends MdsException {
     private static final long serialVersionUID = -6214111291407582493L;
 
     public ObjectCreateException(String entityName, Throwable cause) {
-        super("Unable to create of entity " + entityName, cause, "mds.error.objectUpdateError");
+        super("Unable to create of entity " + entityName + ". " + getMessageFromCause(cause), cause, "mds.error.objectUpdateError");
+    }
+
+    private static String getMessageFromCause(Throwable cause) {
+        String message = "";
+        if (cause instanceof ConstraintViolationException) {
+            Set<ConstraintViolation<?>> violations = ((ConstraintViolationException) cause).getConstraintViolations();
+            for (ConstraintViolation violation : violations) {
+                message += String.format("Field %s %s\n", violation.getPropertyPath(), violation.getMessage() );
+            }
+        }
+        return message;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/ex/object/ObjectUpdateException.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/ex/object/ObjectUpdateException.java
@@ -2,6 +2,10 @@ package org.motechproject.mds.ex.object;
 
 import org.motechproject.mds.ex.MdsException;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.Set;
+
 /**
  * Signals that it was not possible to update object instance from the provided data.
  */
@@ -10,7 +14,18 @@ public class ObjectUpdateException extends MdsException {
     private static final long serialVersionUID = -6214111291407582493L;
 
     public ObjectUpdateException(String entityName, Long id, Throwable cause) {
-        super("Unable to object of entity " + entityName + " with id " + id,
+        super("Unable to object of entity " + entityName + " with id " + id + ". " + getMessageFromCause(cause),
                 cause, "mds.error.objectUpdateError");
+    }
+
+    private static String getMessageFromCause(Throwable cause) {
+        String message = "";
+        if (cause instanceof ConstraintViolationException) {
+            Set<ConstraintViolation<?>> violations = ((ConstraintViolationException) cause).getConstraintViolations();
+            for (ConstraintViolation violation : violations) {
+                message += String.format("Field %s %s\n", violation.getPropertyPath(), violation.getMessage() );
+            }
+        }
+        return message;
     }
 }


### PR DESCRIPTION
when creating an instance through the UI (and the log error isn't helpful either)

Added message from ConstraintViolation to Exception message.