### PR TITLE
MOTECH-1899: Improves handling server log on the UI

### DIFF
--- a/modules/admin/src/main/java/org/motechproject/admin/web/controller/ServerLogController.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/web/controller/ServerLogController.java
@@ -57,7 +57,7 @@ public class ServerLogController {
         if (!logFile.exists()) {
             writer.write("server.tomcat.error.logFileNotFound");
         } else {
-            long readSize = FileUtils.ONE_MB;
+            long readSize = FileUtils.ONE_KB * 200;
             long fileSize = logFile.length();
 
             try (InputStream in = new FileInputStream(logFile)) {

--- a/modules/admin/src/main/resources/webapp/js/controllers.js
+++ b/modules/admin/src/main/resources/webapp/js/controllers.js
@@ -688,7 +688,7 @@
                     if (data === 'server.tomcat.error.logFileNotFound') {
                         $('#logContent').html($scope.msg(data));
                     } else {
-                        $('#logContent').html(data.replace(/\r\n|\n/g, "<br/>"));
+                        $('#logContent').html(data);
                         unblockUI();
                     }
                 }).

--- a/modules/admin/src/main/resources/webapp/partials/log.html
+++ b/modules/admin/src/main/resources/webapp/partials/log.html
@@ -12,7 +12,7 @@
             </div>
             <div class="clearfix"></div>
         </div>
-        <div id="logContent" class="log-content"></div>
+         <pre id="logContent" class="log-content"></pre>
     </div>
     <ul sidebar>
         <li go-to-top>


### PR DESCRIPTION
This commit improves handling server log on the UI. I changed size of logs to display,
now its 200KB. The size is similar to Jenkins console output,
its approximately 2000 lines. Also I changed html tag from "div" to "pre".
Thanks to that we don't have to parse plain text.