### PR TITLE
MOTECH-1978: cast WebappClassLoader to its superclass

### DIFF
--- a/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
+++ b/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
@@ -2,6 +2,7 @@ package org.motechproject.server.impl;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.reflect.FieldUtils;
 import org.motechproject.server.api.BundleLoader;
 import org.motechproject.server.api.BundleLoadingException;
 import org.osgi.framework.Bundle;
@@ -205,19 +206,7 @@ public class JspBundleLoader implements BundleLoader, ServletContextAware {
         Class cl = loader.getClass();
 
         if ("org.apache.catalina.loader.WebappClassLoader".equals(cl.getName())) {
-            boolean found = false;
-            for (Field field : cl.getDeclaredFields()) {
-                if ("resourceEntries".equals(field.getName())) {
-                    found = true;
-                    break;
-                }
-            }
-            if (found) {
-                clearMap(cl, loader, "resourceEntries");
-            } else {
-                Object obj = loader.getClass().getSuperclass().cast(loader);
-                clearMap(cl.getSuperclass(), obj, "resourceEntries");
-            }
+            clearMap(cl, loader, "resourceEntries");
         } else {
             LOGGER.debug("class loader " + cl.getName() + " is not tomcat loader.");
         }
@@ -226,7 +215,7 @@ public class JspBundleLoader implements BundleLoader, ServletContextAware {
 
     private static void clearMap(Class cl, Object obj, String name)
             throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-        Field field = cl.getDeclaredField(name);
+        Field field = FieldUtils.getField(cl, name, true);
         field.setAccessible(true);
         Object cache = field.get(obj);
         Class ccl = cache.getClass();

--- a/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
+++ b/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
@@ -20,7 +20,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.*;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.ResourceBundle;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -201,16 +206,16 @@ public class JspBundleLoader implements BundleLoader, ServletContextAware {
         Class cl = loader.getClass();
 
         if ("org.apache.catalina.loader.WebappClassLoader".equals(cl.getName())) {
-            List<Field> fields = new ArrayList<Field>(Arrays.asList(cl.getDeclaredFields()));
+            ArrayList<Field> fields = new ArrayList<Field>(Arrays.asList(cl.getDeclaredFields()));
             boolean found = false;
-            for(Field field : fields){
-                if(field.getName().equals(("resourceEntries"))){
+            for (Field field : fields) {
+                if ("resourceEntries".equals(field.getName())) {
                     found = true;
                 }
             }
-            if(found)
+            if (found) {
                 clearMap(cl, loader, "resourceEntries");
-            else {
+            } else {
                 Object obj = loader.getClass().getSuperclass().cast(loader);
                 clearMap(cl.getSuperclass(), obj, "resourceEntries");
             }

--- a/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
+++ b/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
@@ -20,10 +20,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.Properties;
-import java.util.ResourceBundle;
+import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -204,7 +201,19 @@ public class JspBundleLoader implements BundleLoader, ServletContextAware {
         Class cl = loader.getClass();
 
         if ("org.apache.catalina.loader.WebappClassLoader".equals(cl.getName())) {
-            clearMap(cl, loader, "resourceEntries");
+            List<Field> fields = new ArrayList<Field>(Arrays.asList(cl.getDeclaredFields()));
+            boolean found = false;
+            for(Field field : fields){
+                if(field.getName().equals(("resourceEntries"))){
+                    found = true;
+                }
+            }
+            if(found)
+                clearMap(cl, loader, "resourceEntries");
+            else {
+                Object obj = loader.getClass().getSuperclass().cast(loader);
+                clearMap(cl.getSuperclass(), obj, "resourceEntries");
+            }
         } else {
             LOGGER.debug("class loader " + cl.getName() + " is not tomcat loader.");
         }

--- a/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
+++ b/platform/server/src/main/java/org/motechproject/server/impl/JspBundleLoader.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
 import java.net.URL;
 
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.ResourceBundle;
@@ -206,11 +205,11 @@ public class JspBundleLoader implements BundleLoader, ServletContextAware {
         Class cl = loader.getClass();
 
         if ("org.apache.catalina.loader.WebappClassLoader".equals(cl.getName())) {
-            ArrayList<Field> fields = new ArrayList<Field>(Arrays.asList(cl.getDeclaredFields()));
             boolean found = false;
-            for (Field field : fields) {
+            for (Field field : cl.getDeclaredFields()) {
                 if ("resourceEntries".equals(field.getName())) {
                     found = true;
+                    break;
                 }
             }
             if (found) {


### PR DESCRIPTION
in tomcat-7 WebappClassLoader has field "resourceEntries" but in tomcat-8 only its superclass has this field so the object must be casted to its superclass to get "resourceEntries" field