### PR TITLE
MOTECH-1976: Active style for tabs is applied correctly

### DIFF
--- a/modules/admin/src/main/resources/webapp/index.html
+++ b/modules/admin/src/main/resources/webapp/index.html
@@ -3,33 +3,50 @@
         <ul class="breadcrumb" role="navigation">
             <li><a role="menu" href=".">{{msg('server.home')}}</a></li>
             <li><a role="menu" href="#/admin/bundles">{{msg('admin.module')}}</a></li>
-            <li ng-show="active('#/admin/bundles')" ng-class="active('#/admin/bundles')">{{msg('admin.manageModules')}}</li>
-            <li ng-show="active('#/admin/bundle/')" ng-class="active('#/admin/bundle/')">{{msg('admin.bundle.title')}}</li>
-            <li ng-show="active('#/admin/messages')||active('#/admin/messagesSettings')"><a role="menu" href="#/admin/messages">{{msg('admin.messages')}}</a></li>
-            <li ng-show="active('#/admin/messages')&&!active('#/admin/messagesSettings')" ng-class="active('#/admin/messages')">{{msg('admin.messages')}}</li>
-            <li ng-show="active('#/admin/messagesSettings')" ng-class="active('#/admin/messagesSettings')">{{msg('admin.messages.notifications.title')}}</li>
-            <li ng-show="active('#/admin/platform-settings')" ng-class="active('#/admin/platform-settings')">{{msg('admin.settings')}}</li>
-            <li ng-show="active('#/admin/log')&&!active('#/admin/logOptions')" ng-class="active('#/admin/log')">{{msg('admin.log')}}</li>
-            <li ng-show="active('#/admin/logOptions')" ng-class="active('#/admin/logOptions')">{{msg('admin.log.options')}}</li>
-            <li ng-show="active('#/admin/topics')" ng-class="active('#/admin/topics')">{{msg('admin.topics')}}</li>
-            <li ng-show="active('#/admin/queues')&&!active('#/admin/queues/browse')" ng-class="active('#/admin/queues')">{{msg('admin.queues')}}</li>
-            <li ng-show="active('#/admin/queues/browse')"><a role="menu" href="#/admin/queues">{{msg('admin.queues')}}</a></li>
-            <li ng-show="active('#/admin/queues/browse')" ng-class="active('#/admin/queues/browse')">{{msg('admin.queue.messages.pending')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'bundles'"
+                ng-class="{'active': selectedTabState.selectedTab === 'bundles' || 'active': selectedTabState.selectedTab === 'bundle'}">{{msg('admin.manageModules')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'bundle'"
+                ng-class="{'active': selectedTabState.selectedTab === 'bundles' || 'active': selectedTabState.selectedTab === 'bundle'}">{{msg('admin.bundle.title')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'messages' || selectedTabState.selectedTab === 'messagesSettings'">
+                <a role="menu" href="#/admin/messages">{{msg('admin.messages')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'messages'" ng-class="{'active': selectedTabState.selectedTab === 'messages'}">{{msg('admin.messages')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'messagesSettings'" ng-class="{'active': selectedTabState.selectedTab === 'messagesSettings'}">{{msg('admin.messages.notifications.title')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'platform-settings'" ng-class="{'active': selectedTabState.selectedTab === 'platform-settings'}">{{msg('admin.settings')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'log'" ng-class="{'active': selectedTabState.selectedTab === 'log'}">{{msg('admin.log')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'logOptions'" ng-class="{'active': selectedTabState.selectedTab === 'logOptions'}">{{msg('admin.log.options')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'topics'" ng-class="{'active': selectedTabState.selectedTab === 'topics'}">{{msg('admin.topics')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'queues'" ng-class="{'active': selectedTabState.selectedTab === 'queues'}">{{msg('admin.queues')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'browse'"> <a role="menu" href="#/admin/queues">{{msg('admin.queues')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'browse'" ng-class="{'active': selectedTabState.selectedTab === 'browse'}">{{msg('admin.queue.messages.pending')}}</li>
         </ul>
     </div>
     <div class="header-footer">
         <ul id="content-tabs" role="tablist" class="nav nav-tabs">
-            <li class="active" ng-show="active('#/admin/bundles')||active('#/admin/bundle')"><a href="#/admin/bundle">{{msg('admin.bundles')}}</a></li>
-            <li class="active" ng-show="active('#/admin/messages')&&!active('#/admin/messagesSettings')"><a href="#/admin/messages">{{msg('admin.messages')}}</a></li>
-            <li ng-show="active('#/admin/messagesSettings')"><a href="#/admin/messages">{{msg('admin.messages')}}</a></li>
-            <li ng-class="active('#/admin/messagesSettings')" ng-show="active('#/admin/messagesSettings')||active('#/admin/messages')"><a href="#/admin/messagesSettings">{{msg('admin.messages.notifications.title')}}</a></li>
-            <li class="active" ng-show="active('#/admin/platform-settings')"><a href="#/admin/platform-settings">{{msg('admin.settings')}}</a></li>
-            <li class="active" ng-show="active('#/admin/log')&&!active('#/admin/logOptions')"><a href="#/admin/log">{{msg('admin.log')}}</a></li>
-            <li ng-class="" ng-show="active('#/admin/logOptions')"><a href="#/admin/log">{{msg('admin.log')}}</a></li>
-            <li ng-class="active('#/admin/logOptions')" ng-show="active('#/admin/logOptions')||active('#/admin/log')"><a href="#/admin/logOptions">{{msg('admin.log.options')}}</a></li>
-            <li class="active" ng-show="active('#/admin/topics')"><a href="#/admin/topics">{{msg('admin.topic.statistics')}}</a></li>
-            <li class="active" ng-show="active('#/admin/queues')&&!active('#/admin/queues/browse')"><a href="#/admin/queues">{{msg('admin.queue.statistics')}}</a></li>
-            <li class="active" ng-show="active('#/admin/queues/browse')"><a href="#/admin/queues/browse">{{msg('admin.queue.messages.pending')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'bundles' || selectedTabState.selectedTab === 'bundle'}"
+                ng-show="selectedTabState.selectedTab === 'bundles' || selectedTabState.selectedTab === 'bundle'"
+                ng-click="selectedTabState.selectedTab = 'bundles'"><a href="#/admin/bundles">{{msg('admin.bundles')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'messages'}" ng-show="selectedTabState.selectedTab === 'messages'">
+                <a href="#/admin/messages">{{msg('admin.messages')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'messagesSettings'" ng-click="selectedTabState.selectedTab = 'messages'">
+                <a href="#/admin/messages">{{msg('admin.messages')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'messagesSettings'}"
+                ng-show="selectedTabState.selectedTab === 'messages' || selectedTabState.selectedTab === 'messagesSettings'"
+                ng-click="selectedTabState.selectedTab = 'messagesSettings'"><a href="#/admin/messagesSettings">{{msg('admin.messages.notifications.title')}}</a></li>
+            <li class="active" ng-show="selectedTabState.selectedTab === 'platform-settings'" ng-click="selectedTabState.selectedTab = 'platform-settings'">
+                <a href="#/admin/platform-settings">{{msg('admin.settings')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'log'}" ng-show="selectedTabState.selectedTab === 'log'">
+                <a href="#/admin/log">{{msg('admin.log')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'logOptions'" ng-click="selectedTabState.selectedTab = 'log'">
+                <a href="#/admin/log">{{msg('admin.log')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'logOptions'}"
+                ng-show="selectedTabState.selectedTab === 'logOptions' || selectedTabState.selectedTab === 'log'"
+                ng-click="selectedTabState.selectedTab = 'logOptions'"><a href="#/admin/logOptions">{{msg('admin.log.options')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'topics'" ng-class="{'active': selectedTabState.selectedTab === 'topics'}"
+                ng-click="selectedTabState.selectedTab = 'topics'"><a href="#/admin/topics">{{msg('admin.topic.statistics')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'queues'" ng-class="{'active': selectedTabState.selectedTab === 'queues'}">
+                <a href="#/admin/queues">{{msg('admin.queue.statistics')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'browse'" ng-class="{'active': selectedTabState.selectedTab === 'browse'}">
+                <a href="#/admin/queues/browse">{{msg('admin.queue.messages.pending')}}</a></li>
         </ul>
         <div class="clearfix"></div>
     </div>
@@ -41,7 +58,7 @@
             </div>
         </div>
     </div>
-    <div ng-controller="AdminPaginationMessageCtrl" class="header-footer pagination-centered" ng-show="pagedItems.length &gt; 0 && active('#/admin/messages') && !active('#/admin/messagesSettings')">
+    <div ng-controller="AdminPaginationMessageCtrl" class="header-footer pagination-centered" ng-show="pagedItems.length &gt; 0 && selectedTabState.selectedTab === 'messages'">
         <ul class="pagination pagination-sm lightblue">
             <li ng-class="{disabled: currentPage == 0}"><a ng-click="firstPage()">{{msg('server.pagination.first')}}</a></li>
             <li ng-class="{disabled: currentPage == 0}"><a ng-click="prevPage()">{{msg('server.pagination.prev')}}</a></li>

--- a/modules/admin/src/main/resources/webapp/partials/bundles.html
+++ b/modules/admin/src/main/resources/webapp/partials/bundles.html
@@ -99,7 +99,8 @@
                     <img ng-src="../admin/api/bundles/{{bundle.bundleId}}/icon" class="small-icon"/>
                 </div>
             </td>
-            <td><a ng-href="#/admin/bundle/{{bundle.bundleId}}">{{bundle.name | moduleName }}</a>
+            <td><a ng-href="#/admin/bundle/{{bundle.bundleId}}"
+                   ng-click="selectedTabState.selectedTab = 'bundle'">{{bundle.name | moduleName }}</a>
                     <span ng-show="showDocs(bundle)" class="pull-right btn btn-xs btn-primary" ng-click="openInNewTab(bundle.docURL)">
                         <i class="fa fa-fw fa-info-circle"></i>
                     </span>

--- a/modules/admin/src/main/resources/webapp/partials/queue_stats.html
+++ b/modules/admin/src/main/resources/webapp/partials/queue_stats.html
@@ -13,7 +13,8 @@
         <tbody ng-repeat="queue in queues">
             <tr>
                 <td class="ng-binding">
-                    <a ng-href="#/admin/queues/browse?queueName={{queue.destination}}">{{queue.destination}}</a>
+                    <a ng-href="#/admin/queues/browse?queueName={{queue.destination}}"
+                       ng-click="selectedTabState.selectedTab = 'browse'">{{queue.destination}}</a>
                 </td>
                 <td class="ng-binding">{{queue.queueSize}}</td>
                 <td class="ng-binding">{{queue.consumerCount}}</td>

--- a/modules/tasks/tasks/src/main/resources/webapp/index.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/index.html
@@ -3,15 +3,15 @@
         <ul class="breadcrumb" role="navigation">
             <li><a role="menu" href=".">{{msg('server.home')}}</a></li>
             <li><a role="menu" href="#/tasks/dashboard">{{msg('task.tab')}}</a></li>
-            <li ng-show="active('#/tasks/dashboard')" ng-class="active('#/tasks/dashboard')">{{msg('task.tab')}} list</li>
-            <li ng-show="active('#/tasks/settings')" ng-class="active('#/tasks/settings')">{{msg('task.tab.settings')}}</li>
-            <li ng-show="active('#/tasks/task/new')" ng-class="active('#/tasks/task/new')">{{msg('task.new')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'dashboard'" ng-class="{'active': selectedTabState.selectedTab === 'dashboard'}">{{msg('task.tab')}} list</li>
+            <li ng-show="selectedTabState.selectedTab === 'settings'" ng-class="{'active': selectedTabState.selectedTab === 'settings'}">{{msg('task.tab.settings')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'new'" ng-class="{'active': selectedTabState.selectedTab === 'new'}">{{msg('task.new')}}</li>
         </ul>
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs tasks ">
-            <li ng-class="active('#/tasks/dashboard')"><a  href="#/tasks/dashboard">{{msg('task.tab')}}</a></li>
-            <li ng-class="active('#/tasks/settings')"><a  href="#/tasks/settings">{{msg('task.tab.settings')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'dashboard'}" ng-click="selectedTabState.selectedTab = 'dashboard'"><a  href="#/tasks/dashboard">{{msg('task.tab')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'settings'}" ng-click="selectedTabState.selectedTab = 'settings'"><a  href="#/tasks/settings">{{msg('task.tab.settings')}}</a></li>
         </ul>
     </div>
     <div class="ui-layout-content">

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/tasks.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/tasks.html
@@ -3,7 +3,7 @@
     <h4 class="frame-title">{{msg('task.header.tasks')}}</h4>
     <div class="toolbox">
         <div class="btn-group">
-            <a href="#/tasks/task/new" type="button" class="btn btn-success"><i class="fa fa-plus"></i> {{msg('task.new')}}</a>
+            <a href="#/tasks/task/new" type="button" class="btn btn-success" ng-click="selectedTabState.selectedTab = 'new'"><i class="fa fa-plus"></i> {{msg('task.new')}}</a>
             <a role="button" class="btn btn-default" data-toggle="modal" data-target="#importTaskModal" data-backdrop="static"><span class="glyphicon glyphicon-import"></span> {{msg('task.import')}}</a>
             <button type="button" class="btn btn-default" id="tasks-filters"><i class="fa fa-filter"></i>&nbsp;{{msg('task.section.filters')}}</button>
         </div>

--- a/platform/email/src/main/resources/webapp/index.html
+++ b/platform/email/src/main/resources/webapp/index.html
@@ -3,16 +3,16 @@
         <ul class="breadcrumb" role="navigation">
             <li><a role="menu" href=".">{{msg('server.home')}}</a></li>
             <li><a role="menu" href="#/email/send">{{msg('email')}}</a></li>
-            <li ng-show="active('#/email/send')" ng-class="active('#/email/send')">{{msg('email.send')}}</li>
-            <li ng-show="active('#/email/logging')" ng-class="active('#/email/logging')">{{msg('email.logging')}}</li>
-            <li ng-show="active('#/email/settings')" ng-class="active('#/email/settings')">{{msg('email.settings')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'send'" ng-class="{'active': selectedTabState.selectedTab === 'send'}">{{msg('email.send')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'logging'" ng-class="{'active': selectedTabState.selectedTab === 'logging'}">{{msg('email.logging')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'settings'" ng-class="{'active': selectedTabState.selectedTab === 'settings'}">{{msg('email.settings')}}</li>
         </ul>
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs tasks ">
-            <li ng-class="active('#/email/send')"><a  ng-href="#/email/send">{{msg('email.send')}}</a></li>
-            <li ng-class="active('#/email/logging')"><a ng-href="#/email/logging">{{msg('email.logging')}}</a></li>
-            <li ng-class="active('#/email/settings')"><a  ng-href="#/email/settings">{{msg('email.settings')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'send'}" ng-click="selectedTabState.selectedTab = 'send'"><a  ng-href="#/email/send">{{msg('email.send')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'logging'}" ng-click="selectedTabState.selectedTab = 'logging'"><a ng-href="#/email/logging">{{msg('email.logging')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'settings'}" ng-click="selectedTabState.selectedTab = 'settings'"><a  ng-href="#/email/settings">{{msg('email.settings')}}</a></li>
         </ul>
     </div>
     <div class="ui-layout-content">

--- a/platform/mds/mds-web/src/main/resources/webapp/index.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/index.html
@@ -7,7 +7,9 @@
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs mds">
-            <li ng-class="active('#/mds/' + tab)" ng-repeat="tab in AVAILABLE_TABS">
+            <li ng-class="{'active': selectedTabState.selectedTab === tab}"
+                ng-click="selectedTabState.selectedTab = tab"
+                ng-repeat="tab in AVAILABLE_TABS">
                 <a href="#/mds/{{tab}}">
                     {{msg('mds.tab.' + tab)}}
                 </a>

--- a/platform/server-bundle/src/main/resources/webapp/js/controllers.js
+++ b/platform/server-bundle/src/main/resources/webapp/js/controllers.js
@@ -305,6 +305,16 @@
             return parseUri(window.location.href).anchor;
         };
 
+        /**
+        Deprecated. This function exists for backward compatibility
+        and should not be used.
+        */
+        $scope.active = function(url) {
+            if (window.location.href.indexOf(url) !== -1) {
+                return "active";
+            }
+        };
+
         $scope.safeApply = function (fun) {
             var phase = this.$root.$$phase;
 

--- a/platform/server-bundle/src/main/resources/webapp/js/controllers.js
+++ b/platform/server-bundle/src/main/resources/webapp/js/controllers.js
@@ -46,6 +46,8 @@
         $scope.activeLink = undefined;
         $scope.documentationUrl = undefined;
         $scope.activeMenu = "servermodules";
+        $scope.selectedTabState = {};
+        $scope.selectedTabState.selectedTab = "";
 
         $scope.loginViewData = {};
         $scope.resetViewData = {};
@@ -174,6 +176,7 @@
 
         $scope.loadModule = function (moduleName, url) {
             var refresh, resultScope, reloadModule;
+            $scope.selectedTabState.selectedTab = url.substring(url.lastIndexOf("/")+1);
             $scope.activeLink = {moduleName: moduleName, url: url};
             if (moduleName) {
                 blockUI();
@@ -300,12 +303,6 @@
 
         $scope.getCurrentAnchor = function () {
             return parseUri(window.location.href).anchor;
-        };
-
-        $scope.active = function(url) {
-            if (window.location.href.indexOf(url) !== -1) {
-                return "active";
-            }
         };
 
         $scope.safeApply = function (fun) {

--- a/platform/web-security/src/main/resources/webapp/index.html
+++ b/platform/web-security/src/main/resources/webapp/index.html
@@ -2,25 +2,30 @@
     <div class="header-footer-breadcrumb">
         <ul class="breadcrumb" role="navigation">
             <li><a role="menu" href=".">{{msg('server.home')}}</a></li>
-            <li ng-show="active('#/webSecurity/profile')"><a role="menu" href="#/webSecurity/profile">{{msg('websecurity')}}</a></li>
-            <li ng-show="active('#/webSecurity/permissions')"><a role="menu" href="#/webSecurity/permissions">{{msg('websecurity')}}</a></li>
-            <li ng-show="active('#/webSecurity/roles')"><a role="menu" href="#/webSecurity/roles">{{msg('websecurity')}}</a></li>
-            <li ng-show="active('#/webSecurity/users')"><a role="menu" href="#/webSecurity/users">{{msg('websecurity')}}</a></li>
-            <li ng-show="active('#/webSecurity/dynamicURL')"><a role="menu" href="#/webSecurity/dynamicURL">{{msg('websecurity')}}</a></li>
-            <li ng-show="active('#/webSecurity/profile')" ng-class="active('#/webSecurity/profile')">{{msg('security.profile')}}</li>
-            <li ng-show="active('#/webSecurity/permissions')" ng-class="active('#/webSecurity/permissions')">{{msg('security.managePermissions')}}</li>
-            <li ng-show="active('#/webSecurity/roles')" ng-class="active('#/webSecurity/roles')">{{msg('security.manageRoles')}}</li>
-            <li ng-show="active('#/webSecurity/users')" ng-class="active('#/webSecurity/users')">{{msg('security.administeringUsers')}}</li>
-            <li ng-show="active('#/webSecurity/dynamicURL')" ng-class="active('#/webSecurity/dynamicURL')">{{msg('security.manageURL')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'profile'"><a role="menu" href="#/webSecurity/profile">{{msg('websecurity')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'permissions'"><a role="menu" href="#/webSecurity/permissions">{{msg('websecurity')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'roles'"><a role="menu" href="#/webSecurity/roles">{{msg('websecurity')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'users'"><a role="menu" href="#/webSecurity/users">{{msg('websecurity')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'dynamicURL'"><a role="menu" href="#/webSecurity/dynamicURL">{{msg('websecurity')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'profile'" ng-class="{'active': selectedTabState.selectedTab === 'profile'}">{{msg('security.profile')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'permissions'" ng-class="{'active': selectedTabState.selectedTab === 'permissions'}">{{msg('security.managePermissions')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'roles'" ng-class="{'active': selectedTabState.selectedTab === 'roles'}">{{msg('security.manageRoles')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'users'" ng-class="{'active': selectedTabState.selectedTab === 'users'}">{{msg('security.administeringUsers')}}</li>
+            <li ng-show="selectedTabState.selectedTab === 'dynamicURL'" ng-class="{'active': selectedTabState.selectedTab === 'dynamicURL'}">{{msg('security.manageURL')}}</li>
         </ul>
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs">
-            <li ng-show="active('#/webSecurity/profile')" ng-class="active('#/webSecurity/profile')"><a  href="#/webSecurity/profile">{{msg('security.profile')}}</a></li>
-            <li ng-show="active('#/webSecurity/permissions')" ng-class="active('#/webSecurity/permissions')"><a  href="#/webSecurity/permissions">{{msg('security.managePermissions')}}</a></li>
-            <li ng-show="active('#/webSecurity/roles')" ng-class="active('#/webSecurity/roles')"><a href="#/webSecurity/roles">{{msg('security.manageRoles')}}</a></li>
-            <li ng-show="active('#/webSecurity/users')" ng-class="active('#/webSecurity/users')"><a href="#/webSecurity/users">{{msg('security.administeringUsers')}}</a></li>
-            <li ng-show="active('#/webSecurity/dynamicURL')" ng-class="active('#/webSecurity/dynamicURL')"><a href="#/webSecurity/dynamicURL">{{msg('security.manageURL')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'profile'" ng-class="{'active': selectedTabState.selectedTab === 'profile'}"
+                ng-click="selectedTabState.selectedTab = 'profile'"><a  href="#/webSecurity/profile">{{msg('security.profile')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'permissions'" ng-class="{'active': selectedTabState.selectedTab === 'permissions'}"
+                ng-click="selectedTabState.selectedTab = 'permissions'"><a  href="#/webSecurity/permissions">{{msg('security.managePermissions')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'roles'" ng-class="{'active': selectedTabState.selectedTab === 'roles'}"
+                ng-click="selectedTabState.selectedTab = 'roles'"><a href="#/webSecurity/roles">{{msg('security.manageRoles')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'users'" ng-class="{'active': selectedTabState.selectedTab === 'users'}"
+                ng-click="selectedTabState.selectedTab = 'users'"><a href="#/webSecurity/users">{{msg('security.administeringUsers')}}</a></li>
+            <li ng-show="selectedTabState.selectedTab === 'dynamicURL'" ng-class="{'active': selectedTabState.selectedTab === 'dynamicURL'}"
+                ng-click="selectedTabState.selectedTab = 'dynamicURL'"><a href="#/webSecurity/dynamicURL">{{msg('security.manageURL')}}</a></li>
         </ul>
     </div>
     <div class="ui-layout-content">

--- a/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/index.html
+++ b/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/index.html
@@ -11,7 +11,7 @@
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs">
-            <li ng-class="{'active': selectedTabState.selectedTab === 'hello-world'}" ng-click="selectedTabState.selectedTab = 'hello-world'">
+            <li ng-class="{'active': selectedTabState.selectedTab === 'helloWorld'}" ng-click="selectedTabState.selectedTab = 'helloWorld'">
                 <a href="${symbol_pound}/helloWorld" >{{msg('${artifactId}')}}</a></li>
         </ul>
     </div>

--- a/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/index.html
+++ b/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/index.html
@@ -11,7 +11,8 @@
     </div>
     <div class="header-footer">
         <ul id="content-tabs" class="nav nav-tabs">
-            <li ng-class="active('${symbol_pound}/hello-world')"><a href="${symbol_pound}/helloWorld" >{{msg('${artifactId}')}}</a></li>
+            <li ng-class="{'active': selectedTabState.selectedTab === 'hello-world'}" ng-click="selectedTabState.selectedTab = 'hello-world'">
+                <a href="${symbol_pound}/helloWorld" >{{msg('${artifactId}')}}</a></li>
         </ul>
     </div>
     <div class="ui-layout-content">

--- a/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/js/app.js
+++ b/utils/archetypes/http-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/webapp/js/app.js
@@ -10,6 +10,6 @@
         .config(['$routeProvider',
         function ($routeProvider) {
             $routeProvider.
-                when('/helloWorld', {templateUrl: '../${artifactId}/resources/partials/say-hello.html', controller: 'HelloWorldController'});
+                when('/${artifactId}/helloWorld', {templateUrl: '../${artifactId}/resources/partials/say-hello.html', controller: 'HelloWorldController'});
     }]);
 }());

--- a/utils/archetypes/minimal-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/motech/applicationContext.xml
+++ b/utils/archetypes/minimal-bundle-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/motech/applicationContext.xml
@@ -35,7 +35,7 @@
                 <entry key="messages" value="../${artifactId}/resources/messages/" />
             </map>
         </constructor-arg>
-        <property name="defaultURL" value="/helloWorld"/>
+        <property name="defaultURL" value="/${artifactId}/helloWorld"/>
     </bean>
 #end
 


### PR DESCRIPTION
Added selectedTabState to server-bundle, which allows to correctly apply 'active' style for tabs with redirect. Changed the way in which 'active' style is set for tabs and breadcrumb to work with new approach. Removed active() method from server-bundle as it is not needed anymore.