### PR TITLE
MOTECH-1925: Import CSV is not possible for readonly entities

### DIFF
--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
@@ -268,6 +268,7 @@ public class InstanceController extends MdsController {
     @ResponseBody
     public long importCsv(@PathVariable long entityId, @RequestParam(required = true)  MultipartFile csvFile) {
         instanceService.verifyEntityAccess(entityId);
+        instanceService.validateNonEditableProperty(entityId);
         try {
             try (InputStream in = csvFile.getInputStream()) {
                 Reader reader = new InputStreamReader(in);

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/InstanceService.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/InstanceService.java
@@ -2,6 +2,7 @@ package org.motechproject.mds.web.service;
 
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.FieldInstanceDto;
+import org.motechproject.mds.ex.entity.EntityInstancesNonEditableException;
 import org.motechproject.mds.filter.Filters;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.web.domain.EntityRecord;
@@ -282,7 +283,16 @@ public interface InstanceService {
 
     /**
      * Checks whether the logged in user has access to the entity with the given ID.
+     *
      * @param entityId the id of the entity
      */
     void verifyEntityAccess(Long entityId);
+
+    /**
+     * Checks whether the entity with the given ID is non editable.
+     *
+     * @param entityId the id of the entity
+     * @throws EntityInstancesNonEditableException if the entity is non editable
+     */
+    void validateNonEditableProperty(Long entityId);
 }

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
@@ -293,7 +293,7 @@ public class InstanceServiceImpl implements InstanceService {
 
     @Override
     public void revertPreviousVersion(Long entityId, Long instanceId, Long historyId) {
-        validateNonEditableProperty(getEntity(entityId));
+        validateNonEditableProperty(entityId);
         HistoryRecord historyRecord = getHistoryRecord(entityId, instanceId, historyId);
         if (!historyRecord.isRevertable()) {
             EntityDto entity = getEntity(entityId);
@@ -457,6 +457,17 @@ public class InstanceServiceImpl implements InstanceService {
     public void verifyEntityAccess(Long entityId) {
         EntityDto entity = getEntity(entityId);
         validateCredentialsForReading(entity);
+    }
+
+    @Override
+    public void validateNonEditableProperty(Long entityId) {
+        validateNonEditableProperty(getEntity(entityId));
+    }
+
+    private void validateNonEditableProperty(EntityDto entity) {
+        if (entity.isNonEditable()) {
+            throw new EntityInstancesNonEditableException();
+        }
     }
 
     private void populateDefaultFields(List<FieldRecord> fieldRecords) {
@@ -934,12 +945,6 @@ public class InstanceServiceImpl implements InstanceService {
 
     private boolean isAuthorizedByReadAccessOrIsInstanceRestriction(boolean authorized, SecurityMode readOnlySecurityMode, SecurityMode securityMode) {
         return !authorized && !readOnlySecurityMode.isInstanceRestriction() && !securityMode.isInstanceRestriction();
-    }
-
-    private void validateNonEditableProperty(EntityDto entity) {
-        if (entity.isNonEditable()) {
-            throw new EntityInstancesNonEditableException();
-        }
     }
 
     private void validateNonEditableField(FieldRecord fieldRecord, Object instance, Object parsedValue) throws IllegalAccessException {

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
@@ -22,7 +22,7 @@
             </select>
         </span>
         <div class="btn-group">
-            <button ng-click="importEntityInstances()" type="button" class="btn btn-default" ng-show="showImportButton">
+            <button ng-click="importEntityInstances()" type="button" class="btn btn-default" ng-show="showImportButton && !shouldHideButton()">
                 <span class="glyphicon glyphicon-import"></span>
                 {{msg('mds.btn.importCsv')}}
             </button>

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
@@ -372,6 +372,7 @@ public class InstanceServiceTest {
         EntityDto entityWithRelatedField = mock(EntityDto.class);
         when(entityService.getEntity(ENTITY_ID + 1)).thenReturn(entityWithRelatedField);
         when(entityWithRelatedField.getClassName()).thenReturn(AnotherSample.class.getName());
+        when(entityWithRelatedField.getId()).thenReturn(ENTITY_ID + 1);
 
         ServiceReference serviceReferenceForClassWithRelatedField = mock(ServiceReference.class);
         MotechDataService serviceForClassWithRelatedField = mock(MotechDataService.class);
@@ -455,6 +456,7 @@ public class InstanceServiceTest {
     public void shouldThrowExceptionWhileSavingInstanceInNonEditableEntity() {
         EntityDto nonEditableEntity = new EntityDto();
         nonEditableEntity.setNonEditable(true);
+        nonEditableEntity.setId(ENTITY_ID + 1);
         EntityRecord entityRecord = new EntityRecord(null, ENTITY_ID + 1, new ArrayList<FieldRecord>());
 
         when(entityService.getEntity(ENTITY_ID + 1)).thenReturn(nonEditableEntity);

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/ex/entity/EntityInstancesNonEditableException.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/ex/entity/EntityInstancesNonEditableException.java
@@ -1,10 +1,15 @@
 package org.motechproject.mds.ex.entity;
 
+import org.motechproject.mds.ex.MdsException;
+
 /**
  * The <code>EntityInstancesNonEditableException</code> exception signals a situation in which an user
  * try to edit an instance from nonEditable Entity.
  */
-public class EntityInstancesNonEditableException extends RuntimeException {
+public class EntityInstancesNonEditableException extends MdsException {
     private static final long serialVersionUID = -7816428477739342897L;
 
+    public EntityInstancesNonEditableException() {
+        super("mds.error.entityIsReadOnly");
+    }
 }


### PR DESCRIPTION
Now the import button is invisible above the entities grid for readonly entities.
Additionally I disallowed it at the backend.

Conflicts:
	platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java