### PR TITLE
MOTECH-1942 SQL migration fixes 0.25 -> 0.26

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
@@ -14,6 +14,7 @@ import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.TypeHelper;
 import org.motechproject.mds.util.ValidationUtil;
 
+import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.IdentityType;
@@ -87,6 +88,7 @@ public class Field {
     private boolean nonDisplayable;
 
     @Persistent
+    @Column(allowsNull = "true")
     private boolean uiChanged;
 
     @Persistent(mappedBy = "field")

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/SchemaGenerator.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/SchemaGenerator.java
@@ -58,9 +58,10 @@ public class SchemaGenerator implements InitializingBean {
     }
 
     @Override
-    public void afterPropertiesSet() {
+    public void afterPropertiesSet() throws IOException {
+        runMigrations(new File(mdsConfig.getFlywayMigrationDirectory(), Constants.EntitiesMigration.PRE_SCHEMA_CREATION_DIRECTORY));
         generateSchema();
-        runMigrations();
+        runMigrations(mdsConfig.getFlywayMigrationDirectory());
     }
 
     public void generateSchema() {
@@ -76,8 +77,8 @@ public class SchemaGenerator implements InitializingBean {
         }
     }
 
-    public void runMigrations() {
-        File migrationDirectory = mdsConfig.getFlywayMigrationDirectory();
+    public void runMigrations(File migrationDirectory) {
+        LOGGER.debug("Starting the flyway modules migrations.");
         //No migration directory
         if (!migrationDirectory.exists()) {
             return;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
@@ -604,6 +604,8 @@ public final class Constants {
         public static final String MIGRATION_DIRECTORY = "/.motech/migration";
 
         public static final String FILESYSTEM_PREFIX = "filesystem:";
+
+        public static final String PRE_SCHEMA_CREATION_DIRECTORY = "preSchemaGeneration";
     }
 
     /**

--- a/platform/mds/mds/src/main/resources/db/migration/default/V30__MOTECH-1618.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V30__MOTECH-1618.sql
@@ -1,3 +1,20 @@
--- adds maxFetchDepth column ---
+-- conditionally adds maxFetchDepth column ---
+
+CREATE OR REPLACE FUNCTION addMaxFetch()
+
+RETURNS void AS $$
+BEGIN
+
+IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_name = 'Entity' AND column_name = 'maxFetchDepth') THEN
 
 ALTER TABLE "Entity" ADD COLUMN "maxFetchDepth" bigint DEFAULT NULL;
+
+END IF;
+
+END;
+
+$$ LANGUAGE plpgsql;
+
+SELECT addMaxFetch();
+
+DROP FUNCTION addMaxFetch();

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V30__MOTECH-1618.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V30__MOTECH-1618.sql
@@ -1,3 +1,21 @@
--- adds maxFetchDepth column ---
+-- conditionally adds maxFetchDepth column ---
+
+DROP PROCEDURE IF EXISTS addMaxFetchDepth;
+
+DELIMITER //
+CREATE PROCEDURE addMaxFetchDepth()
+BEGIN
+
+IF NOT EXISTS (SELECT * FROM information_schema.columns WHERE table_name = 'Entity' AND column_name = 'maxFetchDepth') THEN
 
 ALTER TABLE Entity ADD maxFetchDepth bigint(20) DEFAULT NULL;
+
+END IF;
+
+END//
+
+DELIMITER ;
+
+CALL addMaxFetchDepth();
+
+DROP PROCEDURE IF EXISTS addMaxFetchDepth;

--- a/platform/web-security/src/main/resources/db/migration/default/preSchemaGeneration/V2__MOTECH-1942.sql
+++ b/platform/web-security/src/main/resources/db/migration/default/preSchemaGeneration/V2__MOTECH-1942.sql
@@ -1,0 +1,22 @@
+-- Change empty values in MOTECH User openId column to NULL to avoid unique constraint violation
+
+CREATE OR REPLACE FUNCTION convertMotechUserOpenId()
+
+RETURNS void AS $$
+BEGIN
+
+IF EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'MOTECH_WEB_SECURITY_MOTECHUSER') THEN
+
+UPDATE "MOTECH_WEB_SECURITY_MOTECHUSER"
+SET "openId" = NULL
+WHERE "openId" = '';
+
+END IF;
+
+END;
+
+$$ LANGUAGE plpgsql;
+
+SELECT convertMotechUserOpenId();
+
+DROP FUNCTION convertMotechUserOpenId();

--- a/platform/web-security/src/main/resources/db/migration/mysql/preSchemaGeneration/V2__MOTECH-1942.sql
+++ b/platform/web-security/src/main/resources/db/migration/mysql/preSchemaGeneration/V2__MOTECH-1942.sql
@@ -1,0 +1,23 @@
+-- Change empty values in MOTECH User openId column to NULL to avoid unique constraint violation
+
+DROP PROCEDURE IF EXISTS convertMotechUserOpenId;
+
+DELIMITER //
+CREATE PROCEDURE convertMotechUserOpenId()
+BEGIN
+
+IF EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'MOTECH_WEB_SECURITY_MOTECHUSER') THEN
+
+UPDATE MOTECH_WEB_SECURITY_MOTECHUSER
+SET openId = NULL
+WHERE openId = "";
+
+END IF;
+
+END//
+
+DELIMITER ;
+
+CALL convertMotechUserOpenId();
+
+DROP PROCEDURE IF EXISTS convertMotechUserOpenId;


### PR DESCRIPTION
Since version 0.26 the openId is marked as unique. This
means that empty strings will be recognized as duplicates
and won't be allowed. Until version 0.26 we used to put
empty string as openId if it wasn't provided. This migration
changes all empty openId fields to NULL since they are
allowed, even when unique constraint is placed. Moreover
some other migrations have been fixed.

Conflicts:
	platform/mds/mds/src/main/java/org/motechproject/mds/jdo/SchemaGenerator.java