### PR TITLE
MOTECH-1931: Fix ordering inconsistencies

### DIFF
--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskActivityServiceImplTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskActivityServiceImplTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.motechproject.mds.query.QueryParams;
+import org.motechproject.mds.util.Order;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActivity;
 import org.motechproject.tasks.domain.TaskActivityType;
@@ -151,7 +152,7 @@ public class TaskActivityServiceImplTest {
     public void shouldReturnPaginatedActivitiesForGivenTask() {
         Set<TaskActivityType> types = new HashSet<>();
         types.addAll(Arrays.asList(TaskActivityType.values()));
-        QueryParams queryParams = new QueryParams(null);
+        QueryParams queryParams = new QueryParams((Order) null);
         when(taskActivitiesDataService.byTaskAndActivityTypes(TASK_ID, types, queryParams)).thenReturn(activities);
 
         List<TaskActivity> actual = activityService.getTaskActivities(TASK_ID, types, queryParams);

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
@@ -321,7 +321,7 @@ public class InstanceController extends MdsController {
     private QueryParams buildQueryParams(GridSettings settings, List<Order> orderList) {
         // just check if the page is set
         int page = (settings.getPage() == null) ? 1 : settings.getPage();
-        int pageSize = (settings.getPage() == null) ? 10 : settings.getRows();
+        int pageSize = (settings.getRows() == null) ? 10 : settings.getRows();
 
         return new QueryParams(page, pageSize, orderList);
     }
@@ -337,7 +337,7 @@ public class InstanceController extends MdsController {
         if (order != null) {
             orderList.add(order);
             if (!Constants.Util.ID_FIELD_NAME.equalsIgnoreCase(order.getField())) {
-                // if the ordering is done on a field other then id
+                // if the ordering is done on a field other than id
                 // we want to add the id ordering as backup, so that results stay consistent
                 orderList.add(new Order(Constants.Util.ID_FIELD_NAME, Order.Direction.ASC));
             }

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,16 +135,7 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/instances/{entityId}/{instanceId}/history", method = RequestMethod.GET)
     @ResponseBody
     public Records<HistoryRecord> getHistory(@PathVariable Long entityId, @PathVariable Long instanceId, GridSettings settings) {
-        Order order = null;
-        if (settings.getSortColumn() != null && !settings.getSortColumn().isEmpty()) {
-            order = new Order(settings.getSortColumn(), settings.getSortDirection());
-        }
-
-        if (settings.getPage() == null) {
-            settings.setPage(1);
-            settings.setRows(10);
-        }
-        QueryParams queryParams = new QueryParams(settings.getPage(), settings.getRows(), order);
+        QueryParams queryParams = buildQueryParams(settings);
         List<HistoryRecord> historyRecordsList = instanceService.getInstanceHistory(entityId, instanceId, queryParams);
 
         long recordCount = instanceService.countHistoryRecords(entityId, instanceId);
@@ -193,12 +185,7 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/entities/{entityId}/trash", method = RequestMethod.GET)
     @ResponseBody
     public Records<EntityRecord> getTrash(@PathVariable Long entityId, GridSettings settings) {
-        Order order = null;
-        if (settings.getSortColumn() != null && !settings.getSortColumn().isEmpty()) {
-            order = new Order(settings.getSortColumn(), settings.getSortDirection());
-        }
-
-        QueryParams queryParams = new QueryParams(settings.getPage(), settings.getRows(), order);
+        QueryParams queryParams = buildQueryParams(settings);
         List<EntityRecord> trashRecordsList = instanceService.getTrashRecords(entityId, queryParams);
 
         long recordCount = instanceService.countTrashRecords(entityId);
@@ -233,8 +220,8 @@ public class InstanceController extends MdsController {
                 "Content-Disposition",
                 "attachment; filename=" + fileName + "." + outputFormat.toLowerCase());
 
-        Order order = StringUtils.isNotEmpty(settings.getSortColumn()) ? new Order(settings.getSortColumn(), settings.getSortDirection()) : null;
-        QueryParams queryParams = new QueryParams(1, StringUtils.equalsIgnoreCase(exportRecords, "all") ? null : Integer.valueOf(exportRecords), order);
+        final Integer pageSize = StringUtils.equalsIgnoreCase(exportRecords, "all") ? null : Integer.valueOf(exportRecords);
+        QueryParams queryParams = new QueryParams(1, pageSize, buildOrderList(settings));
 
         if (Constants.ExportFormat.PDF.equals(outputFormat)) {
             csvImportExportService.exportPdf(entityId, response.getOutputStream(), settings.getLookup(), queryParams,
@@ -248,12 +235,7 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/entities/{entityId}/instances", method = RequestMethod.POST)
     @ResponseBody
     public Records<?> getInstances(@PathVariable Long entityId, GridSettings settings) throws IOException {
-        Order order = null;
-        if (!settings.getSortColumn().isEmpty()) {
-            order = new Order(settings.getSortColumn(), settings.getSortDirection());
-        }
-
-        QueryParams queryParams = new QueryParams(settings.getPage(), settings.getRows(), order);
+        QueryParams queryParams = buildQueryParams(settings);
 
         String lookup = settings.getLookup();
         String filterStr = settings.getFilter();
@@ -330,5 +312,37 @@ public class InstanceController extends MdsController {
         int index = ArrayUtils.indexOf(content, (byte) ',') + 1;
 
         return ArrayUtils.toObject(decoder.decode(ArrayUtils.subarray(content, index, content.length)));
+    }
+
+    private QueryParams buildQueryParams(GridSettings settings) {
+        return buildQueryParams(settings, buildOrderList(settings));
+    }
+
+    private QueryParams buildQueryParams(GridSettings settings, List<Order> orderList) {
+        // just check if the page is set
+        int page = (settings.getPage() == null) ? 1 : settings.getPage();
+        int pageSize = (settings.getPage() == null) ? 10 : settings.getRows();
+
+        return new QueryParams(page, pageSize, orderList);
+    }
+
+    private List<Order> buildOrderList(GridSettings settings) {
+        Order order = null;
+
+        if (settings.getSortColumn() != null && !settings.getSortColumn().isEmpty()) {
+            order = new Order(settings.getSortColumn(), settings.getSortDirection());
+        }
+
+        List<Order> orderList = new ArrayList<>();
+        if (order != null) {
+            orderList.add(order);
+            if (!Constants.Util.ID_FIELD_NAME.equalsIgnoreCase(order.getField())) {
+                // if the ordering is done on a field other then id
+                // we want to add the id ordering as backup, so that results stay consistent
+                orderList.add(new Order(Constants.Util.ID_FIELD_NAME, Order.Direction.ASC));
+            }
+        }
+
+        return orderList;
     }
 }

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/controller/InstanceControllerTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/controller/InstanceControllerTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -66,7 +67,7 @@ public class InstanceControllerTest {
                 "attachment; filename=Entity_1_instances.csv");
 
         assertNull(captor.getValue().getPageSize());
-        assertNull(captor.getValue().getOrder());
+        assertFalse(captor.getValue().isOrderSet());
     }
 
     @Test
@@ -91,8 +92,8 @@ public class InstanceControllerTest {
                 "attachment; filename=Entity_1_instances.csv");
 
         QueryParams captorValue = queryParamsCaptor.getValue();
-        assertEquals(Order.Direction.ASC, captorValue.getOrder().getDirection());
-        assertEquals("sortColumn", captorValue.getOrder().getField());
+        assertEquals(Order.Direction.ASC, captorValue.getOrderList().get(0).getDirection());
+        assertEquals("sortColumn", captorValue.getOrderList().get(0).getField());
         assertEquals(Integer.valueOf(1), captorValue.getPage());
         assertEquals(Integer.valueOf(50), captorValue.getPageSize());
 

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/rest/MdsRestControllerTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/rest/MdsRestControllerTest.java
@@ -536,7 +536,7 @@ public class MdsRestControllerTest {
         assertNotNull(queryParams);
         assertEquals(Integer.valueOf(5), queryParams.getPage());
         assertEquals(Integer.valueOf(14), queryParams.getPageSize());
-        Order order = queryParams.getOrder();
+        Order order = queryParams.getOrderList().get(0);
         assertNotNull(order);
         assertEquals("name", order.getField());
         assertEquals(Order.Direction.DESC, order.getDirection());

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/rest/ParamParserTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/rest/ParamParserTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ParamParserTest {
 
@@ -25,9 +26,10 @@ public class ParamParserTest {
 
         assertEquals(Integer.valueOf(14), queryParams.getPage());
         assertEquals(Integer.valueOf(120), queryParams.getPageSize());
-        assertNotNull(queryParams.getOrder());
-        assertEquals("someColumn", queryParams.getOrder().getField());
-        assertEquals(Order.Direction.DESC, queryParams.getOrder().getDirection());
+        assertNotNull(queryParams.getOrderList());
+        assertEquals(1, queryParams.getOrderList().size());
+        assertEquals("someColumn", queryParams.getOrderList().get(0).getField());
+        assertEquals(Order.Direction.DESC, queryParams.getOrderList().get(0).getDirection());
 
         // null order
 
@@ -36,7 +38,7 @@ public class ParamParserTest {
 
         queryParams = ParamParser.buildQueryParams(requestParams);
 
-        assertNull(queryParams.getOrder());
+        assertTrue(queryParams.getOrderList().isEmpty());
 
         // default order direction
 
@@ -44,9 +46,10 @@ public class ParamParserTest {
 
         queryParams = ParamParser.buildQueryParams(requestParams);
 
-        assertNotNull(queryParams.getOrder());
-        assertEquals("anotherColumn", queryParams.getOrder().getField());
-        assertEquals(Order.Direction.ASC, queryParams.getOrder().getDirection());
+        assertNotNull(queryParams.getOrderList());
+        assertEquals(1, queryParams.getOrderList().size());
+        assertEquals("anotherColumn", queryParams.getOrderList().get(0).getField());
+        assertEquals(Order.Direction.ASC, queryParams.getOrderList().get(0).getDirection());
     }
 
     @Test

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
@@ -141,7 +141,7 @@ public class InstanceServiceTest {
         mockDataService();
         mockSampleFields();
         mockEntity();
-        QueryParams queryParams = new QueryParams(1, 10, null);
+        QueryParams queryParams = new QueryParams(1, 10);
         when(trashService.getInstancesFromTrash(anyString(), eq(queryParams))).thenReturn(sampleCollection());
 
         List<EntityRecord> records = instanceService.getTrashRecords(ENTITY_ID, queryParams);
@@ -927,7 +927,10 @@ public class InstanceServiceTest {
             assertEquals(strField, LOOKUP_1_EXPECTED_PARAM);
             assertEquals(Integer.valueOf(1), queryParams.getPage());
             assertEquals(Integer.valueOf(5), queryParams.getPageSize());
-            assertEquals("strField descending", queryParams.getOrder().toString());
+
+            assertEquals(1, queryParams.getOrderList().size());
+            assertEquals("strField", queryParams.getOrderList().get(0).getField());
+            assertEquals(Order.Direction.DESC, queryParams.getOrderList().get(0).getDirection());
 
             return new TestSample("strField", 6);
         }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/query/QueryParams.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/query/QueryParams.java
@@ -1,10 +1,11 @@
 package org.motechproject.mds.query;
 
-import org.apache.commons.lang.StringUtils;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.Order;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility class containing parameters which control order and size of query results.
@@ -15,7 +16,7 @@ public class QueryParams implements Serializable {
 
     private final Integer page;
     private final Integer pageSize;
-    private final Order order;
+    private final List<Order> orderList;
 
     /**
      * Constant query parameter, that orders records ascending by ID.
@@ -29,7 +30,7 @@ public class QueryParams implements Serializable {
      * @param pageSize amount of entries to include, per page
      */
     public QueryParams(Integer page, Integer pageSize) {
-        this(page, pageSize, null);
+        this(page, pageSize, new ArrayList<Order>());
     }
 
     /**
@@ -44,6 +45,15 @@ public class QueryParams implements Serializable {
     /**
      * Creates query parameters.
      *
+     * @param orderList the list of order instructions that will be applied to the query
+     */
+    public QueryParams(List<Order> orderList) {
+        this(null, null, orderList);
+    }
+
+    /**
+     * Creates query parameters.
+     *
      * @param page number of page
      * @param pageSize amount of entries to include, per page
      * @param order specifies order of the records
@@ -51,7 +61,23 @@ public class QueryParams implements Serializable {
     public QueryParams(Integer page, Integer pageSize, Order order) {
         this.page = page;
         this.pageSize = pageSize;
-        this.order = order;
+        this.orderList = new ArrayList<>();
+        if (order != null) {
+            orderList.add(order);
+        }
+    }
+
+    /**
+     * Creates query parameters.
+     *
+     * @param page number of page
+     * @param pageSize amount of entries to include, per page
+     * @param orderList the list of order instructions that will be applied to the query
+     */
+    public QueryParams(Integer page, Integer pageSize, List<Order> orderList) {
+        this.page = page;
+        this.pageSize = pageSize;
+        this.orderList = (orderList == null) ? new ArrayList<Order>() : orderList;
     }
 
     public Integer getPage() {
@@ -62,34 +88,38 @@ public class QueryParams implements Serializable {
         return pageSize;
     }
 
-    public Order getOrder() {
-        return order;
+    public List<Order> getOrderList() {
+        return orderList;
     }
 
     public boolean isOrderSet() {
-        return order != null && StringUtils.isNotBlank(order.getField());
+        return !orderList.isEmpty();
     }
 
     public boolean isPagingSet() {
         return page != null && pageSize != null;
     }
 
+    public void addOrder(Order order) {
+        orderList.add(order);
+    }
+
     /**
-     * Creates query parameter that sorts records ascending, by the given field.
-     *
-     * @param field field to sort records by
-     * @return query parameter, ordering records ascending
-     */
+      * Creates query parameter that sorts records ascending, by the given field.
+      *
+      * @param field field to sort records by
+      * @return query parameter, ordering records ascending
+      */
     public static QueryParams ascOrder(String field) {
         return new QueryParams(new Order(field, Order.Direction.ASC));
     }
 
     /**
-     * Creates query parameter that sorts records descending, by the given field.
-     *
-     * @param field field to sort records by
-     * @return query parameter, ordering records descending
-     */
+      * Creates query parameter that sorts records descending, by the given field.
+      *
+      * @param field field to sort records by
+      * @return query parameter, ordering records descending
+      */
     public static QueryParams descOrder(String field) {
         return new QueryParams(new Order(field, Order.Direction.DESC));
     }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/query/QueryUtil.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/query/QueryUtil.java
@@ -43,7 +43,8 @@ public final class QueryUtil {
                 query.setRange(fromIncl, toExcl);
             }
             if (queryParams.isOrderSet()) {
-                query.setOrdering(queryParams.getOrder().toString());
+                String order = StringUtils.join(queryParams.getOrderList(), ", ");
+                query.setOrdering(order);
             }
         }
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
@@ -458,7 +458,7 @@ public class MdsBundleIT extends BasePaxIT {
             assertEquals(3, resultList.size());
             assertInstanceOne(resultList.get(0), objClass);
             assertInstanceTwo(resultList.get(1), objClass);
-            assertInstanceFive(resultList.get(2), objClass);
+            assertInstanceFour(resultList.get(2), objClass);
         }
     }
 
@@ -941,7 +941,7 @@ public class MdsBundleIT extends BasePaxIT {
     }
 
     private void assertInstanceFive(Object instance, Class objClass) throws Exception {
-        updateInstance(instance, true, "notInSet", "notInSetCp", Collections.emptyList(),
+        assertInstance(instance, true, "notInSet", "notInSetCp", Collections.emptyList(),
                 NOW.plusHours(4), LD_NOW, null, TEST_PERIOD, BYTE_ARRAY_VALUE,
                 DATE_NOW, DOUBLE_VALUE_2, MORNING_TIME, 4, toEnum(objClass, "two"));
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
@@ -290,18 +290,27 @@ public class MdsBundleIT extends BasePaxIT {
         Object instance4 = loadedClass.newInstance();
         Object instance5 = loadedClass.newInstance();
 
+        // instance 1
         updateInstance(instance, true, "trueNow", "trueNowCp", asList("1", "2", "3"),
                        NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
                        DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"));
+
+        // instance 2
         updateInstance(instance2, true, "trueInRange", "trueInRangeCp", asList("2", "4"),
                        NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
                        DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(loadedClass, "two"));
+
+        // instance 3
         updateInstance(instance3, false, "falseInRange", "falseInRangeCp", null,
                        NOW.plusHours(2), LD_NOW.plusDays(1), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
                        DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(loadedClass, "three"));
+
+        // instance 4
         updateInstance(instance4, true, "trueOutOfRange", "trueOutOfRangeCp", null,
                        NOW.plusHours(3), LD_NOW.plusDays(10), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
                        DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(loadedClass, "one"));
+
+        // instance 5
         updateInstance(instance5, true, "notInSet", "notInSetCp", null,
                        NOW.plusHours(4), LD_NOW, null, TEST_PERIOD, BYTE_ARRAY_VALUE,
                        DATE_NOW, DOUBLE_VALUE_2, MORNING_TIME, 4, toEnum(loadedClass, "two"));
@@ -319,9 +328,7 @@ public class MdsBundleIT extends BasePaxIT {
         Long count = (Long) MethodUtils.invokeMethod(service, "countByUniqueString", "trueNow");
         assertEquals(count, (Long) 1L);
 
-        assertInstance(retrieved, true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(loadedClass, "one"));
+        assertInstanceOne(retrieved, loadedClass);
 
         assertEquals(1, service.retrieveAll().size());
         service.create(instance2);
@@ -329,8 +336,20 @@ public class MdsBundleIT extends BasePaxIT {
         service.create(instance4);
         service.create(instance5);
         assertEquals(INSTANCE_COUNT, service.retrieveAll().size());
-    }
 
+        // verify double order
+        QueryParams queryParams = new QueryParams(asList(new Order("someLocalDate", Order.Direction.DESC),
+                new Order("someString", Order.Direction.ASC)));
+        List<Object> result = service.retrieveAll(queryParams);
+
+        assertNotNull(result);
+        assertEquals(5, result.size());
+        assertInstanceFour(result.get(0), loadedClass);
+        assertInstanceThree(result.get(1), loadedClass);
+        assertInstanceTwo(result.get(2), loadedClass);
+        assertInstanceFive(result.get(3), loadedClass);
+        assertInstanceOne(result.get(4), loadedClass);
+    }
 
     private void verifyLookups(boolean usingLookupService) throws Exception{
         // if using lookup service set tot true then all data access
@@ -353,9 +372,7 @@ public class MdsBundleIT extends BasePaxIT {
 
         Class objClass = resultList.get(0).getClass();
 
-        assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                       NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+        assertInstanceOne(resultList.get(0), objClass);
 
         // verify lookups
         if (usingLookupService) {
@@ -372,9 +389,7 @@ public class MdsBundleIT extends BasePaxIT {
         resultList = (List) resultObj;
 
         assertEquals(4, resultList.size());
-        assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                       NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+        assertInstanceOne(resultList.get(0), objClass);
 
         List<String> list = new ArrayList<>();
         list.add("2");
@@ -398,12 +413,8 @@ public class MdsBundleIT extends BasePaxIT {
         assertTrue(resultObj instanceof List);
         resultList = (List) resultObj;
         assertEquals(2, resultList.size());
-        assertInstance(resultList.get(0), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
-                       NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
-        assertInstance(resultList.get(1), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                       NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+        assertInstanceTwo(resultList.get(0), objClass);
+        assertInstanceOne(resultList.get(1), objClass);
 
         // usage of a custom operator
         if (usingLookupService) {
@@ -419,15 +430,9 @@ public class MdsBundleIT extends BasePaxIT {
         assertTrue(resultObj instanceof List);
         resultList = (List) resultObj;
         assertEquals(3, resultList.size());
-        assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
-        assertInstance(resultList.get(1), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
-                NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
-        assertInstance(resultList.get(2), false, "falseInRange", "falseInRangeCp", Collections.emptyList(),
-                NOW.plusHours(2), LD_NOW.plusDays(1), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(objClass, "three"));
+        assertInstanceOne(resultList.get(0), objClass);
+        assertInstanceTwo(resultList.get(1), objClass);
+        assertInstanceThree(resultList.get(2), objClass);
 
         // usage of matches, case sensitive and case insensitive
         String[] textsToSearch = { "true", "TRUE" };
@@ -451,15 +456,9 @@ public class MdsBundleIT extends BasePaxIT {
             assertTrue(resultObj instanceof List);
             resultList = (List) resultObj;
             assertEquals(3, resultList.size());
-            assertInstance(resultList.get(0), true, "trueNow", "trueNowCp", asList("1", "2", "3"),
-                    NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
-            assertInstance(resultList.get(1), true, "trueInRange", "trueInRangeCp", asList("2", "4"),
-                    NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
-            updateInstance(resultList.get(2), true, "trueOutOfRange", "trueOutOfRangeCp", null,
-                    NOW.plusHours(3), LD_NOW.plusDays(10), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
-                    DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "one"));
+            assertInstanceOne(resultList.get(0), objClass);
+            assertInstanceTwo(resultList.get(1), objClass);
+            assertInstanceFive(resultList.get(2), objClass);
         }
     }
 
@@ -472,6 +471,7 @@ public class MdsBundleIT extends BasePaxIT {
         Object retrieved = allObjects.get(0);
         Class objClass = retrieved.getClass();
 
+        // instance 1.1
         updateInstance(retrieved, false, "anotherString", "anotherStringCp", asList("4", "5"),
                 YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
                 DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
@@ -479,9 +479,7 @@ public class MdsBundleIT extends BasePaxIT {
         service.update(retrieved);
         Object updated = service.retrieveAll(QueryParams.descOrder("someDateTime")).get(0);
 
-        assertInstance(updated, false, "anotherString", "anotherStringCp", asList("4", "5"),
-                       YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                       DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+        assertInstanceOneDotOne(updated, objClass);
     }
 
     private void verifyInstanceCreatingOrUpdating(Class<?> loadedClass) throws Exception {
@@ -572,9 +570,7 @@ public class MdsBundleIT extends BasePaxIT {
         assertEquals(1, result.size());
 
         Class objClass = result.get(0).getClass();
-        assertInstance(result.get(0), false, "anotherString", "anotherStringCp", asList("4", "5"),
-                YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
-                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+        assertInstanceOneDotOne(result.get(0), objClass);
 
         List<String> names = (List<String>) service.executeSQLQuery(new SqlQueryExecution<List<String>>() {
             @Override
@@ -912,5 +908,41 @@ public class MdsBundleIT extends BasePaxIT {
             }
         }
         return null;
+    }
+
+    private void assertInstanceOne(Object instance, Class objClass) throws Exception {
+        assertInstance(instance, true, "trueNow", "trueNowCp", asList("1", "2", "3"),
+                NOW, LD_NOW, TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 1, toEnum(objClass, "one"));
+    }
+
+    private void assertInstanceTwo(Object instance, Class objClass) throws Exception {
+        assertInstance(instance, true, "trueInRange", "trueInRangeCp", asList("2", "4"),
+                NOW.plusHours(1), LD_NOW.plusDays(1), TEST_MAP, TEST_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_NOW, DOUBLE_VALUE_1, MORNING_TIME, 2, toEnum(objClass, "two"));
+    }
+
+    private void assertInstanceThree(Object instance, Class objClass) throws Exception {
+        assertInstance(instance, false, "falseInRange", "falseInRangeCp", Collections.emptyList(),
+                NOW.plusHours(2), LD_NOW.plusDays(1), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 2, toEnum(objClass, "three"));
+    }
+
+    private void assertInstanceOneDotOne(Object instance, Class objClass) throws Exception {
+        assertInstance(instance, false, "anotherString", "anotherStringCp", asList("4", "5"),
+                YEAR_LATER, LD_YEAR_AGO, TEST_MAP2, NEW_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 10, toEnum(objClass, "two"));
+    }
+
+    private void assertInstanceFour(Object instance, Class objClass) throws Exception {
+        assertInstance(instance, true, "trueOutOfRange", "trueOutOfRangeCp", Collections.emptyList(),
+                NOW.plusHours(3), LD_NOW.plusDays(10), null, TEST_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_TOMORROW, DOUBLE_VALUE_2, NIGHT_TIME, 3, toEnum(objClass, "one"));
+    }
+
+    private void assertInstanceFive(Object instance, Class objClass) throws Exception {
+        updateInstance(instance, true, "notInSet", "notInSetCp", Collections.emptyList(),
+                NOW.plusHours(4), LD_NOW, null, TEST_PERIOD, BYTE_ARRAY_VALUE,
+                DATE_NOW, DOUBLE_VALUE_2, MORNING_TIME, 4, toEnum(objClass, "two"));
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/HistoryServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/HistoryServiceContextIT.java
@@ -104,7 +104,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
     public void shouldCreateHistoricalRecord() throws Exception {
         Object instance = createInstance(ORIGINAL_VALUES[0]);
 
-        QueryParams queryParams = new QueryParams(1,10,null);
+        QueryParams queryParams = new QueryParams(1, 10);
         List records = historyService.getHistoryForInstance(instance, queryParams);
         // The latest revision should not be present in the result
         assertRecords(records, 0);
@@ -139,7 +139,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
     @Test
     public void shouldNotMixHistoricalRecords() throws Exception {
         // creates and updates instances one after another
-        QueryParams queryParams = new QueryParams(1,10,null);
+        QueryParams queryParams = new QueryParams(1, 10);
         Object instance1 = createInstance(ORIGINAL_VALUES[0]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[2]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[4]);
@@ -182,7 +182,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
 
     @Test
     public void shouldRemoveOnlyCorrectRecords() throws Exception {
-        QueryParams queryParams = new QueryParams(1,10,null);
+        QueryParams queryParams = new QueryParams(1, 10);
         Object instance1 = createInstance(ORIGINAL_VALUES[0]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[2]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[4]);
@@ -206,7 +206,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
 
     @Test
     public void shouldConnectHistoricalRecordsWithTrashInstance() throws Exception {
-        QueryParams queryParams = new QueryParams(1, 10, null);
+        QueryParams queryParams = new QueryParams(1, 10);
         Object instance1 = createInstance(ORIGINAL_VALUES[0]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[2]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[4]);
@@ -252,7 +252,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
     @Test
     @Ignore
     public void shouldRevertPreviousVersion() throws Exception {
-        QueryParams queryParams = new QueryParams(1,10,null);
+        QueryParams queryParams = new QueryParams(1, 10);
         Object instance = createInstance(ORIGINAL_VALUES[0]);
         instance = updateInstance(instance, ORIGINAL_VALUES[2]);
         instance = updateInstance(instance, ORIGINAL_VALUES[4]);
@@ -286,7 +286,7 @@ public class HistoryServiceContextIT extends BaseInstanceIT {
     @Test
     @Ignore
     public void shouldProperlyAssignRecordsAfterMoveFromTrash() throws Exception {
-        QueryParams queryParams = new QueryParams(1,10,null);
+        QueryParams queryParams = new QueryParams(1, 10);
         Object instance1 = createInstance(ORIGINAL_VALUES[0]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[2]);
         instance1 = updateInstance(instance1, ORIGINAL_VALUES[4]);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/lookup/LookupExecutorTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/lookup/LookupExecutorTest.java
@@ -197,9 +197,10 @@ public class LookupExecutorTest {
             assertNotNull(queryParams);
             assertEquals(Integer.valueOf(PAGE), queryParams.getPage());
             assertEquals(Integer.valueOf(PAGE_SIZE), queryParams.getPageSize());
-            assertNotNull(queryParams.getOrder());
-            assertEquals(SORT_FIELD, queryParams.getOrder().getField());
-            assertEquals(DIRECTION, queryParams.getOrder().getDirection());
+            assertNotNull(queryParams.getOrderList());
+            assertEquals(1, queryParams.getOrderList().size());
+            assertEquals(SORT_FIELD, queryParams.getOrderList().get(0).getField());
+            assertEquals(DIRECTION, queryParams.getOrderList().get(0).getDirection());
         }
 
         public List<TestClass> findByRelationFields(String strParam, long longParam, int intParam , String strParam2) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/query/QueryUtilTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/query/QueryUtilTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
@@ -40,7 +41,7 @@ public class QueryUtilTest {
     public void shouldSetQueryParams() {
         when(queryParams.isOrderSet()).thenReturn(true);
         when(queryParams.isPagingSet()).thenReturn(true);
-        when(queryParams.getOrder()).thenReturn(new Order("field", "ascending"));
+        when(queryParams.getOrderList()).thenReturn(singletonList(new Order("field", "ascending")));
         when(queryParams.getPage()).thenReturn(2);
         when(queryParams.getPageSize()).thenReturn(10);
 
@@ -106,6 +107,16 @@ public class QueryUtilTest {
     public void shouldSetCountResult() {
         QueryUtil.setCountResult(query);
         verify(query).setResult("count(this)");
+    }
+
+    @Test
+    public void shouldSetMultipleOrders() {
+        QueryParams queryParams = new QueryParams(null, null, asList(new Order("field1", Order.Direction.DESC),
+                new Order("field2", Order.Direction.ASC), new Order("field3", Order.Direction.ASC)));
+
+        QueryUtil.setQueryParams(query, queryParams);
+
+        verify(query).setOrdering("field1 descending, field2 ascending, field3 ascending");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
* Allowed ordering on multiple fields using QueryParams
* In the data-browser, use ID ordering as backup to the provided
  one
* Cleaned up some duplications in InstanceController and MdsBundleIT