### PR TITLE
MOTECH-1964: Validation for task name

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/TaskNameAlreadyExistsException.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/TaskNameAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package org.motechproject.tasks.ex;
+
+public class TaskNameAlreadyExistsException extends RuntimeException {
+
+    private static final long serialVersionUID = 9084172986189170522L;
+
+    public TaskNameAlreadyExistsException(String taskName) {
+        super("Task with name " + taskName + " already exists");
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/TaskNameAlreadyExistsException.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/TaskNameAlreadyExistsException.java
@@ -1,9 +1,17 @@
 package org.motechproject.tasks.ex;
 
+/**
+ * Thrown when attempting to save task with already existing task name.
+ */
 public class TaskNameAlreadyExistsException extends RuntimeException {
 
     private static final long serialVersionUID = 9084172986189170522L;
 
+    /**
+     * Exception constructor.
+     *
+     * @param taskName the task name
+     */
     public TaskNameAlreadyExistsException(String taskName) {
         super("Task with name " + taskName + " already exists");
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -584,14 +584,12 @@ public class TaskServiceImpl implements TaskService {
     private void validateName(Task task) {
 
         Long taskId = task.getId();
-        int tasksWithName = tasksDataService.findTasksByName(task.getName()).size();
+        List<Task> tasksWithName = tasksDataService.findTasksByName(task.getName());
 
-        if(taskId == null && tasksWithName > 0) {
-            LOGGER.warn("Task with name: {} already exists", task.getName());
+        if(taskId == null && tasksWithName.size() > 0) {
             throw new TaskNameAlreadyExistsException(task.getName());
-        } else if (taskId != null && tasksWithName > 0) {
-            if(!(tasksDataService.findTasksByName(task.getName()).get(0).getId().equals(taskId))) {
-                LOGGER.warn("Task with name: {} already exists", task.getName());
+        } else if (taskId != null && tasksWithName.size() > 0) {
+            if(!(tasksWithName.get(0).getId().equals(taskId))) {
                 throw new TaskNameAlreadyExistsException(task.getName());
             }
         }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -588,10 +588,8 @@ public class TaskServiceImpl implements TaskService {
 
         if(taskId == null && tasksWithName.size() > 0) {
             throw new TaskNameAlreadyExistsException(task.getName());
-        } else if (taskId != null && tasksWithName.size() > 0) {
-            if(!(tasksWithName.get(0).getId().equals(taskId))) {
-                throw new TaskNameAlreadyExistsException(task.getName());
-            }
+        } else if (taskId != null && tasksWithName.size() > 0 && !(tasksWithName.get(0).getId().equals(taskId))) {
+            throw new TaskNameAlreadyExistsException(task.getName());
         }
     }
 

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -29,6 +29,7 @@ import org.motechproject.tasks.domain.TaskTriggerInformation;
 import org.motechproject.tasks.domain.TriggerEvent;
 import org.motechproject.tasks.ex.ActionNotFoundException;
 import org.motechproject.tasks.ex.CustomParserNotFoundException;
+import org.motechproject.tasks.ex.TaskNameAlreadyExistsException;
 import org.motechproject.tasks.ex.TaskNotFoundException;
 import org.motechproject.tasks.ex.TriggerNotFoundException;
 import org.motechproject.tasks.ex.ValidationException;
@@ -111,6 +112,7 @@ public class TaskServiceImpl implements TaskService {
             throw new ValidationException(TASK, errors);
         }
 
+        validateName(task);
         errors.addAll(validateTrigger(task));
         errors.addAll(validateDataSources(task));
         errors.addAll(validateActions(task));
@@ -577,6 +579,22 @@ public class TaskServiceImpl implements TaskService {
         logResultOfValidation("task action", task.getName(), errors);
 
         return errors;
+    }
+
+    private void validateName(Task task) {
+
+        Long taskId = task.getId();
+        int tasksWithName = tasksDataService.findTasksByName(task.getName()).size();
+
+        if(taskId == null && tasksWithName > 0) {
+            LOGGER.warn("Task with name: {} already exists", task.getName());
+            throw new TaskNameAlreadyExistsException(task.getName());
+        } else if (taskId != null && tasksWithName > 0) {
+            if(!(tasksDataService.findTasksByName(task.getName()).get(0).getId().equals(taskId))) {
+                LOGGER.warn("Task with name: {} already exists", task.getName());
+                throw new TaskNameAlreadyExistsException(task.getName());
+            }
+        }
     }
 
     private void logResultOfValidation(String validationName, String taskName, Set<TaskError> errors) {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -588,7 +588,7 @@ public class TaskServiceImpl implements TaskService {
 
         if(taskId == null && tasksWithName.size() > 0) {
             throw new TaskNameAlreadyExistsException(task.getName());
-        } else if (taskId != null && tasksWithName.size() > 0 && !(tasksWithName.get(0).getId().equals(taskId))) {
+        } else if (taskId != null && tasksWithName.size() > 0 && !tasksWithName.get(0).getId().equals(taskId)) {
             throw new TaskNameAlreadyExistsException(task.getName());
         }
     }

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskServiceImplTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskServiceImplTest.java
@@ -17,9 +17,9 @@ import org.mockito.verification.VerificationMode;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.mds.query.QueryExecution;
+import org.motechproject.tasks.domain.ActionEvent;
 import org.motechproject.tasks.domain.ActionEventBuilder;
 import org.motechproject.tasks.domain.ActionParameterBuilder;
-import org.motechproject.tasks.domain.ActionEvent;
 import org.motechproject.tasks.domain.Channel;
 import org.motechproject.tasks.domain.DataSource;
 import org.motechproject.tasks.domain.EventParameter;
@@ -41,6 +41,7 @@ import org.motechproject.tasks.domain.TaskEventInformation;
 import org.motechproject.tasks.domain.TaskTriggerInformation;
 import org.motechproject.tasks.domain.TriggerEvent;
 import org.motechproject.tasks.ex.ActionNotFoundException;
+import org.motechproject.tasks.ex.TaskNameAlreadyExistsException;
 import org.motechproject.tasks.ex.TaskNotFoundException;
 import org.motechproject.tasks.ex.TriggerNotFoundException;
 import org.motechproject.tasks.ex.ValidationException;
@@ -190,6 +191,16 @@ public class TaskServiceImplTest {
         when(providerService.getProviderById(1234L)).thenReturn(provider);
 
         taskService.save(task);
+    }
+
+    @Test(expected = TaskNameAlreadyExistsException.class)
+    public void shouldNotSaveTaskWithDuplicateName() {
+
+        when(tasksDataService.findTasksByName("name")).thenReturn(
+                asList(new Task("name", trigger, asList(action))));
+
+        Task t = new Task("name", trigger, asList(action), null, false, false);
+        taskService.save(t);
     }
 
     @Test

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskServiceImplTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskServiceImplTest.java
@@ -76,6 +76,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.motechproject.tasks.domain.ParameterType.UNICODE;
@@ -195,12 +196,17 @@ public class TaskServiceImplTest {
 
     @Test(expected = TaskNameAlreadyExistsException.class)
     public void shouldNotSaveTaskWithDuplicateName() {
-
         when(tasksDataService.findTasksByName("name")).thenReturn(
                 asList(new Task("name", trigger, asList(action))));
 
         Task t = new Task("name", trigger, asList(action), null, false, false);
-        taskService.save(t);
+
+        try {
+            taskService.save(t);
+        } finally {
+            verify(tasksDataService, times(1)).findTasksByName(t.getName());
+            verifyNoMoreInteractions(tasksDataService);
+        }
     }
 
     @Test


### PR DESCRIPTION
Added task name validation - the TaskNameAlreadyExistsException will be thrown when attempting to save task with already existing name. Added test for new behaviour.