### PR TITLE
MOTECH-1782  Allow the scheduler to act as a task trigger (0.27.X)

### DIFF
--- a/docs/source/modules/scheduler.rst
+++ b/docs/source/modules/scheduler.rst
@@ -252,8 +252,8 @@ OSGi Services
         //Params below are very basic information about a SMS.
         //Those params means that SMS module will send a SMS with message "Hello!" to number 000000000.
         Map<String, Object> params = new HashMap();
-        params.add("message", "Hello!");
-        params.add("recipient", 000000000);
+        params.put("message", "Hello!");
+        params.put("recipient", 000000000);
 
         return new MotechEvent("send_SMS_now", params);
     }
@@ -261,10 +261,10 @@ OSGi Services
     public void scheduleSendSMSJob() {
 
         //First, we need a MotechEvent.
-        MotechEvent = prepareMessage();
+        MotechEvent motechEvent = prepareMessage();
 
         //We'll also need a cron expression
-        String cronExpression = "0 0 8 1/1 * ? *"
+        String cronExpression = "0 0 8 1/1 * ? *";
 
         //and a start date.
         Calendar calendar = Calendar.getInstance();
@@ -283,7 +283,7 @@ OSGi Services
     //Now same scenario, but we only want to send that SMS once, and we want to do it tomorow.
     public void scheduleSendSMSNowJob() {
 
-        MotechEvent = prepareMessage();
+        MotechEvent motechEvent = prepareMessage();
 
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_YEAR, 1);

--- a/modules/scheduler/scheduler/src/main/resources/webapp/messages/messages.properties
+++ b/modules/scheduler/scheduler/src/main/resources/webapp/messages/messages.properties
@@ -5,6 +5,12 @@ scheduler.scheduleRunOnceJob=Schedule run once job
 scheduler.scheduleDayOfWeekJob=Schedule day of week job
 scheduler.schedulePeriodRepeatingJob=Schedule repeating job with period interval
 scheduler.unscheduleJobs=Unschedule jobs
+scheduler.cronJobTrigger=Cron job trigger
+scheduler.repeatingJobTrigger=Repeating job trigger
+scheduler.runOnceJobTrigger=Run once job trigger
+scheduler.dayOfWeekJobTrigger=Day of week job trigger
+scheduler.repeatingJobWithPeriodIntervalTrigger=Repeating job with period interval trigger
+
 
 scheduler.motechEventSubject=Motech event subject
 scheduler.motechEventParameters=Motech event parameters

--- a/modules/tasks/tasks/pom.xml
+++ b/modules/tasks/tasks/pom.xml
@@ -160,6 +160,7 @@
                             org.springframework.context.config,
                             org.springframework.web.multipart.commons,
                             org.springframework.web.servlet.config,
+                            org.springframework.transaction,
                             *
                         </Import-Package>
                         <Bundle-DocURL>

--- a/modules/tasks/tasks/pom.xml
+++ b/modules/tasks/tasks/pom.xml
@@ -38,6 +38,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>motech-scheduler</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
         </dependency>

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerJobType.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerJobType.java
@@ -1,0 +1,14 @@
+package org.motechproject.tasks.domain;
+
+/**
+ * The <code>SchedulerJobType</code> enumerates possible types of jobs to be scheduled in <code>MotechSchedulerService</code>.
+ *
+ *  @see org.motechproject.scheduler.service.MotechSchedulerService
+ */
+public enum SchedulerJobType {
+    CRON_JOB,
+    REPEATING_JOB,
+    RUN_ONCE_JOB,
+    DAY_OF_WEEK_JOB,
+    REPEATING_JOB_WITH_PERIOD_INTERVAL
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
@@ -67,14 +67,6 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
     @Field
     private Period repeatPeriod;
 
-
-    /**
-     * Constructor
-     */
-    public SchedulerTaskTriggerInformation() {
-        this(null, null, null, null, null, null, null);
-    }
-
     /**
      * Constructor.
      *
@@ -86,12 +78,9 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
      * @param triggerListener  the trigger listener
      */
     public SchedulerTaskTriggerInformation(String displayName, String channelName, String moduleName,
-                                           String moduleVersion, String subject, String triggerListener,
-                                           String startDate) {
+                                           String moduleVersion, String subject, String triggerListener) {
         super(displayName, channelName, moduleName, moduleVersion, subject, triggerListener);
-        this.startDate = startDate;
     }
-
 
     public SchedulerJobType getType() {
         return type;

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
@@ -1,0 +1,139 @@
+package org.motechproject.tasks.domain;
+
+
+import org.motechproject.mds.annotations.Access;
+import org.motechproject.mds.annotations.CrudEvents;
+import org.motechproject.mds.annotations.Entity;
+import org.motechproject.mds.annotations.Field;
+import org.motechproject.mds.event.CrudEventType;
+import org.motechproject.mds.util.SecurityMode;
+import org.motechproject.tasks.constants.TasksRoles;
+
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
+import java.util.List;
+
+
+/**
+ * Extends TaskTriggerInformation representation of a single task trigger by adding scheduleTaskParameters used in
+ * scheduling this trigger. It is a part of the task model.
+ */
+@Entity(recordHistory = true)
+@CrudEvents(CrudEventType.NONE)
+@Access(value = SecurityMode.PERMISSIONS, members = {TasksRoles.MANAGE_TASKS})
+@Inheritance(strategy= InheritanceStrategy.SUPERCLASS_TABLE)
+public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
+
+    private static final long serialVersionUID = 4921423073444417178L;
+
+    public enum schedulerJobType {
+        CRON_JOB,
+        REPEATING_JOB,
+        RUN_ONCE_JOB,
+        DAY_OF_WEEK_JOB,
+        REPEATING_JOB_WITH_PERIOD_INTERVAL
+    }
+
+    @Field
+    private schedulerJobType type;
+
+    @Field
+    private String startDate;
+
+    @Field
+    private String endDate;
+
+    @Field
+    private long interval;
+
+    @Field
+    private String cronExpression;
+
+    @Field
+    private int repeatCount;
+
+    @Field
+    private List<String> days;
+
+
+    /**
+     * Constructor
+     */
+    public SchedulerTaskTriggerInformation() {
+        this(null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param displayName  the trigger display name
+     * @param channelName  the trigger channel name
+     * @param moduleName  the trigger module name
+     * @param moduleVersion  the module version
+     * @param subject  the trigger subject
+     * @param triggerListener  the trigger listener
+     */
+    public SchedulerTaskTriggerInformation(String displayName, String channelName, String moduleName,
+                                           String moduleVersion, String subject, String triggerListener,
+                                           String startDate) {
+        super(displayName, channelName, moduleName, moduleVersion, subject, triggerListener);
+        this.startDate = startDate;
+    }
+
+
+    public schedulerJobType getType() {
+        return type;
+    }
+
+    public void setType(schedulerJobType type) {
+        this.type = type;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    public void setCronExpression(String cronExpression) {
+        this.cronExpression = cronExpression;
+    }
+
+    public int getRepeatCount() {
+        return repeatCount;
+    }
+
+    public void setRepeatCount(int repeatCount) {
+        this.repeatCount = repeatCount;
+    }
+
+    public List<String> getDays() {
+        return days;
+    }
+
+    public void setDays(List<String> days) {
+        this.days = days;
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
@@ -29,7 +29,7 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
 
     private static final long serialVersionUID = 4921423073444417178L;
 
-    public enum schedulerJobType {
+    public enum SchedulerJobType {
         CRON_JOB,
         REPEATING_JOB,
         RUN_ONCE_JOB,
@@ -38,7 +38,7 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
     }
 
     @Field
-    private schedulerJobType type;
+    private SchedulerJobType type;
 
     @Field
     private String startDate;
@@ -93,11 +93,11 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
     }
 
 
-    public schedulerJobType getType() {
+    public SchedulerJobType getType() {
         return type;
     }
 
-    public void setType(schedulerJobType type) {
+    public void setType(SchedulerJobType type) {
         this.type = type;
     }
 

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
@@ -29,14 +29,6 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
 
     private static final long serialVersionUID = 4921423073444417178L;
 
-    public enum SchedulerJobType {
-        CRON_JOB,
-        REPEATING_JOB,
-        RUN_ONCE_JOB,
-        DAY_OF_WEEK_JOB,
-        REPEATING_JOB_WITH_PERIOD_INTERVAL
-    }
-
     @Field
     private SchedulerJobType type;
 

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/SchedulerTaskTriggerInformation.java
@@ -1,6 +1,9 @@
 package org.motechproject.tasks.domain;
 
 
+import org.joda.time.Period;
+import org.motechproject.commons.date.model.DayOfWeek;
+import org.motechproject.commons.date.model.Time;
 import org.motechproject.mds.annotations.Access;
 import org.motechproject.mds.annotations.CrudEvents;
 import org.motechproject.mds.annotations.Entity;
@@ -44,7 +47,7 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
     private String endDate;
 
     @Field
-    private long interval;
+    private int interval;
 
     @Field
     private String cronExpression;
@@ -53,7 +56,16 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
     private int repeatCount;
 
     @Field
-    private List<String> days;
+    private List<DayOfWeek> days;
+
+    @Field
+    private boolean ignoreFiresignorePastFiresAtStart;
+
+    @Field
+    private Time time;
+
+    @Field
+    private Period repeatPeriod;
 
 
     /**
@@ -105,11 +117,11 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
         this.endDate = endDate;
     }
 
-    public long getInterval() {
+    public int getInterval() {
         return interval;
     }
 
-    public void setInterval(long interval) {
+    public void setInterval(int interval) {
         this.interval = interval;
     }
 
@@ -129,11 +141,35 @@ public class SchedulerTaskTriggerInformation extends TaskTriggerInformation {
         this.repeatCount = repeatCount;
     }
 
-    public List<String> getDays() {
+    public List<DayOfWeek> getDays() {
         return days;
     }
 
-    public void setDays(List<String> days) {
+    public void setDays(List<DayOfWeek> days) {
         this.days = days;
+    }
+
+    public boolean isIgnoreFiresignorePastFiresAtStart() {
+        return ignoreFiresignorePastFiresAtStart;
+    }
+
+    public void setIgnoreFiresignorePastFiresAtStart(boolean ignoreFiresignorePastFiresAtStart) {
+        this.ignoreFiresignorePastFiresAtStart = ignoreFiresignorePastFiresAtStart;
+    }
+
+    public Time getTime() {
+        return time;
+    }
+
+    public void setTime(Time time) {
+        this.time = time;
+    }
+
+    public Period getRepeatPeriod() {
+        return repeatPeriod;
+    }
+
+    public void setRepeatPeriod(Period repeatPeriod) {
+        this.repeatPeriod = repeatPeriod;
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskEventInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskEventInformation.java
@@ -1,10 +1,15 @@
 package org.motechproject.tasks.domain;
 
+
 import org.motechproject.mds.annotations.CrudEvents;
 import org.motechproject.mds.annotations.Entity;
 import org.motechproject.mds.annotations.Field;
 import org.motechproject.mds.event.CrudEventType;
 
+import javax.jdo.annotations.Discriminator;
+import javax.jdo.annotations.DiscriminatorStrategy;
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -17,6 +22,8 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
  */
 @Entity
 @CrudEvents(CrudEventType.NONE)
+@Inheritance(strategy= InheritanceStrategy.NEW_TABLE)
+@Discriminator(strategy= DiscriminatorStrategy.CLASS_NAME)
 public abstract class TaskEventInformation implements Serializable {
     private static final long serialVersionUID = -4931626162036319942L;
 

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskTriggerInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskTriggerInformation.java
@@ -11,6 +11,9 @@ import org.motechproject.mds.event.CrudEventType;
 import org.motechproject.mds.util.SecurityMode;
 import org.motechproject.tasks.constants.TasksRoles;
 
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
+
 /**
  * Represents information about a single task trigger. A task trigger is an event that triggers execution of a task. It
  * is a part of the task model.
@@ -18,6 +21,7 @@ import org.motechproject.tasks.constants.TasksRoles;
 @Entity(recordHistory = true)
 @CrudEvents(CrudEventType.NONE)
 @Access(value = SecurityMode.PERMISSIONS, members = {TasksRoles.MANAGE_TASKS})
+@Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
 public class TaskTriggerInformation extends TaskEventInformation {
 
     private static final long serialVersionUID = 2024337448953130758L;
@@ -72,5 +76,11 @@ public class TaskTriggerInformation extends TaskEventInformation {
     @JsonIgnore
     public String getEffectiveListenerSubject() {
         return StringUtils.isEmpty(triggerListenerSubject) ? super.getSubject() : triggerListenerSubject;
+    }
+
+    @Ignore
+    @JsonIgnore
+    public void setEffectiveListenerSubject(String effectiveListenerSubject){
+        this.triggerListenerSubject = effectiveListenerSubject;
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
@@ -10,6 +10,8 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.type.TypeFactory;
 import org.codehaus.jackson.type.JavaType;
 import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.motechproject.commons.date.model.Time;
 import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
@@ -71,6 +73,7 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
 
         if (jsonNode.get("trigger").toString().contains(SCHEDULER_TASK)){
             setProperty("trigger", typeFactory.constructType(SchedulerTaskTriggerInformation.class));
+            parseSchedulerTaskTriggerInformationFields();
         } else {
             setProperty("trigger", typeFactory.constructType(TaskTriggerInformation.class));
         }
@@ -102,4 +105,27 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
             }
         }
     }
+
+    private String removeSpareQuotation(String input) {
+        StringBuilder sb = new StringBuilder(input);
+        sb.deleteCharAt(sb.length() - 1);
+        sb.deleteCharAt(0);
+        return sb.toString();
+    }
+
+    private void parseSchedulerTaskTriggerInformationFields(){
+        if (jsonNode.get("trigger").toString().contains("time")) {
+            ((SchedulerTaskTriggerInformation) task.getTrigger()).setTime(
+                    Time.parseTime(removeSpareQuotation(jsonNode.get("trigger").get("time").toString()), ":"));
+        }
+
+        if (jsonNode.get("trigger").toString().contains("repeatPeriod")) {
+            ((SchedulerTaskTriggerInformation) task.getTrigger()).setRepeatPeriod(
+                    Period.parse(removeSpareQuotation(jsonNode.get("trigger").get("repeatPeriod").toString())));
+        }
+    }
+
+
 }
+
+

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
@@ -10,6 +10,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.type.TypeFactory;
 import org.codehaus.jackson.type.JavaType;
 import org.joda.time.DateTime;
+import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TaskConfig;
@@ -29,10 +30,13 @@ import java.util.Set;
 public class TaskDeserializer extends JsonDeserializer<Task> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskDeserializer.class);
+    private static final String SCHEDULER_TASK = "org.motechproject.tasks.scheduler.";
 
     private ObjectMapper mapper;
     private Task task;
     private JsonNode jsonNode;
+
+
 
     @Override
     public Task deserialize(JsonParser jsonParser,
@@ -64,7 +68,12 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
         setProperty("enabled", stringType);
         setProperty("hasRegisteredChannel", stringType);
         setProperty("taskConfig", typeFactory.constructType(TaskConfig.class));
-        setProperty("trigger", typeFactory.constructType(TaskTriggerInformation.class));
+
+        if (jsonNode.get("trigger").toString().contains(SCHEDULER_TASK)){
+            setProperty("trigger", typeFactory.constructType(SchedulerTaskTriggerInformation.class));
+        } else {
+            setProperty("trigger", typeFactory.constructType(TaskTriggerInformation.class));
+        }
 
         setProperty(
                 "validationErrors",

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/json/TaskDeserializer.java
@@ -4,6 +4,7 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.ObjectCodec;
+import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -50,6 +51,7 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
 
         if (codec instanceof ObjectMapper) {
             mapper = (ObjectMapper) codec;
+            mapper.configure(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         } else {
             mapper = new ObjectMapper();
         }
@@ -71,7 +73,7 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
         setProperty("hasRegisteredChannel", stringType);
         setProperty("taskConfig", typeFactory.constructType(TaskConfig.class));
 
-        if (jsonNode.get("trigger").toString().contains(SCHEDULER_TASK)){
+        if (jsonNode.get("trigger").toString().contains(SCHEDULER_TASK)) {
             setProperty("trigger", typeFactory.constructType(SchedulerTaskTriggerInformation.class));
             parseSchedulerTaskTriggerInformationFields();
         } else {
@@ -98,6 +100,7 @@ public class TaskDeserializer extends JsonDeserializer<Task> {
     private void setProperty(String propertyName, String jsonPropertyName, JavaType javaType) {
         if (jsonNode.has(jsonPropertyName)) {
             try {
+
                 Object value = mapper.readValue(jsonNode.get(jsonPropertyName), javaType);
                 BeanUtils.setProperty(task, propertyName, value);
             } catch (IllegalAccessException | InvocationTargetException | IOException e) {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtil.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtil.java
@@ -1,0 +1,166 @@
+package org.motechproject.tasks.service;
+
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.motechproject.commons.date.model.DayOfWeek;
+import org.motechproject.commons.date.model.Time;
+import org.motechproject.event.MotechEvent;
+import org.motechproject.scheduler.contract.CronSchedulableJob;
+import org.motechproject.scheduler.contract.DayOfWeekSchedulableJob;
+import org.motechproject.scheduler.contract.RepeatingPeriodSchedulableJob;
+import org.motechproject.scheduler.contract.RepeatingSchedulableJob;
+import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
+import org.motechproject.scheduler.service.MotechSchedulerService;
+import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
+import org.motechproject.tasks.domain.Task;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class SchedulerTaskTriggerUtil {
+
+    @Autowired
+    private MotechSchedulerService schedulerService;
+    @Autowired
+    private TaskService taskService;
+
+
+    public void scheduleTriggerJob(String subject) {
+
+        MotechEvent motechEvent = prepareSchedulerEvent(subject);
+
+        Task task = getSingleTaskBySubject(subject);
+
+        DateTime now = new DateTime();
+        DateTimeFormatter formatter = DateTimeFormat.forPattern("yy-MM-dd HH:mm Z");
+        DateTime startDate;
+        DateTime endDate;
+        boolean ignorePastFiresAtStart;
+        int interval;
+        String cronExpression;
+        List<DayOfWeek> days;
+        Time time;
+        Period repeatPeriod;
+
+        SchedulerTaskTriggerInformation trigger = (SchedulerTaskTriggerInformation) task.getTrigger();
+
+        SchedulerTaskTriggerInformation.schedulerJobType triggerType = trigger.getType();
+
+        switch (triggerType) {
+            case RUN_ONCE_JOB:
+                startDate = formatter.parseDateTime(trigger.getStartDate());
+                // todo check if start date is not in the past, or the exception will be thrown, add 'else' scenario
+                if (now.isBefore(startDate)) {
+                    RunOnceSchedulableJob job = new RunOnceSchedulableJob(motechEvent, startDate.toDate());
+                    schedulerService.safeScheduleRunOnceJob(job);
+                }
+                break;
+
+            case REPEATING_JOB:
+                startDate = formatter.parseDateTime(trigger.getStartDate());
+                endDate = formatter.parseDateTime(trigger.getEndDate());
+                interval = trigger.getInterval();
+                ignorePastFiresAtStart = trigger.isIgnoreFiresignorePastFiresAtStart();
+                // todo check if start date is not in the past, or the exception will be thrown, add 'else' scenario
+                if (now.isBefore(startDate)) {
+                    RepeatingSchedulableJob job = new RepeatingSchedulableJob(motechEvent, interval,
+                            startDate.toDate(), endDate.toDate(), ignorePastFiresAtStart);
+                    schedulerService.safeScheduleRepeatingJob(job);
+                }
+                break;
+
+            case CRON_JOB:
+                startDate = formatter.parseDateTime(trigger.getStartDate());
+                endDate = formatter.parseDateTime(trigger.getEndDate());
+                cronExpression = trigger.getCronExpression();
+                ignorePastFiresAtStart = trigger.isIgnoreFiresignorePastFiresAtStart();
+                // todo check if start date is not in the past, or the exception will be thrown, add 'else' scenario
+                if (now.isBefore(startDate)) {
+                    CronSchedulableJob job = new CronSchedulableJob(motechEvent, cronExpression,
+                            startDate.toDate(), endDate.toDate(), ignorePastFiresAtStart);
+                    schedulerService.safeScheduleJob(job);
+                }
+                break;
+
+            case DAY_OF_WEEK_JOB:
+                startDate = formatter.parseDateTime(trigger.getStartDate());
+                endDate = formatter.parseDateTime(trigger.getEndDate());
+                days = trigger.getDays();
+                time = trigger.getTime();
+                ignorePastFiresAtStart = trigger.isIgnoreFiresignorePastFiresAtStart();
+                // todo check if start date is not in the past, or the exception will be thrown, add 'else' scenario
+                if (now.isBefore(startDate)) {
+                    DayOfWeekSchedulableJob job = new DayOfWeekSchedulableJob(motechEvent, startDate.toLocalDate(),
+                            endDate.toLocalDate(), days, time, ignorePastFiresAtStart);
+                    schedulerService.scheduleDayOfWeekJob(job);
+                }
+                break;
+
+            case REPEATING_JOB_WITH_PERIOD_INTERVAL:
+                startDate = formatter.parseDateTime(trigger.getStartDate());
+                endDate = formatter.parseDateTime(trigger.getEndDate());
+                repeatPeriod = trigger.getRepeatPeriod();
+                ignorePastFiresAtStart = trigger.isIgnoreFiresignorePastFiresAtStart();
+                // todo check if start date is not in the past, or the exception will be thrown, add 'else' scenario
+                if (now.isBefore(startDate)) {
+                    RepeatingPeriodSchedulableJob job = new RepeatingPeriodSchedulableJob(motechEvent, startDate.toDate(),
+                            endDate.toDate(), repeatPeriod, ignorePastFiresAtStart);
+                    schedulerService.safeScheduleRepeatingPeriodJob(job);
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    public void setSchedulerTaskTriggerType(Task task) {
+        String[] name = task.getTrigger().getSubject().split("\\.");
+        switch (name[name.length-1]) {
+            case "runOnceJob":
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.RUN_ONCE_JOB);
+                break;
+
+            case "repeatingJob":
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.REPEATING_JOB);
+                break;
+
+            case "cronJob":
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.CRON_JOB);
+                break;
+
+            case "dayOfWeekJob":
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.DAY_OF_WEEK_JOB);
+                break;
+
+            case "repeatingJobWithPeriodInterval":
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
+                break;
+        }
+    }
+
+    public MotechEvent prepareSchedulerEvent(String subject) {
+        Map<String, Object> values = new HashMap<>();
+
+        return new MotechEvent(subject, values);
+    }
+
+    public Task getSingleTaskBySubject(String subject) {
+        List<Task> tasks;
+        String[] name = subject.split("\\.");
+        tasks = taskService.findTasksByName(name[name.length-1]);
+
+        if (tasks.size() == 1) {
+            return tasks.get(0);
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtil.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtil.java
@@ -50,7 +50,7 @@ public class SchedulerTaskTriggerUtil {
 
         SchedulerTaskTriggerInformation trigger = (SchedulerTaskTriggerInformation) task.getTrigger();
 
-        SchedulerTaskTriggerInformation.schedulerJobType triggerType = trigger.getType();
+        SchedulerTaskTriggerInformation.SchedulerJobType triggerType = trigger.getType();
 
         switch (triggerType) {
             case RUN_ONCE_JOB:
@@ -124,23 +124,23 @@ public class SchedulerTaskTriggerUtil {
         String[] name = task.getTrigger().getSubject().split("\\.");
         switch (name[name.length-1]) {
             case "runOnceJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.RUN_ONCE_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
                 break;
 
             case "repeatingJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.REPEATING_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
                 break;
 
             case "cronJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.CRON_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
                 break;
 
             case "dayOfWeekJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.DAY_OF_WEEK_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
                 break;
 
             case "repeatingJobWithPeriodInterval":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.schedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
                 break;
         }
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskService.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskService.java
@@ -17,7 +17,17 @@ import java.util.List;
 public interface TaskService {
 
     /**
-     * Saves the given task in the database.
+     * Saves the given task in the database giving choice whether
+     * register its handler or not.
+     *
+     * @param task  the task to be saved, not null
+     * @param registerHandler   if true the tasks handler will be registered
+     *                          if false it will not
+     */
+    void save(final Task task, boolean registerHandler);
+
+    /**
+     * Saves the given task in the database and registers its handler.
      *
      * @param task  the task to be saved, not null
      */

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskServiceNotifier.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskServiceNotifier.java
@@ -1,0 +1,81 @@
+package org.motechproject.tasks.service;
+
+import org.motechproject.tasks.contract.ActionEventRequest;
+import org.motechproject.tasks.contract.ChannelRequest;
+import org.motechproject.tasks.contract.EventParameterRequest;
+import org.motechproject.tasks.contract.TriggerEventRequest;
+import org.motechproject.tasks.ex.ValidationException;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TaskServiceNotifier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskServiceNotifier.class);
+
+    private BundleContext bundleContext;
+    private ChannelService channelService;
+
+
+    @Autowired
+    public TaskServiceNotifier(BundleContext bundleContext, ChannelService channelService ) {
+        this.bundleContext = bundleContext;
+        this.channelService = channelService;
+    }
+
+    @PostConstruct
+    public void updateTaskInfo() {
+        LOGGER.info("Updating tasks integration");
+
+        try {
+            updateChannel();
+        } catch (ValidationException e) {
+            LOGGER.error("Channel generated was not accepted by tasks due to validation errors", e);
+        }
+    }
+
+    private void updateChannel() {
+
+        LOGGER.info("Registering tasks channel with the channel service");
+
+        List<EventParameterRequest> eventParameters = new ArrayList<>();
+        eventParameters.add(new EventParameterRequest("runDate", "scheduler.runDate", "DATE"));
+
+        List<TriggerEventRequest> triggers = buildTriggers();
+       //triggers.add(new TriggerEventRequest("scheduler.runOnceJobTrigger", "org.motechproject.tasks.scheduler.runOnceJob.", null, eventParameters));
+
+        ChannelRequest channelRequest = new ChannelRequest("scheduler",
+                bundleContext.getBundle().getSymbolicName(),
+                bundleContext.getBundle().getVersion().toString(),
+                null, triggers, new ArrayList<ActionEventRequest>());
+
+        channelService.registerChannel(channelRequest);
+    }
+
+    public List<TriggerEventRequest> buildTriggers() {
+        List<String> triggerNames = new ArrayList<>();
+        triggerNames.add("cronJob");
+        triggerNames.add("repeatingJob");
+        triggerNames.add("runOnceJob");
+        triggerNames.add("dayOfWeekJob");
+        triggerNames.add("repeatingJobWithPeriodInterval");
+
+        List<TriggerEventRequest> triggers = new ArrayList<>();
+        List<EventParameterRequest> parameters = new ArrayList<>();
+
+        for (String name : triggerNames) {
+            String displayName = "scheduler." + name + "Trigger";
+            String eventSubject = "org.motechproject.tasks.scheduler." + name +".";
+
+            triggers.add(new TriggerEventRequest(displayName, eventSubject, null, parameters));
+        }
+
+        return triggers;
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskTriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskTriggerHandler.java
@@ -18,6 +18,7 @@ import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TriggerEvent;
 import org.motechproject.tasks.ex.TaskHandlerException;
 import org.motechproject.tasks.ex.TriggerNotFoundException;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskTriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskTriggerHandler.java
@@ -11,7 +11,6 @@ import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventListenerRegistryService;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.listener.annotations.MotechListenerEventProxy;
-import org.motechproject.scheduler.contract.RunOnceJobId;
 import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.motechproject.server.config.SettingsFacade;
 import org.motechproject.tasks.domain.Task;
@@ -254,20 +253,12 @@ public class TaskTriggerHandler implements TriggerHandler {
         return number;
     }
 
+    public void unscheduleTaskTriggerFor(Task task){
+        schedulerTaskTriggerUtil.unscheduleTaskTrigger(task);
+    }
+
     @Autowired(required = false)
     public void setBundleContext(BundleContext bundleContext) {
         this.executor.setBundleContext(bundleContext);
     }
-
-    public void unscheduleTaskTriggerFor(Task task){
-
-        // Since no jobId is assigned when creating motechEvent "null" is put here. Fix when event jobId will be used.
-        // todo actually we can use task name as a jobID
-        RunOnceJobId jobId = new RunOnceJobId(task.getTrigger().getEffectiveListenerSubject(), "null");
-        schedulerService.unscheduleJob(jobId);
-    }
-
-
-
-
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TriggerHandler.java
@@ -29,7 +29,7 @@ public interface TriggerHandler {
      */
     void handle(MotechEvent event) throws TriggerNotFoundException;
 
-    // todo
-    void unscheduleTaskTriggerFor(Task task);
+    //todo
+    public void unscheduleTaskTriggerFor(Task task);
 
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TriggerHandler.java
@@ -1,6 +1,7 @@
 package org.motechproject.tasks.service;
 
 import org.motechproject.event.MotechEvent;
+import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.ex.TriggerNotFoundException;
 
 /**
@@ -27,5 +28,8 @@ public interface TriggerHandler {
      * @throws TriggerNotFoundException if the trigger for the given event wasn't found
      */
     void handle(MotechEvent event) throws TriggerNotFoundException;
+
+    // todo
+    void unscheduleTaskTriggerFor(Task task);
 
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -20,6 +20,7 @@ import org.motechproject.tasks.domain.DataSource;
 import org.motechproject.tasks.domain.Filter;
 import org.motechproject.tasks.domain.FilterSet;
 import org.motechproject.tasks.domain.Lookup;
+import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TaskConfigStep;
@@ -34,6 +35,7 @@ import org.motechproject.tasks.ex.TriggerNotFoundException;
 import org.motechproject.tasks.ex.ValidationException;
 import org.motechproject.tasks.repository.TasksDataService;
 import org.motechproject.tasks.service.ChannelService;
+import org.motechproject.tasks.service.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.service.TaskDataProviderService;
 import org.motechproject.tasks.service.TaskService;
 import org.motechproject.tasks.service.TriggerHandler;
@@ -79,13 +81,13 @@ import static org.motechproject.tasks.validation.TaskValidator.TASK;
 @Service("taskService")
 public class TaskServiceImpl implements TaskService {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskServiceImpl.class);
-    private static final String SCHEDULER_TASK_TRIGGER_WILDCARD = "org.motechproject.tasks.scheduler(.*)";
 
     private TasksDataService tasksDataService;
     private ChannelService channelService;
     private TaskDataProviderService providerService;
     private EventRelay eventRelay;
     private BundleContext bundleContext;
+    private SchedulerTaskTriggerUtil schedulerTaskTriggerUtil;
 
 
     private static final String[] TASK_TRIGGER_VALIDATION_ERRORS = new String[]{"task.validation.error.triggerNotExist",
@@ -131,8 +133,9 @@ public class TaskServiceImpl implements TaskService {
         }
 
         // todo clean those ifs somehow
-        if (task.getTrigger().getSubject().matches(SCHEDULER_TASK_TRIGGER_WILDCARD)) {
+        if (task.getTrigger() instanceof SchedulerTaskTriggerInformation) {
             task.getTrigger().setEffectiveListenerSubject(task.getTrigger().getSubject() + task.getName());
+            schedulerTaskTriggerUtil.setSchedulerTaskTriggerType(task);
         }
 
         addOrUpdate(task);
@@ -700,6 +703,8 @@ public class TaskServiceImpl implements TaskService {
         }
     }
 
+
+
     @Autowired
     public void setTasksDataService(TasksDataService tasksDataService) {
         this.tasksDataService = tasksDataService;
@@ -723,5 +728,10 @@ public class TaskServiceImpl implements TaskService {
     @Autowired
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
+    }
+
+    @Autowired
+    public void setSchedulerTaskTriggerUtil(SchedulerTaskTriggerUtil schedulerTaskTriggerUtil) {
+        this.schedulerTaskTriggerUtil = schedulerTaskTriggerUtil;
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -35,10 +35,10 @@ import org.motechproject.tasks.ex.TriggerNotFoundException;
 import org.motechproject.tasks.ex.ValidationException;
 import org.motechproject.tasks.repository.TasksDataService;
 import org.motechproject.tasks.service.ChannelService;
-import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.service.TaskDataProviderService;
 import org.motechproject.tasks.service.TaskService;
 import org.motechproject.tasks.service.TriggerHandler;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.validation.TaskValidator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 
 import javax.jdo.Query;
@@ -105,12 +106,13 @@ public class TaskServiceImpl implements TaskService {
         );
     }
 
-
+    @Transactional
     public void save(final Task task){
         save(task, true);
     }
 
     @Override
+    @Transactional
     public void save(final Task task, boolean registerHandler) {
         Set<TaskError> errors = TaskValidator.validate(task);
 
@@ -132,7 +134,6 @@ public class TaskServiceImpl implements TaskService {
             task.setValidationErrors(null);
         }
 
-        // todo clean those ifs somehow
         if (task.getTrigger() instanceof SchedulerTaskTriggerInformation) {
             task.getTrigger().setEffectiveListenerSubject(task.getTrigger().getSubject() + task.getName());
             schedulerTaskTriggerUtil.setSchedulerTaskTriggerType(task);

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -35,7 +35,7 @@ import org.motechproject.tasks.ex.TriggerNotFoundException;
 import org.motechproject.tasks.ex.ValidationException;
 import org.motechproject.tasks.repository.TasksDataService;
 import org.motechproject.tasks.service.ChannelService;
-import org.motechproject.tasks.service.SchedulerTaskTriggerUtil;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.service.TaskDataProviderService;
 import org.motechproject.tasks.service.TaskService;
 import org.motechproject.tasks.service.TriggerHandler;

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -288,7 +288,9 @@ public class TaskServiceImpl implements TaskService {
             throw new TaskNotFoundException(taskId);
         }
 
-        unscheduleTaskTrigger(t);
+        if (t.getTrigger() instanceof SchedulerTaskTriggerInformation) {
+            unscheduleTaskTrigger(t);
+        }
 
         tasksDataService.delete(t);
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/util/SchedulerTaskTriggerUtil.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/util/SchedulerTaskTriggerUtil.java
@@ -1,4 +1,4 @@
-package org.motechproject.tasks.service;
+package org.motechproject.tasks.util;
 
 import org.joda.time.DateTime;
 import org.joda.time.Period;
@@ -20,8 +20,10 @@ import org.motechproject.scheduler.contract.RunOnceJobId;
 import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
 import org.motechproject.scheduler.exception.MotechSchedulerException;
 import org.motechproject.scheduler.service.MotechSchedulerService;
+import org.motechproject.tasks.domain.SchedulerJobType;
 import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
 import org.motechproject.tasks.domain.Task;
+import org.motechproject.tasks.service.TaskService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +66,7 @@ public class SchedulerTaskTriggerUtil {
         Period repeatPeriod;
 
         SchedulerTaskTriggerInformation trigger = (SchedulerTaskTriggerInformation) task.getTrigger();
-        SchedulerTaskTriggerInformation.SchedulerJobType triggerType = trigger.getType();
+        SchedulerJobType triggerType = trigger.getType();
 
         switch (triggerType) {
             case RUN_ONCE_JOB:
@@ -131,23 +133,23 @@ public class SchedulerTaskTriggerUtil {
         String[] name = task.getTrigger().getSubject().split("\\.");
         switch (name[name.length-1]) {
             case "runOnceJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerJobType.RUN_ONCE_JOB);
                 break;
 
             case "repeatingJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerJobType.REPEATING_JOB);
                 break;
 
             case "cronJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerJobType.CRON_JOB);
                 break;
 
             case "dayOfWeekJob":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerJobType.DAY_OF_WEEK_JOB);
                 break;
 
             case "repeatingJobWithPeriodInterval":
-                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
+                ((SchedulerTaskTriggerInformation) task.getTrigger()).setType(SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
                 break;
 
             default:
@@ -155,7 +157,7 @@ public class SchedulerTaskTriggerUtil {
         }
     }
 
-    public MotechEvent prepareSchedulerEvent(String subject) {
+    private MotechEvent prepareSchedulerEvent(String subject) {
         Map<String, Object> values = new HashMap<>();
 
         return new MotechEvent(subject, values);

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/util/SchedulerTriggerRegistration.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/util/SchedulerTriggerRegistration.java
@@ -1,10 +1,11 @@
-package org.motechproject.tasks.service;
+package org.motechproject.tasks.util;
 
 import org.motechproject.tasks.contract.ActionEventRequest;
 import org.motechproject.tasks.contract.ChannelRequest;
 import org.motechproject.tasks.contract.EventParameterRequest;
 import org.motechproject.tasks.contract.TriggerEventRequest;
 import org.motechproject.tasks.ex.ValidationException;
+import org.motechproject.tasks.service.ChannelService;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,16 +16,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class TaskServiceNotifier {
+public class SchedulerTriggerRegistration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TaskServiceNotifier.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerTriggerRegistration.class);
 
     private BundleContext bundleContext;
     private ChannelService channelService;
 
 
     @Autowired
-    public TaskServiceNotifier(BundleContext bundleContext, ChannelService channelService ) {
+    public SchedulerTriggerRegistration(BundleContext bundleContext, ChannelService channelService) {
         this.bundleContext = bundleContext;
         this.channelService = channelService;
     }

--- a/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
+++ b/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
@@ -58,6 +58,9 @@
     <osgi:reference id="tasksDataServiceOSGi"
                     interface="org.motechproject.tasks.repository.TasksDataService"/>
 
+    <osgi:reference id="motechSchedulerService"
+                    interface="org.motechproject.scheduler.service.MotechSchedulerService"/>
+
 
     <osgi:service id="channelServiceOsgi" auto-export="interfaces" ref="channelService"
                   interface="org.motechproject.tasks.service.ChannelService">

--- a/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
+++ b/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
@@ -2,17 +2,21 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:osgi="http://www.eclipse.org/gemini/blueprint/schema/blueprint"
+       xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:security="http://www.springframework.org/schema/security"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
        http://www.eclipse.org/gemini/blueprint/schema/blueprint http://www.eclipse.org/gemini/blueprint/schema/blueprint/gemini-blueprint.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
-       http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+       http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd">
 
     <import resource="classpath*:META-INF/motech/applicationTasks.xml"/>
 
     <context:annotation-config/>
     <security:global-method-security pre-post-annotations="enabled"/>
+
+    <tx:annotation-driven transaction-manager="transactionManager"/>
 
     <bean id="moduleRegistrationData" class="org.motechproject.osgi.web.ModuleRegistrationData">
         <constructor-arg name="url" value="../tasks/index.html"/>
@@ -60,6 +64,10 @@
 
     <osgi:reference id="motechSchedulerService"
                     interface="org.motechproject.scheduler.service.MotechSchedulerService"/>
+
+    <osgi:reference id="transactionManager"
+                    interface="org.springframework.transaction.PlatformTransactionManager"
+                    context-class-loader="unmanaged"/>
 
 
     <osgi:service id="channelServiceOsgi" auto-export="interfaces" ref="channelService"

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -794,6 +794,30 @@
         };
     });
 
+
+    directives.directive('datetimePickerTriggerInput', function () {
+        return {
+            restrict: 'A',
+            link: function (scope, element, attrs) {
+                var parent = scope;
+
+                element.datetimepicker({
+                    showTimezone: true,
+                    useLocalTimezone: true,
+                    dateFormat: 'yy-mm-dd',
+                    timeFormat: 'HH:mm z',
+                    showOn: true,
+                    constrainInput: false,
+                    onSelect: function (dateTex) {
+                        //parent.selectedTrigger.eventParameters[$(this).data('index')].value = dateTex;
+                        parent.task.trigger.startDate = dateTex;
+                        parent.$apply();
+                    }
+                });
+            }
+        };
+    });
+
     directives.directive('datetimePickerInput', function () {
         return {
             restrict: 'A',

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -795,7 +795,7 @@
     });
 
 
-    directives.directive('datetimePickerTriggerInput', function () {
+    directives.directive('datetimePickerStartDateInput', function () {
         return {
             restrict: 'A',
             link: function (scope, element, attrs) {
@@ -817,6 +817,29 @@
             }
         };
     });
+
+    directives.directive('datetimePickerEndDateInput', function () {
+            return {
+                restrict: 'A',
+                link: function (scope, element, attrs) {
+                    var parent = scope;
+
+                    element.datetimepicker({
+                        showTimezone: true,
+                        useLocalTimezone: true,
+                        dateFormat: 'yy-mm-dd',
+                        timeFormat: 'HH:mm z',
+                        showOn: true,
+                        constrainInput: false,
+                        onSelect: function (dateTex) {
+                            //parent.selectedTrigger.eventParameters[$(this).data('index')].value = dateTex;
+                            parent.task.trigger.endDate = dateTex;
+                            parent.$apply();
+                        }
+                    });
+                }
+            };
+        });
 
     directives.directive('datetimePickerInput', function () {
         return {

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -809,7 +809,6 @@
                     showOn: true,
                     constrainInput: false,
                     onSelect: function (dateTex) {
-                        //parent.selectedTrigger.eventParameters[$(this).data('index')].value = dateTex;
                         parent.task.trigger.startDate = dateTex;
                         parent.$apply();
                     }
@@ -832,7 +831,6 @@
                         showOn: true,
                         constrainInput: false,
                         onSelect: function (dateTex) {
-                            //parent.selectedTrigger.eventParameters[$(this).data('index')].value = dateTex;
                             parent.task.trigger.endDate = dateTex;
                             parent.$apply();
                         }

--- a/modules/tasks/tasks/src/main/resources/webapp/js/util.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/util.js
@@ -105,7 +105,6 @@
             },
             trigger: {
                 select: function (scope, channel, trigger) {
-                angular.element("#simpleTriggerInput").collapse({'toggle' : false});
                     if (!scope.task) {
                         scope.task = {};
                     }
@@ -123,13 +122,10 @@
 
                     angular.element("#trigger-" + channel.moduleName).parent('li').addClass('selectedTrigger').addClass('active');
 
-                    if (channel.displayName === "scheduler"){
-                            angular.element("#simpleTriggerInput").collapse('show');
-                    } else {
-                        if (angular.element("#collapse-trigger").collapse) {
-                            angular.element("#collapse-trigger").collapse('hide');
-                            }
+                    if ((angular.element("#collapse-trigger").collapse) && (channel.displayName !== "scheduler")) {
+                        angular.element("#collapse-trigger").collapse('hide');
                     }
+
 
                     scope.selectedTrigger = trigger;
 

--- a/modules/tasks/tasks/src/main/resources/webapp/js/util.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/util.js
@@ -105,6 +105,7 @@
             },
             trigger: {
                 select: function (scope, channel, trigger) {
+                angular.element("#simpleTriggerInput").collapse({'toggle' : false});
                     if (!scope.task) {
                         scope.task = {};
                     }
@@ -120,8 +121,12 @@
 
                     angular.element("#trigger-" + channel.moduleName).parent('li').addClass('selectedTrigger').addClass('active');
 
-                    if (angular.element("#collapse-trigger").collapse) {
-                        angular.element("#collapse-trigger").collapse('hide');
+                    if (channel.displayName === "scheduler"){
+                            angular.element("#simpleTriggerInput").collapse('show');
+                    } else {
+                        if (angular.element("#collapse-trigger").collapse) {
+                            angular.element("#collapse-trigger").collapse('hide');
+                            }
                     }
 
                     scope.selectedTrigger = trigger;

--- a/modules/tasks/tasks/src/main/resources/webapp/js/util.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/util.js
@@ -110,14 +110,16 @@
                         scope.task = {};
                     }
 
-                    scope.task.trigger = {
-                        displayName: trigger.displayName,
-                        channelName: channel.displayName,
-                        moduleName: channel.moduleName,
-                        moduleVersion: channel.moduleVersion,
-                        subject: trigger.subject,
-                        triggerListenerSubject: trigger.triggerListenerSubject
-                    };
+                    if (!scope.task.trigger) {
+                        scope.task.trigger = {
+                            displayName: trigger.displayName,
+                            channelName: channel.displayName,
+                            moduleName: channel.moduleName,
+                            moduleVersion: channel.moduleVersion,
+                            subject: trigger.subject,
+                            triggerListenerSubject: trigger.triggerListenerSubject
+                        };
+                    }
 
                     angular.element("#trigger-" + channel.moduleName).parent('li').addClass('selectedTrigger').addClass('active');
 

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
@@ -162,6 +162,7 @@ task.notification.addObject=Added new {0} object
 
 task.placeholder.numberOnly=Enter only numbers or drag trigger fields
 task.placeholder.dateOnly=Select date or drag trigger field
+task.placeholder.dateOnlyNoTrigger=Select date
 task.placeholder.timeOnly=Select time or drag trigger field
 task.placeholder.booleanOnly=Drag trigger field
 task.placeholder.searchTrigger=Search Trigger
@@ -348,3 +349,5 @@ task.lessDaysFromNow=Less days from now than
 task.moreDaysFromNow=More days from now than
 task.lessMonthsFromNow=Less months from now than
 task.moreMonthsFromNow=More months from now than
+
+task.trigger.scheduler.fireDate=Fire date

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
@@ -168,7 +168,11 @@ task.placeholder.booleanOnly=Drag trigger field
 task.placeholder.searchTrigger=Search Trigger
 task.placeholder.searchData=Search Data
 task.placeholder.searchAction=Search Actions
-task.placeholder.searchOptions = Search Options
+task.placeholder.searchOptions=Search Options
+task.placeholder.intervalTime=Enter interval time (in seconds)
+task.placeholder.cronExpression=Enter cron expression
+task.placeholder.dayOfWeek=Enter days of week
+task.placeholder.period=Enter time period
 
 task.warning=Warning
 task.exist=Exist
@@ -351,3 +355,13 @@ task.lessMonthsFromNow=Less months from now than
 task.moreMonthsFromNow=More months from now than
 
 task.trigger.scheduler.fireDate=Fire date
+task.trigger.scheduler.startDate=Start date
+task.trigger.scheduler.endDate=End date
+task.trigger.scheduler.interval=Interval
+task.trigger.scheduler.ignorePastFires=Ignore past fires as start
+task.trigger.scheduler.period=Period
+task.trigger.scheduler.cronExpression=Cron expression
+task.trigger.scheduler.dayOfWeek=Day of week
+task.trigger.scheduler.time=Time
+
+

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
@@ -6,7 +6,7 @@ task.active=Active
 task.paused=Paused
 task.channel.deregistered=Channel not registered
 
-task.confirm.remove=Remove task ?
+task.confirm.remove=Remove task?
 task.confirm.trigger=Changing trigger could invalidate form. Continue?
 task.confirm.action=Current action will be lost. Continue?
 task.confirm.filterSet=Current filter set will be lost. Continue?

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages_es.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages_es.properties
@@ -6,7 +6,7 @@
 # task.paused=Paused
 # task.channel.deregistered=Channel not registered
 
-# task.confirm.remove=Remove task ?
+# task.confirm.remove=Remove task?
 # task.confirm.trigger=Changing trigger could invalidate form. Continue?
 # task.confirm.action=Current action will be lost. Continue?
 # task.confirm.filterSet=Current filter set will be lost. Continue?

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -78,11 +78,55 @@
                                     <div class="clearfix"></div>
                                 </div>
                                 <div>
-                                    <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.runOnceJob.'" class="col-md-10 col-sm-9">
-                                        <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.fireDate')}}</label>
+                                    <div ng-if="(task.trigger.subject != undefined)" class="col-md-10 col-sm-9">
+                                        <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.startDate')}}</label>
                                         <div class="input-group">
-                                            <input id="startDate" ng-model="task.trigger.startDate" type="text" class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
+                                            <input id="startDate" ng-model="task.trigger.startDate" type="text" class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-start-date-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
                                             <div class="input-group-btn" datetime-picker><button class="btn btn-default">{{msg('task.button.selectDate')}}</button></div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject != 'org.motechproject.tasks.scheduler.runOnceJob.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.endDate')}}</label>
+                                            <div class="input-group">
+                                                <input id="endDate" ng-model="task.trigger.endDate" type="text" class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-end-date-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
+                                                <div class="input-group-btn" datetime-picker><button class="btn btn-default">{{msg('task.button.selectDate')}}</button></div>
+                                            </div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.repeatingJob.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.interval')}}</label>
+                                            <div class="input-group">
+                                                <input id="interval" ng-model="task.trigger.interval" class="actionField form-control" type="text" data-index="{{$index}}" data-type="INTEGER" placeholder="{{msg('task.placeholder.intervalTime')}}" style="background:white;"/>
+                                            </div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.repeatingJobWithPeriodInterval.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.period')}}</label>
+                                            <div class="input-group">
+                                                <input type="text" class="actionField form-control" ng-model="task.trigger.repeatPeriod" data-index="{{$index}}" data-type="PERIOD" placeholder="{{msg('task.placeholder.period')}}" style="background:white;"/>
+                                            </div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.cronJob.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.cronExpression')}}</label>
+                                            <div class="input-group">
+                                                <input id="cronExpression" ng-model="task.trigger.cronExpression" class="actionField form-control" type="text" data-index="{{$index}}" data-type="TEXT" placeholder="{{msg('task.placeholder.cronExpression')}}" style="background:white;"/>
+                                            </div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.dayOfWeekJob.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.dayOfWeek')}}</label>
+                                            <div class="input-group">
+                                                <input id="dayOfWeek" ng-model="task.trigger.days" class="actionField form-control" type="text" data-index="{{$index}}" data-type="LIST" placeholder="{{msg('task.placeholder.dayOfWeek')}}" style="background:white;"/>
+                                            </div>
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.time')}}</label>
+                                            <div class="input-group">
+                                                <input id="time" ng-model="task.trigger.time" class="actionField form-control" type="text" data-index="{{$index}}" data-type="TIME" placeholder="{{msg('task.placeholder.timeOnly')}}" style="background:white;"/>
+                                            </div>
+                                        </div>
+                                        <div ng-if="task.trigger.subject != 'org.motechproject.tasks.scheduler.runOnceJob.'">
+                                            <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.ignorePastFires')}}</label>
+                                            <label class="radio-inline">
+                                                <input type="radio"  data-ng-model="task.trigger.ignoreFiresignorePastFiresAtStart" data-ng-value="true"/> {{msg('yes')}}
+                                            </label>
+                                            <label class="radio-inline">
+                                                <input type="radio"  data-ng-model="task.trigger.ignoreFiresignorePastFiresAtStart" data-ng-value="false"/> {{msg('no')}}
+                                            </label>
                                         </div>
                                     </div>
                                 </div>

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -77,9 +77,18 @@
                                     </ul>
                                     <div class="clearfix"></div>
                                 </div>
+
+                                <div  >
+                                    <div ui-if="BrowserDetect.browser!='Chrome' && BrowserDetect.browser!='Explorer'" class="col-md-10 col-sm-9">
+                                        <label class="col-md-2 col-sm-3 control-label"> start date </label>
+                                        <div  class="input-group">
+                                            <input  id="startDate" type="text"  droppable class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnly')}}" style="background:white;"/>
+                                            <div class="input-group-btn" datetime-picker><button class="btn btn-default">{{msg('task.button.selectDate')}}</button></div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-
                 </div>
 
                 <div ng-hide="!task.trigger.subject">

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -112,7 +112,7 @@
                                         <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.dayOfWeekJob.'">
                                             <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.dayOfWeek')}}</label>
                                             <div class="input-group">
-                                                <input id="dayOfWeek" ng-model="task.trigger.days" class="actionField form-control" type="text" data-index="{{$index}}" data-type="LIST" placeholder="{{msg('task.placeholder.dayOfWeek')}}" style="background:white;"/>
+                                                <input type="text" id="dayOfWeek" ng-model="task.trigger.days" droppable class="actionField form-control" data-index="{{$index}}" data-type="TEXT" placeholder="{{msg('task.placeholder.dayOfWeek')}}" style="background:white;"/>
                                             </div>
                                             <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.time')}}</label>
                                             <div class="input-group">

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -81,7 +81,7 @@
                                     <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.runOnceJob.'" class="col-md-10 col-sm-9">
                                         <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.fireDate')}}</label>
                                         <div class="input-group">
-                                            <input id="startDate" type="text" droppable class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
+                                            <input id="startDate" ng-model="task.trigger.startDate" type="text" class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
                                             <div class="input-group-btn" datetime-picker><button class="btn btn-default">{{msg('task.button.selectDate')}}</button></div>
                                         </div>
                                     </div>

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -77,12 +77,11 @@
                                     </ul>
                                     <div class="clearfix"></div>
                                 </div>
-
-                                <div  >
-                                    <div ui-if="BrowserDetect.browser!='Chrome' && BrowserDetect.browser!='Explorer'" class="col-md-10 col-sm-9">
-                                        <label class="col-md-2 col-sm-3 control-label"> start date </label>
-                                        <div  class="input-group">
-                                            <input  id="startDate" type="text"  droppable class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnly')}}" style="background:white;"/>
+                                <div>
+                                    <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.runOnceJob.'" class="col-md-10 col-sm-9">
+                                        <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.fireDate')}}</label>
+                                        <div class="input-group">
+                                            <input id="startDate" type="text" droppable class="actionField form-control" data-index="{{$index}}" data-type="DATE" datetime-picker-trigger-input placeholder="{{msg('task.placeholder.dateOnlyNoTrigger')}}" style="background:white;"/>
                                             <div class="input-group-btn" datetime-picker><button class="btn btn-default">{{msg('task.button.selectDate')}}</button></div>
                                         </div>
                                     </div>

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -100,7 +100,7 @@
                                         <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.repeatingJobWithPeriodInterval.'">
                                             <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.period')}}</label>
                                             <div class="input-group">
-                                                <input type="text" class="actionField form-control" ng-model="task.trigger.repeatPeriod" data-index="{{$index}}" data-type="PERIOD" placeholder="{{msg('task.placeholder.period')}}" style="background:white;"/>
+                                                <input type="text" class="actionField form-control" ng-model="task.trigger.repeatPeriod" data-index="{{$index}}" data-type="TEXT" placeholder="{{msg('task.placeholder.period')}}" style="background:white;"/>
                                             </div>
                                         </div>
                                         <div ng-if="task.trigger.subject === 'org.motechproject.tasks.scheduler.cronJob.'">
@@ -116,7 +116,7 @@
                                             </div>
                                             <label class="col-md-2 col-sm-3 control-label">{{msg('task.trigger.scheduler.time')}}</label>
                                             <div class="input-group">
-                                                <input id="time" ng-model="task.trigger.time" class="actionField form-control" type="text" data-index="{{$index}}" data-type="TIME" placeholder="{{msg('task.placeholder.timeOnly')}}" style="background:white;"/>
+                                                <input id="time" ng-model="task.trigger.time" class="actionField form-control" type="text" data-index="{{$index}}" data-type="TEXT" placeholder="{{msg('task.placeholder.timeOnly')}}" style="background:white;"/>
                                             </div>
                                         </div>
                                         <div ng-if="task.trigger.subject != 'org.motechproject.tasks.scheduler.runOnceJob.'">

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtilTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtilTest.java
@@ -1,0 +1,308 @@
+package org.motechproject.tasks.service;
+
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.motechproject.commons.date.model.DayOfWeek;
+import org.motechproject.commons.date.model.Time;
+import org.motechproject.scheduler.contract.CronJobId;
+import org.motechproject.scheduler.contract.CronSchedulableJob;
+import org.motechproject.scheduler.contract.DayOfWeekSchedulableJob;
+import org.motechproject.scheduler.contract.JobId;
+import org.motechproject.scheduler.contract.RepeatingJobId;
+import org.motechproject.scheduler.contract.RepeatingPeriodSchedulableJob;
+import org.motechproject.scheduler.contract.RepeatingSchedulableJob;
+import org.motechproject.scheduler.contract.RunOnceJobId;
+import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
+import org.motechproject.scheduler.exception.MotechSchedulerException;
+import org.motechproject.scheduler.service.MotechSchedulerService;
+import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
+import org.motechproject.tasks.domain.Task;
+import org.motechproject.testing.utils.TimeFaker;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SchedulerTaskTriggerUtilTest {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormat.forPattern("yy-MM-dd HH:mm Z");
+
+    private static final String MODULE_NAME = "org.motechproject.motech-tasks";
+    private static final String VERSION = "0.27.0.SNAPSHOT";
+    private static final String CHANNEL = "scheduler";
+    private static final String BASE_SUBJECT = "org.motechproject.tasks.scheduler.";
+
+    @Mock
+    private TaskService taskService;
+
+    @Mock
+    private MotechSchedulerService schedulerService;
+
+    @Mock
+    private Task task;
+
+    @InjectMocks
+    private SchedulerTaskTriggerUtil schedulerTaskTriggerUtil = new SchedulerTaskTriggerUtil();
+
+    private String taskName;
+    private SchedulerTaskTriggerInformation triggerInformation;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        TimeFaker.fakeNow(new DateTime(2015, 9, 15, 8, 0, 0));
+    }
+
+    @After
+    public void tearDown() {
+        TimeFaker.stopFakingTime();
+    }
+
+    @Test
+    public void shouldScheduleJobForRunOnceTrigger() {
+        taskName = "Run Once Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.runOnceJobTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+        triggerInformation.setStartDate("2015-09-25 08:00 +0200");
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.scheduleTriggerJob("org.motechproject.tasks.scheduler.runOnceJob." + taskName);
+
+        ArgumentCaptor<RunOnceSchedulableJob> captor = ArgumentCaptor.forClass(RunOnceSchedulableJob.class);
+        verify(schedulerService).safeScheduleRunOnceJob(captor.capture());
+
+        RunOnceSchedulableJob actual = captor.getValue();
+
+        assertEquals(BASE_SUBJECT + "runOnceJob." + taskName, actual.getMotechEvent().getSubject());
+        assertEquals(actual.getStartDate(), DATE_FORMAT.parseDateTime(triggerInformation.getStartDate()).toDate());
+    }
+
+    @Test(expected = MotechSchedulerException.class)
+    public void shouldRejectPastDateForRunOnceJobScheduling() {
+        taskName = "Run Once Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.runOnceJobTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+        triggerInformation.setStartDate("2015-09-10 08:00 +0200");
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        try {
+            schedulerTaskTriggerUtil.scheduleTriggerJob("org.motechproject.tasks.scheduler.runOnceJob." + taskName);
+        } finally {
+            verify(schedulerService, never()).safeScheduleRunOnceJob(any(RunOnceSchedulableJob.class));
+        }
+    }
+
+    @Test
+    public void shouldScheduleJobForRepeatingTrigger() {
+        taskName = "Repeating Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.repeatingJobTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
+        triggerInformation.setStartDate("2015-09-25 08:00 +0200");
+        triggerInformation.setEndDate("2015-09-28 08:00 +0200");
+        triggerInformation.setInterval(100);
+        triggerInformation.setIgnoreFiresignorePastFiresAtStart(false);
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.scheduleTriggerJob(BASE_SUBJECT + "repeatingJob." + taskName);
+
+        ArgumentCaptor<RepeatingSchedulableJob> captor = ArgumentCaptor.forClass(RepeatingSchedulableJob.class);
+        verify(schedulerService).safeScheduleRepeatingJob(captor.capture());
+
+        RepeatingSchedulableJob actual = captor.getValue();
+
+        assertEquals(BASE_SUBJECT + "repeatingJob." + taskName, actual.getMotechEvent().getSubject());
+        assertEquals(actual.getStartTime(), DATE_FORMAT.parseDateTime(triggerInformation.getStartDate()).toDate());
+        assertEquals(actual.getEndTime(), DATE_FORMAT.parseDateTime(triggerInformation.getEndDate()).toDate());
+        assertEquals((long) actual.getRepeatIntervalInSeconds(), 100L);
+        assertEquals(actual.isIgnorePastFiresAtStart(), false);
+    }
+
+    @Test
+    public void shouldScheduleJobForCronTrigger() {
+        taskName = "Cron Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.cronJobTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "cronJob.", BASE_SUBJECT + "cronJob." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
+        triggerInformation.setStartDate("2015-09-25 08:00 +0200");
+        triggerInformation.setEndDate("2015-09-28 08:00 +0200");
+        triggerInformation.setCronExpression("0 15 10 * * ?");
+        triggerInformation.setIgnoreFiresignorePastFiresAtStart(false);
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.scheduleTriggerJob(BASE_SUBJECT + "cronJob." + taskName);
+
+        ArgumentCaptor<CronSchedulableJob> captor = ArgumentCaptor.forClass(CronSchedulableJob.class);
+        verify(schedulerService).safeScheduleJob(captor.capture());
+
+        CronSchedulableJob actual = captor.getValue();
+
+        assertEquals(BASE_SUBJECT + "cronJob." + taskName, actual.getMotechEvent().getSubject());
+        assertEquals(actual.getStartTime(), DATE_FORMAT.parseDateTime(triggerInformation.getStartDate()).toDate());
+        assertEquals(actual.getEndTime(), DATE_FORMAT.parseDateTime(triggerInformation.getEndDate()).toDate());
+        assertEquals(actual.getCronExpression(), "0 15 10 * * ?");
+        assertEquals(actual.isIgnorePastFiresAtStart(), false);
+    }
+
+    @Test
+    public void shouldScheduleDayOfWeekTrigger() {
+        taskName = "Day of week Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.dayOfWeekTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "dayOfWeekJob.", BASE_SUBJECT + "dayOfWeekJob." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
+        triggerInformation.setStartDate("2015-09-25 08:00 +0200");
+        triggerInformation.setEndDate("2015-09-28 08:00 +0200");
+        triggerInformation.setDays(Arrays.asList(DayOfWeek.Monday, DayOfWeek.Friday));
+        triggerInformation.setTime(new Time(11, 30));
+        triggerInformation.setIgnoreFiresignorePastFiresAtStart(false);
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.scheduleTriggerJob(BASE_SUBJECT + "dayOfWeekJob." + taskName);
+
+        ArgumentCaptor<DayOfWeekSchedulableJob> captor = ArgumentCaptor.forClass(DayOfWeekSchedulableJob.class);
+        verify(schedulerService).scheduleDayOfWeekJob(captor.capture());
+
+        DayOfWeekSchedulableJob actual = captor.getValue();
+
+        assertEquals(BASE_SUBJECT + "dayOfWeekJob." + taskName, actual.getMotechEvent().getSubject());
+        assertEquals(actual.getStartDate(), DATE_FORMAT.parseDateTime(triggerInformation.getStartDate()).toLocalDate());
+        assertEquals(actual.getEndDate(), DATE_FORMAT.parseDateTime(triggerInformation.getEndDate()).toLocalDate());
+        assertEquals(2, actual.getCronDays().size());
+        // Monday is represented as 2 and Friday as 6
+        assertTrue(actual.getCronDays().contains(2));
+        assertTrue(actual.getCronDays().contains(6));
+        assertEquals(actual.getTime(), new Time(11, 30));
+        assertEquals(actual.isIgnorePastFiresAtStart(), false);
+    }
+
+    @Test
+    public void shouldScheduleRepeatingWithPeriodTrigger() {
+        taskName = "Repeating with period Task Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.repeatingWithPeriodTrigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "repeatingJobWithPeriod.", BASE_SUBJECT + "repeatingJobWithPeriod." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
+        triggerInformation.setStartDate("2015-09-25 08:00 +0200");
+        triggerInformation.setEndDate("2015-09-28 08:00 +0200");
+        triggerInformation.setRepeatPeriod(new Period(11, 30, 0, 0));
+        triggerInformation.setIgnoreFiresignorePastFiresAtStart(false);
+
+        when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.scheduleTriggerJob(BASE_SUBJECT + "repeatingJobWithPeriod." + taskName);
+
+        ArgumentCaptor<RepeatingPeriodSchedulableJob> captor = ArgumentCaptor.forClass(RepeatingPeriodSchedulableJob.class);
+        verify(schedulerService).safeScheduleRepeatingPeriodJob(captor.capture());
+
+        RepeatingPeriodSchedulableJob actual = captor.getValue();
+
+        assertEquals(BASE_SUBJECT + "repeatingJobWithPeriod." + taskName, actual.getMotechEvent().getSubject());
+        assertEquals(actual.getStartTime(), DATE_FORMAT.parseDateTime(triggerInformation.getStartDate()).toDate());
+        assertEquals(actual.getEndTime(), DATE_FORMAT.parseDateTime(triggerInformation.getEndDate()).toDate());
+        assertEquals(actual.getRepeatPeriod(), new Period(11, 30, 0, 0));
+        assertEquals(actual.isIgnorePastFiresAtStart(), false);
+    }
+
+    @Test
+    public void shouldProperlyUnscheduleRunOnceJob() {
+        taskName = "Unschedule Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.unscheduleTaskTrigger(task);
+
+        ArgumentCaptor<JobId> captor = ArgumentCaptor.forClass(JobId.class);
+        verify(schedulerService).unscheduleJob(captor.capture());
+
+        JobId actual = captor.getValue();
+        assertTrue(actual instanceof RunOnceJobId);
+        assertEquals(actual.value(), BASE_SUBJECT + "trigger." + taskName + "-null-runonce");
+    }
+
+    @Test
+    public void shouldProperlyUnscheduleRepeatingJob() {
+        taskName = "Unschedule Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
+
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.unscheduleTaskTrigger(task);
+
+        ArgumentCaptor<JobId> captor = ArgumentCaptor.forClass(JobId.class);
+        verify(schedulerService).unscheduleJob(captor.capture());
+
+        JobId actual = captor.getValue();
+        assertTrue(actual instanceof RepeatingJobId);
+        assertEquals(actual.value(), BASE_SUBJECT + "trigger." + taskName + "-null-repeat");
+    }
+
+    @Test
+    public void shouldProperlyUnscheduleCronJob() {
+        taskName = "Unschedule Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
+
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.unscheduleTaskTrigger(task);
+
+        ArgumentCaptor<JobId> captor = ArgumentCaptor.forClass(JobId.class);
+        verify(schedulerService).unscheduleJob(captor.capture());
+
+        JobId actual = captor.getValue();
+        assertTrue(actual instanceof CronJobId);
+        assertEquals(actual.value(), BASE_SUBJECT + "trigger." + taskName + "-null");
+    }
+
+    @Test
+    public void shouldProperlyUnscheduleDayOfWeekJob() {
+        taskName = "Unschedule Test";
+        triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
+                VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
+        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
+
+        when(task.getTrigger()).thenReturn(triggerInformation);
+
+        schedulerTaskTriggerUtil.unscheduleTaskTrigger(task);
+
+        ArgumentCaptor<JobId> captor = ArgumentCaptor.forClass(JobId.class);
+        verify(schedulerService).unscheduleJob(captor.capture());
+
+        JobId actual = captor.getValue();
+        // Day of Week job is respresented as Cron job and therefore uses Cron Job ID
+        assertTrue(actual instanceof CronJobId);
+        assertEquals(actual.value(), BASE_SUBJECT + "trigger." + taskName + "-null");
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtilTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/SchedulerTaskTriggerUtilTest.java
@@ -23,8 +23,10 @@ import org.motechproject.scheduler.contract.RunOnceJobId;
 import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
 import org.motechproject.scheduler.exception.MotechSchedulerException;
 import org.motechproject.scheduler.service.MotechSchedulerService;
+import org.motechproject.tasks.domain.SchedulerJobType;
 import org.motechproject.tasks.domain.SchedulerTaskTriggerInformation;
 import org.motechproject.tasks.domain.Task;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.motechproject.testing.utils.TimeFaker;
 
 import java.util.Arrays;
@@ -77,7 +79,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Run Once Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.runOnceJobTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+        triggerInformation.setType(SchedulerJobType.RUN_ONCE_JOB);
         triggerInformation.setStartDate("2015-09-25 08:00 +0200");
 
         when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
@@ -99,7 +101,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Run Once Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.runOnceJobTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+        triggerInformation.setType(SchedulerJobType.RUN_ONCE_JOB);
         triggerInformation.setStartDate("2015-09-10 08:00 +0200");
 
         when(taskService.findTasksByName(taskName)).thenReturn(Arrays.asList(task));
@@ -117,7 +119,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Repeating Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.repeatingJobTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "runOnceJob.", BASE_SUBJECT + "runOnceJob." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
+        triggerInformation.setType(SchedulerJobType.REPEATING_JOB);
         triggerInformation.setStartDate("2015-09-25 08:00 +0200");
         triggerInformation.setEndDate("2015-09-28 08:00 +0200");
         triggerInformation.setInterval(100);
@@ -145,7 +147,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Cron Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.cronJobTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "cronJob.", BASE_SUBJECT + "cronJob." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
+        triggerInformation.setType(SchedulerJobType.CRON_JOB);
         triggerInformation.setStartDate("2015-09-25 08:00 +0200");
         triggerInformation.setEndDate("2015-09-28 08:00 +0200");
         triggerInformation.setCronExpression("0 15 10 * * ?");
@@ -173,7 +175,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Day of week Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.dayOfWeekTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "dayOfWeekJob.", BASE_SUBJECT + "dayOfWeekJob." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
+        triggerInformation.setType(SchedulerJobType.DAY_OF_WEEK_JOB);
         triggerInformation.setStartDate("2015-09-25 08:00 +0200");
         triggerInformation.setEndDate("2015-09-28 08:00 +0200");
         triggerInformation.setDays(Arrays.asList(DayOfWeek.Monday, DayOfWeek.Friday));
@@ -206,7 +208,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Repeating with period Task Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.repeatingWithPeriodTrigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "repeatingJobWithPeriod.", BASE_SUBJECT + "repeatingJobWithPeriod." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
+        triggerInformation.setType(SchedulerJobType.REPEATING_JOB_WITH_PERIOD_INTERVAL);
         triggerInformation.setStartDate("2015-09-25 08:00 +0200");
         triggerInformation.setEndDate("2015-09-28 08:00 +0200");
         triggerInformation.setRepeatPeriod(new Period(11, 30, 0, 0));
@@ -234,7 +236,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Unschedule Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.RUN_ONCE_JOB);
+        triggerInformation.setType(SchedulerJobType.RUN_ONCE_JOB);
 
         when(task.getTrigger()).thenReturn(triggerInformation);
 
@@ -253,7 +255,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Unschedule Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.REPEATING_JOB);
+        triggerInformation.setType(SchedulerJobType.REPEATING_JOB);
 
         when(task.getTrigger()).thenReturn(triggerInformation);
 
@@ -272,7 +274,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Unschedule Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.CRON_JOB);
+        triggerInformation.setType(SchedulerJobType.CRON_JOB);
 
         when(task.getTrigger()).thenReturn(triggerInformation);
 
@@ -291,7 +293,7 @@ public class SchedulerTaskTriggerUtilTest {
         taskName = "Unschedule Test";
         triggerInformation = new SchedulerTaskTriggerInformation("scheduler.trigger", CHANNEL, MODULE_NAME,
                 VERSION, BASE_SUBJECT + "trigger.", BASE_SUBJECT + "trigger." + taskName);
-        triggerInformation.setType(SchedulerTaskTriggerInformation.SchedulerJobType.DAY_OF_WEEK_JOB);
+        triggerInformation.setType(SchedulerJobType.DAY_OF_WEEK_JOB);
 
         when(task.getTrigger()).thenReturn(triggerInformation);
 

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
@@ -16,6 +16,7 @@ import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventListenerRegistryService;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.listener.annotations.MotechListenerEventProxy;
+import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.motechproject.server.config.SettingsFacade;
 import org.motechproject.tasks.domain.ActionEventBuilder;
 import org.motechproject.tasks.domain.ActionParameterBuilder;
@@ -153,6 +154,9 @@ public class TaskTriggerHandlerTest {
     @Mock
     Exception exception;
 
+    @Mock
+    MotechSchedulerService motechSchedulerService;
+
     TaskActionExecutor taskActionExecutor;
 
     TaskTriggerHandler handler;
@@ -174,12 +178,14 @@ public class TaskTriggerHandlerTest {
         when(dataProvider.getName()).thenReturn(TASK_DATA_PROVIDER_NAME);
 
         taskActionExecutor = new TaskActionExecutor(taskService, taskActivityService, eventRelay);
-        handler = new TaskTriggerHandler(taskService, taskActivityService, registryService, eventRelay, taskActionExecutor, settingsFacade);
+        handler = new TaskTriggerHandler(taskService, taskActivityService, registryService, eventRelay,
+                taskActionExecutor, settingsFacade, motechSchedulerService);
         handler.addDataProvider(dataProvider);
         handler.setBundleContext(null);
 
-        verify(taskService).getAllTasks();
-        verify(registryService).registerListener(any(EventListener.class), eq(task.getTrigger().getSubject()));
+        // this is now done outside the constructor in a @PostConstruct method
+        //verify(taskService).getAllTasks();
+        //verify(registryService).registerListener(any(EventListener.class), eq(task.getTrigger().getSubject()));
     }
 
     @Test
@@ -188,7 +194,7 @@ public class TaskTriggerHandlerTest {
 
         when(taskService.getAllTasks()).thenReturn(new ArrayList<Task>());
 
-        new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null);
+        new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService);
         verify(eventListenerRegistryService, never()).registerListener(any(EventListener.class), anyString());
     }
 
@@ -247,7 +253,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -274,7 +280,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -302,7 +308,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -330,7 +336,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -359,7 +365,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -388,7 +394,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -417,7 +423,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -446,7 +452,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -475,7 +481,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(createEvent());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -507,7 +513,7 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -561,12 +567,12 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(5, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskActivityService).addError(eq(task), captor.capture());
-        verify(taskService).save(task);
+        //verify(taskService).save(task, true);//todo
         verify(taskActivityService).addWarning(task);
 
         ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
@@ -632,10 +638,10 @@ public class TaskTriggerHandlerTest {
         param.put("patientId", "123");
         handler.handle(new MotechEvent("trigger", param));
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         ArgumentCaptor<Task> taskArgumentCaptor = ArgumentCaptor.forClass(Task.class);
         assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(taskArgumentCaptor.capture());
+        verify(taskService).save(taskArgumentCaptor.capture(), eq(true));
         Task actualTask = taskArgumentCaptor.getValue();
         assertFalse(actualTask.isEnabled());
     }
@@ -690,7 +696,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(new MotechEvent("trigger", param));
 
         assertEquals(0, task.getFailuresInRow());
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskActivityService).addSuccess(task);
     }
 
@@ -737,8 +743,8 @@ public class TaskTriggerHandlerTest {
 
         ArgumentCaptor<Task> taskArgumentCaptor = ArgumentCaptor.forClass(Task.class);
         assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(task);
-        verify(taskService).save(taskArgumentCaptor.capture());
+        verify(taskService).save(task, true);
+        verify(taskService).save(taskArgumentCaptor.capture(), eq(true));
         Task actualTask = taskArgumentCaptor.getValue();
         assertFalse(actualTask.isEnabled());
     }
@@ -785,7 +791,7 @@ public class TaskTriggerHandlerTest {
         handler.handle(new MotechEvent("trigger", param));
 
         assertEquals(0, task.getFailuresInRow());
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskActivityService).addSuccess(task);
     }
 
@@ -808,7 +814,7 @@ public class TaskTriggerHandlerTest {
         assertEquals(5, task.getFailuresInRow());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskActivityService).addError(eq(task), captor.capture());
@@ -847,7 +853,7 @@ public class TaskTriggerHandlerTest {
         assertEquals(5, task.getFailuresInRow());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskActivityService).addError(eq(task), captor.capture());
@@ -893,7 +899,7 @@ public class TaskTriggerHandlerTest {
         assertEquals(5, task.getFailuresInRow());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(dataProvider).lookup("TestObjectField", "id", lookupFields);
@@ -938,7 +944,7 @@ public class TaskTriggerHandlerTest {
         assertEquals(5, task.getFailuresInRow());
         ArgumentCaptor<TaskHandlerException> captor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(dataProvider).lookup("TestObjectField", "id", lookupFields);
@@ -974,7 +980,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1003,7 +1009,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1026,7 +1032,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1052,7 +1058,7 @@ public class TaskTriggerHandlerTest {
 
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
-        verify(taskService, never()).save(task);
+        verify(taskService, never()).save(task, true);
         verify(taskService, never()).getActionEventFor(task.getActions().get(0));
         verify(eventRelay, never()).sendEventMessage(any(MotechEvent.class));
     }
@@ -1102,7 +1108,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1159,7 +1165,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1193,7 +1199,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1230,7 +1236,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1266,7 +1272,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1301,7 +1307,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1332,7 +1338,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1365,7 +1371,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1397,7 +1403,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(1, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(eventRelay).sendEventMessage(captorEvent.capture());
         verify(taskActivityService, never()).addSuccess(task);
 
@@ -1420,7 +1426,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(taskService).findTrigger(TRIGGER_SUBJECT);
         verify(taskService).findActiveTasksForTrigger(triggerEvent);
         verify(taskService).getActionEventFor(task.getActions().get(0));
@@ -1485,7 +1491,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(eventRelay, times(2)).sendEventMessage(captor.capture());
 
         MotechEvent event = captor.getAllValues().get(0);
@@ -1508,7 +1514,7 @@ public class TaskTriggerHandlerTest {
 
         assertEquals(0, task.getFailuresInRow());
 
-        verify(taskService).save(task);
+        verify(taskService).save(task, true);
         verify(eventRelay, times(2)).sendEventMessage(captor.capture());
 
         MotechEvent event = captor.getAllValues().get(1);

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
@@ -157,6 +157,9 @@ public class TaskTriggerHandlerTest {
     @Mock
     MotechSchedulerService motechSchedulerService;
 
+    @Mock
+    SchedulerTaskTriggerUtil schedulerTaskTriggerUtil;
+
     TaskActionExecutor taskActionExecutor;
 
     TaskTriggerHandler handler;
@@ -179,7 +182,7 @@ public class TaskTriggerHandlerTest {
 
         taskActionExecutor = new TaskActionExecutor(taskService, taskActivityService, eventRelay);
         handler = new TaskTriggerHandler(taskService, taskActivityService, registryService, eventRelay,
-                taskActionExecutor, settingsFacade, motechSchedulerService);
+                taskActionExecutor, settingsFacade, motechSchedulerService, schedulerTaskTriggerUtil);
         handler.addDataProvider(dataProvider);
         handler.setBundleContext(null);
 
@@ -194,7 +197,7 @@ public class TaskTriggerHandlerTest {
 
         when(taskService.getAllTasks()).thenReturn(new ArrayList<Task>());
 
-        new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService);
+        new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService, schedulerTaskTriggerUtil);
         verify(eventListenerRegistryService, never()).registerListener(any(EventListener.class), anyString());
     }
 

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskTriggerHandlerTest.java
@@ -36,6 +36,7 @@ import org.motechproject.tasks.domain.TriggerEvent;
 import org.motechproject.tasks.ex.ActionNotFoundException;
 import org.motechproject.tasks.ex.TaskHandlerException;
 import org.motechproject.tasks.ex.TriggerNotFoundException;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
@@ -14,6 +14,7 @@ import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TaskTriggerInformation;
+import org.motechproject.tasks.service.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.service.TaskActionExecutor;
 import org.motechproject.tasks.service.TaskActivityService;
 import org.motechproject.tasks.service.TaskService;
@@ -77,6 +78,9 @@ public class TaskControllerTest {
     @Mock
     Task task;
 
+    @Mock
+    SchedulerTaskTriggerUtil schedulerTaskTriggerUtil;
+
     TaskActionExecutor taskActionExecutor;
 
     TriggerHandler triggerHandler;
@@ -85,7 +89,7 @@ public class TaskControllerTest {
     public void setUp() throws Exception {
         initMocks(this);
         taskActionExecutor = new TaskActionExecutor(taskService, null, null);
-        triggerHandler = new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService);
+        triggerHandler = new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService, schedulerTaskTriggerUtil);
     }
 
     @Test

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
@@ -14,7 +14,7 @@ import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TaskTriggerInformation;
-import org.motechproject.tasks.service.SchedulerTaskTriggerUtil;
+import org.motechproject.tasks.util.SchedulerTaskTriggerUtil;
 import org.motechproject.tasks.service.TaskActionExecutor;
 import org.motechproject.tasks.service.TaskActivityService;
 import org.motechproject.tasks.service.TaskService;

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/TaskControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventListenerRegistryService;
+import org.motechproject.scheduler.service.MotechSchedulerService;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
 import org.motechproject.tasks.domain.TaskTriggerInformation;
@@ -56,6 +57,9 @@ public class TaskControllerTest {
     EventListenerRegistryService eventListenerRegistryService;
 
     @Mock
+    MotechSchedulerService motechSchedulerService;
+
+    @Mock
     HttpServletResponse response;
 
     @Mock
@@ -81,7 +85,7 @@ public class TaskControllerTest {
     public void setUp() throws Exception {
         initMocks(this);
         taskActionExecutor = new TaskActionExecutor(taskService, null, null);
-        triggerHandler = new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null);
+        triggerHandler = new TaskTriggerHandler(taskService, null, eventListenerRegistryService, null, taskActionExecutor, null, motechSchedulerService);
     }
 
     @Test


### PR DESCRIPTION
At the moment we can use scheduler jobs as triggers for tasks. There are five types of triggers to choose, all can be scheduled in parallel, edited and deleted (which also makes job unscheduled).
