### PR TITLE
MOTECH-1933: Fixes exporting instances using lookup with DateTime field

### DIFF
--- a/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
@@ -4371,7 +4371,9 @@
 
             if ($scope.checkboxModel.exportWithLookup === true) {
                 url = url + "&lookup=" + (($scope.selectedLookup) ? $scope.selectedLookup.lookupName : "");
-                url = url + "&fields=" + JSON.stringify($scope.lookupBy);
+                // in lookup fields the special characters may appear (for example '+' before timezone),
+                // we have to encode them before passing this url
+                url = url + "&fields=" + encodeURIComponent(JSON.stringify($scope.lookupBy));
             }
 
             $http.get(url)


### PR DESCRIPTION
This commit fixes the problem. Now special characters (for example  '+' before timezone)
are encoded before passing url to http request.