### PR TITLE
Fixing the Read the Docs Build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-Jinja2==2.7.2
-MarkupSafe==0.21
-Pygments==1.6
+Jinja2==2.8
+MarkupSafe==0.23
+Pygments==2.0.2
 Sphinx==1.3.1
 beautifulsoup4==4.3.2
 docutils==0.11

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==2.7.2
 MarkupSafe==0.21
 Pygments==1.6
-Sphinx==1.2.2
+Sphinx==1.3.1
 beautifulsoup4==4.3.2
 docutils==0.11
 javalang==0.9.5


### PR DESCRIPTION
The Read the Docs documentation is currently failing to build due to our reliance on old dependencies. These commits update the Sphynx version to 1.3.1 as well as the other dependencies on this Sphynx version.

[Here's the link](https://readthedocs.org/projects/motech-project/builds/3406151/) to the passing build on read the docs for this branch.