### PR TITLE
MOTECH-1934: Fixed some issues with Scheduler actions

### DIFF
--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/DayOfWeekSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/DayOfWeekSchedulableJob.java
@@ -36,7 +36,7 @@ public final class DayOfWeekSchedulableJob implements SchedulableJob, Serializab
      * @param ignorePastFiresAtStart  the flag defining whether job should ignore past fires at start or not
      */
     public DayOfWeekSchedulableJob(MotechEvent motechEvent, LocalDate start, LocalDate end, List<DayOfWeek> days, Time time, boolean ignorePastFiresAtStart) {
-        if (motechEvent == null || hasNoDates(start, end) || isEmpty(days)) {
+        if (motechEvent == null || start == null || isEmpty(days)) {
             throw new IllegalArgumentException("null/empty arguments");
         }
         this.motechEvent = motechEvent;
@@ -58,10 +58,6 @@ public final class DayOfWeekSchedulableJob implements SchedulableJob, Serializab
      */
     public DayOfWeekSchedulableJob(MotechEvent motechEvent, LocalDate start, LocalDate end, List<DayOfWeek> days, Time time) {
         this(motechEvent, start, end, days, time, false);
-    }
-
-    private boolean hasNoDates(LocalDate start, LocalDate end) {
-        return start == null || end == null;
     }
 
     public MotechEvent getMotechEvent() {

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerActionProxyServiceImpl.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerActionProxyServiceImpl.java
@@ -32,7 +32,8 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
     @Override
     public void scheduleCronJob(String subject, Map<Object, Object> parameters, String cronExpression, DateTime startTime, DateTime endTime, Boolean ignorePastFiresAtStart) {
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
-        CronSchedulableJob job = new CronSchedulableJob(motechEvent, cronExpression, startTime.toDate(), endTime.toDate(), ignorePastFiresAtStart);
+        CronSchedulableJob job = new CronSchedulableJob(motechEvent, cronExpression, startTime.toDate(),
+                endTime != null ? endTime.toDate() : null, ignorePastFiresAtStart);
 
         scheduler.scheduleJob(job);
     }
@@ -46,7 +47,7 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
         RepeatingSchedulableJob job = new RepeatingSchedulableJob()
                 .setMotechEvent(motechEvent)
                 .setStartTime(startTime.toDate())
-                .setEndTime(endTime.toDate())
+                .setEndTime(endTime != null ? endTime.toDate() : null)
                 .setRepeatCount(repeatCount)
                 .setRepeatIntervalInSeconds(repeatIntervalInSeconds)
                 .setIgnorePastFiresAtStart(ignorePastFiresAtStart)
@@ -69,7 +70,8 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
         Time jobTime = new Time(time.getHourOfDay(), time.getMinuteOfHour());
         List<DayOfWeek> jobDayOfWeeks = createDayOfWeeks(days);
 
-        DayOfWeekSchedulableJob job = new DayOfWeekSchedulableJob(motechEvent, start.toLocalDate(), end.toLocalDate(), jobDayOfWeeks, jobTime, ignorePastFiresAtStart);
+        DayOfWeekSchedulableJob job = new DayOfWeekSchedulableJob(motechEvent, start.toLocalDate(),
+                end != null ? end.toLocalDate() : null, jobDayOfWeeks, jobTime, ignorePastFiresAtStart);
 
         scheduler.scheduleDayOfWeekJob(job);
     }
@@ -79,7 +81,7 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
                                      Period repeatPeriod, Boolean ignorePastFiresAtStart, Boolean useOriginalFireTimeAfterMisfire) {
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
         RepeatingPeriodSchedulableJob job = new RepeatingPeriodSchedulableJob(motechEvent,
-                startTime.toDate(), endTime.toDate(), repeatPeriod, ignorePastFiresAtStart);
+                startTime.toDate(), endTime != null ? endTime.toDate() : null, repeatPeriod, ignorePastFiresAtStart);
                 job.setUseOriginalFireTimeAfterMisfire(useOriginalFireTimeAfterMisfire);
 
         scheduler.scheduleRepeatingPeriodJob(job);

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerDatabaseServiceImpl.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerDatabaseServiceImpl.java
@@ -9,6 +9,7 @@ import org.motechproject.scheduler.contract.EventInfo;
 import org.motechproject.scheduler.contract.JobBasicInfo;
 import org.motechproject.scheduler.contract.JobDetailedInfo;
 import org.motechproject.scheduler.contract.RepeatingJobId;
+import org.motechproject.scheduler.contract.RepeatingPeriodJobId;
 import org.motechproject.scheduler.contract.RunOnceJobId;
 import org.motechproject.scheduler.exception.MotechSchedulerJobRetrievalException;
 import org.motechproject.scheduler.factory.MotechSchedulerFactoryBean;
@@ -412,7 +413,7 @@ public class MotechSchedulerDatabaseServiceImpl implements MotechSchedulerDataba
             return JobBasicInfo.JOBTYPE_RUNONCE;
         } else if (jobKey.getName().endsWith(RepeatingJobId.SUFFIX_REPEATJOBID)) {
             return JobBasicInfo.JOBTYPE_REPEATING;
-        } else if (jobKey.getName().endsWith(RepeatingJobId.SUFFIX_REPEATJOBID)) {
+        } else if (jobKey.getName().endsWith(RepeatingPeriodJobId.SUFFIX_REPEATPERIODJOBID)) {
             return JobBasicInfo.JOBTYPE_PERIOD;
         } else {
             return JobBasicInfo.JOBTYPE_CRON;

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerServiceImpl.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerServiceImpl.java
@@ -542,9 +542,11 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
         LocalDate end = dayOfWeekSchedulableJob.getEndDate();
         Time time = dayOfWeekSchedulableJob.getTime();
 
-        CronScheduleBuilder cronScheduleBuilder = CronScheduleBuilder.atHourAndMinuteOnGivenDaysOfWeek(time.getHour(), time.getMinute(), dayOfWeekSchedulableJob.getCronDays().toArray(new Integer[0]));
+        CronScheduleBuilder cronScheduleBuilder = CronScheduleBuilder.atHourAndMinuteOnGivenDaysOfWeek(time.getHour(),
+                time.getMinute(), dayOfWeekSchedulableJob.getCronDays().toArray(new Integer[0]));
         CronTriggerImpl cronTrigger = (CronTriggerImpl) cronScheduleBuilder.build();
-        CronSchedulableJob cronSchedulableJob = new CronSchedulableJob(motechEvent, cronTrigger.getCronExpression(), start.toDate(), end.toDate(), dayOfWeekSchedulableJob.isIgnorePastFiresAtStart());
+        CronSchedulableJob cronSchedulableJob = new CronSchedulableJob(motechEvent, cronTrigger.getCronExpression(),
+                start.toDate(), end != null ? end.toDate() : null, dayOfWeekSchedulableJob.isIgnorePastFiresAtStart());
 
         scheduleJob(cronSchedulableJob);
     }

--- a/modules/scheduler/scheduler/src/main/resources/task-channel.json
+++ b/modules/scheduler/scheduler/src/main/resources/task-channel.json
@@ -12,7 +12,8 @@
         }, {
           "key": "motechEventParameters",
           "displayName": "scheduler.motechEventParameters",
-          "type": "MAP"
+          "type": "MAP",
+          "required": false
         }, {
           "key": "cronExpression",
           "displayName": "scheduler.cronExpression"
@@ -23,7 +24,8 @@
         }, {
           "key": "endTime",
           "displayName": "scheduler.endDate",
-          "type": "DATE"
+          "type": "DATE",
+          "required": false
         }, {
           "key": "ignorePastFiresAtStart",
           "displayName": "scheduler.ignorePastFiresAtStart",
@@ -42,7 +44,8 @@
         }, {
           "key": "motechEventParameters",
           "displayName": "scheduler.motechEventParameters",
-          "type": "MAP"
+          "type": "MAP",
+          "required": false
         }, {
           "key": "startDate",
           "displayName": "scheduler.startDate",
@@ -50,7 +53,8 @@
         }, {
           "key": "endTime",
           "displayName": "scheduler.endDate",
-          "type": "DATE"
+          "type": "DATE",
+          "required": false
         }, {
           "key": "repeatCount",
           "displayName": "scheduler.repeatCount",
@@ -81,7 +85,8 @@
         }, {
           "key": "motechEventParameters",
           "displayName": "scheduler.motechEventParameters",
-          "type": "MAP"
+          "type": "MAP",
+          "required": false
         }, {
           "key": "startDate",
           "displayName": "scheduler.startDate",
@@ -100,7 +105,8 @@
         }, {
           "key": "motechEventParameters",
           "displayName": "scheduler.motechEventParameters",
-          "type": "MAP"
+          "type": "MAP",
+          "required": false
         }, {
           "key": "startDate",
           "displayName": "scheduler.startDate",
@@ -108,7 +114,8 @@
         }, {
           "key": "endTime",
           "displayName": "scheduler.endDate",
-          "type": "DATE"
+          "type": "DATE",
+          "required": false
         }, {
           "key": "days",
           "displayName": "scheduler.days",
@@ -135,7 +142,8 @@
         }, {
           "key": "motechEventParameters",
           "displayName": "scheduler.motechEventParameters",
-          "type": "MAP"
+          "type": "MAP",
+          "required": false
         }, {
           "key": "startDate",
           "displayName": "scheduler.startDate",
@@ -143,7 +151,8 @@
         }, {
           "key": "endTime",
           "displayName": "scheduler.endDate",
-          "type": "DATE"
+          "type": "DATE",
+          "required": false
         }, {
           "key": "repeatPeriod",
           "displayName": "scheduler.repeatPeriod",

--- a/modules/scheduler/scheduler/src/main/resources/task-channel.json
+++ b/modules/scheduler/scheduler/src/main/resources/task-channel.json
@@ -58,7 +58,7 @@
         }, {
           "key": "repeatIntervalInMilliSeconds",
           "displayName": "scheduler.repeatIntervalInMilliSeconds",
-          "type": "LONG"
+          "type": "INTEGER"
         }, {
           "key": "ignorePastFiresAtStart",
           "displayName": "scheduler.ignorePastFiresAtStart",
@@ -127,7 +127,7 @@
 {
       "displayName": "scheduler.schedulePeriodRepeatingJob",
       "serviceInterface": "org.motechproject.scheduler.service.MotechSchedulerActionProxyService",
-      "serviceMethod": "schedulePeriodRepeatingJob",
+      "serviceMethod": "scheduleRepeatingPeriodJob",
       "actionParameters": [
         {
           "key": "motechEventSubject",

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/ParameterType.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/ParameterType.java
@@ -11,6 +11,7 @@ import org.joda.time.format.DateTimeParser;
 import org.motechproject.commons.api.MotechException;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -24,6 +25,11 @@ public enum ParameterType {
         @Override
         public Object parse(String value) {
             return value;
+        }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return String.class;
         }
     },
 
@@ -39,6 +45,11 @@ public enum ParameterType {
         public Object parse(String value) {
             return value;
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return String.class;
+        }
     },
 
     INTEGER("INTEGER") {
@@ -49,6 +60,11 @@ public enum ParameterType {
             } catch (RuntimeException e) {
                 throw new MotechException("task.error.convertToInteger", e);
             }
+        }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return Integer.class;
         }
     },
 
@@ -61,6 +77,11 @@ public enum ParameterType {
                 throw new MotechException("task.error.convertToLong", e);
             }
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return Long.class;
+        }
     },
 
     DOUBLE("DOUBLE") {
@@ -71,6 +92,11 @@ public enum ParameterType {
             } catch (RuntimeException e) {
                 throw new MotechException("task.error.convertToDouble", e);
             }
+        }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return Double.class;
         }
     },
 
@@ -91,6 +117,11 @@ public enum ParameterType {
                 throw new MotechException("task.error.convertToDate", e);
             }
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return DateTime.class;
+        }
     },
 
     TIME("TIME") {
@@ -108,6 +139,11 @@ public enum ParameterType {
                 throw new MotechException("task.error.convertToTime", e);
             }
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return DateTime.class;
+        }
     },
 
     PERIOD("PERIOD") {
@@ -119,6 +155,11 @@ public enum ParameterType {
                 throw new MotechException("task.error.convertToPeriod", e);
             }
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return Period.class;
+        }
     },
 
     BOOLEAN("BOOLEAN") {
@@ -129,12 +170,22 @@ public enum ParameterType {
             }
             return Boolean.valueOf(value);
         }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return Boolean.class;
+        }
     },
 
     LIST("LIST") {
         @Override
         public Object parse(String value) {
             return Arrays.asList(value.split("(\\r)?\\n"));
+        }
+
+        @Override
+        public Class getUnderlyingClass() {
+            return List.class;
         }
     },
 
@@ -155,6 +206,10 @@ public enum ParameterType {
     private final String value;
 
     public abstract Object parse(String value);
+
+    public Class getUnderlyingClass() {
+        return Object.class;
+    }
 
     public static ParameterType getType(Class clazz) {
         ParameterType type = getNumericalType(clazz);

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/MethodHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/MethodHandler.java
@@ -83,6 +83,8 @@ class MethodHandler {
                     classes[idx] = List.class;
                 } else if (obj != null) {
                     classes[idx] = obj.getClass();
+                } else if (actionParameter.getType() != null) {
+                    classes[idx] = actionParameter.getType().getUnderlyingClass();
                 } else {
                     classes[idx] = Object.class;
                 }


### PR DESCRIPTION
There were two issues with the task-channel.json from the Schedule module.

First one was that the "Schedule repeating job" action was passing the "repeatIntervalInMilliSeconds" argument as "LONG" type instead of the "INTEGER"

The second one was that the "Schedule repeating job with period interval" action was passing the "schedulePeriodRepeatingJob" as the "serviceMethod" parameter instead of the "scheduleRepeatingPeriodJob".

The last issue with the Scheduler action was that the repeating job with period interval was recognised as the repeating job and therefore there were problems with builders casting.