### PR TITLE
MOTECH-1861: Refactored MDS to use dtos when processing schema

### DIFF
--- a/platform/commons-api/src/main/java/org/motechproject/commons/api/StopWatchHelper.java
+++ b/platform/commons-api/src/main/java/org/motechproject/commons/api/StopWatchHelper.java
@@ -1,0 +1,14 @@
+package org.motechproject.commons.api;
+
+import org.apache.commons.lang.time.StopWatch;
+
+public final class StopWatchHelper {
+
+    public static void restart(StopWatch stopWatch) {
+        stopWatch.reset();
+        stopWatch.start();
+    }
+
+    private StopWatchHelper() {
+    }
+}

--- a/platform/commons-api/src/main/java/org/motechproject/commons/api/StopWatchHelper.java
+++ b/platform/commons-api/src/main/java/org/motechproject/commons/api/StopWatchHelper.java
@@ -2,8 +2,15 @@ package org.motechproject.commons.api;
 
 import org.apache.commons.lang.time.StopWatch;
 
+/**
+ * A helper that allows to easily restart the Apache commons stop watch.
+ */
 public final class StopWatchHelper {
 
+    /**
+     * Restarts the provided {@link StopWatch} by calling {@link StopWatch#reset()} and {@link StopWatch#start()} on it.
+     * @param stopWatch the stop watch to restart
+     */
     public static void restart(StopWatch stopWatch) {
         stopWatch.reset();
         stopWatch.start();

--- a/platform/mds/mds-performance-tests/src/main/java/org/motechproject/mds/performance/service/impl/MdsDummyDataGeneratorImpl.java
+++ b/platform/mds/mds-performance-tests/src/main/java/org/motechproject/mds/performance/service/impl/MdsDummyDataGeneratorImpl.java
@@ -10,6 +10,7 @@ import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.LookupFieldDto;
 import org.motechproject.mds.dto.LookupFieldType;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.entity.ServiceNotFoundException;
@@ -75,7 +76,8 @@ public class MdsDummyDataGeneratorImpl implements MdsDummyDataGenerator {
         }
 
         if (regenerateBundle) {
-            jarGeneratorService.regenerateMdsDataBundle();
+            SchemaHolder schemaHolder = entityService.getSchema();
+            jarGeneratorService.regenerateMdsDataBundle(schemaHolder);
         }
     }
 

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/AvailableController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/AvailableController.java
@@ -53,12 +53,7 @@ public class AvailableController extends MdsController {
         list.remove(typeService.findType(org.joda.time.LocalDate.class));
 
         // TextArea type is available only from UI
-        TypeDto textAreaType = new TypeDto();
-        textAreaType.setDefaultName("textArea");
-        textAreaType.setDisplayName("mds.field.textArea");
-        textAreaType.setDescription("mds.field.description.textArea");
-        textAreaType.setTypeClass("textArea");
-        list.add(textAreaType);
+        list.add(textAreaUIType());
 
         CollectionUtils.filter(list, new TypeMatcher(data.getTerm(), messageSource));
         Collections.sort(list, new TypeDisplayNameComparator(messageSource));

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/EntityController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/EntityController.java
@@ -9,6 +9,7 @@ import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.MdsBundleRegenerationService;
+import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.web.SelectData;
 import org.motechproject.mds.web.SelectResult;
 import org.motechproject.mds.web.comparator.EntityNameComparator;
@@ -216,35 +217,45 @@ public class EntityController extends MdsController {
     @PreAuthorize(Roles.HAS_DATA_OR_SCHEMA_ACCESS)
     @ResponseBody
     public List<FieldDto> getFields(@PathVariable Long entityId) {
-        return entityService.getFields(entityId);
+        List<FieldDto> fields = entityService.getFields(entityId);
+        processFieldsForUI(fields);
+        return fields;
     }
 
     @RequestMapping(value = "/entities/{entityId}/entityFields", method = RequestMethod.GET)
     @PreAuthorize(Roles.HAS_DATA_OR_SCHEMA_ACCESS)
     @ResponseBody
     public List<FieldDto> getEntityFields(@PathVariable Long entityId) {
-        return entityService.getEntityFieldsForUI(entityId);
-}
+        List<FieldDto> fields = entityService.getEntityFieldsForUI(entityId);
+        processFieldsForUI(fields);
+        return fields;
+    }
 
     @RequestMapping(value = "/entities/entityFieldsByClassName", method = RequestMethod.GET)
     @PreAuthorize(Roles.HAS_DATA_OR_SCHEMA_ACCESS)
     @ResponseBody
     public List<FieldDto> getEntityFieldsByClassName(@RequestParam(value = "entityClassName", required = true) String entityClassName) {
-        return entityService.getEntityFieldsByClassNameForUI(entityClassName);
+        List<FieldDto> fields = entityService.getEntityFieldsByClassNameForUI(entityClassName);
+        processFieldsForUI(fields);
+        return fields;
     }
 
     @RequestMapping(value = "/entities/{entityId}/displayFields", method = RequestMethod.GET)
     @PreAuthorize(Roles.HAS_DATA_OR_SCHEMA_ACCESS)
     @ResponseBody
     public List<FieldDto> getDisplayFields(@PathVariable Long entityId) {
-        return entityService.getDisplayFields(entityId);
+        List<FieldDto> fields = entityService.getDisplayFields(entityId);
+        processFieldsForUI(fields);
+        return fields;
     }
 
     @RequestMapping(value = "entities/{entityId}/fields/{name}", method = RequestMethod.GET)
     @PreAuthorize(Roles.HAS_DATA_OR_SCHEMA_ACCESS)
     @ResponseBody
     public FieldDto getFieldByName(@PathVariable Long entityId, @PathVariable String name) {
-        return entityService.findFieldByName(entityId, name);
+        FieldDto field = entityService.findFieldByName(entityId, name);
+        processFieldForUI(field);
+        return field;
     }
 
     @RequestMapping(value = "/entities/{entityId}/advanced", method = RequestMethod.GET)
@@ -259,6 +270,20 @@ public class EntityController extends MdsController {
     @ResponseBody
     public AdvancedSettingsDto getCommitedAdvanced(@PathVariable final Long entityId) {
         return entityService.getAdvancedSettings(entityId, true);
+    }
+
+    private void processFieldsForUI(List<FieldDto> fields) {
+        for (FieldDto field : fields) {
+            processFieldForUI(field);
+        }
+    }
+
+    private void processFieldForUI(FieldDto field) {
+        if (Constants.Util.TRUE.equalsIgnoreCase(
+                field.getSettingsValueAsString(Constants.Settings.STRING_TEXT_AREA))) {
+            field.setType(textAreaUIType());
+            field.removeSetting(Constants.Settings.STRING_TEXT_AREA);
+        }
     }
 
     @Autowired

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/InstanceController.java
@@ -7,6 +7,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.motechproject.mds.dto.CsvImportResults;
 import org.motechproject.mds.dto.FieldInstanceDto;
+import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.csv.CsvImportException;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
@@ -86,7 +87,9 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/instances/{entityId}/new")
     @ResponseBody
     public EntityRecord newInstance(@PathVariable Long entityId) {
-        return instanceService.newInstance(entityId);
+        EntityRecord entityRecord = instanceService.newInstance(entityId);
+        processFieldsForUI(entityRecord);
+        return entityRecord;
     }
 
     @RequestMapping(value = "/instances/{entityId}/{instanceId}/fields", method = RequestMethod.GET)
@@ -142,7 +145,10 @@ public class InstanceController extends MdsController {
         long recordCount = instanceService.countHistoryRecords(entityId, instanceId);
         int rowCount = (int) Math.ceil(recordCount / (double) queryParams.getPageSize());
 
-        return new Records<>(queryParams.getPage(), rowCount, (int) recordCount, historyRecordsList);
+        Records<HistoryRecord> records = new Records<>(queryParams.getPage(), rowCount, (int) recordCount,
+                historyRecordsList);
+        processFieldsForUIinHistoryRecords(records);
+        return records;
     }
 
     @RequestMapping(value = "/instances/{entityId}/{instanceId}/previousVersion/{historyId}", method = RequestMethod.GET)
@@ -153,6 +159,7 @@ public class InstanceController extends MdsController {
         if (historyRecord == null) {
             throw new EntityNotFoundException(entityId);
         }
+        processFieldsForUIInHistoryRecord(historyRecord);
         return historyRecord;
     }
 
@@ -166,7 +173,9 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/instances/{entityId}/instance/{instanceId}", method = RequestMethod.GET)
     @ResponseBody
     public EntityRecord getInstance(@PathVariable Long entityId, @PathVariable Long instanceId) {
-        return instanceService.getEntityInstance(entityId, instanceId);
+        EntityRecord entityRecord = instanceService.getEntityInstance(entityId, instanceId);
+        processFieldsForUI(entityRecord);
+        return entityRecord;
     }
 
     @RequestMapping(value = "/instances/{entityId}/instance/{instanceId}/{fieldName}", method = RequestMethod.GET)
@@ -174,7 +183,10 @@ public class InstanceController extends MdsController {
     public Records<EntityRecord> getRelatedValues(@PathVariable Long entityId, @PathVariable Long instanceId,
                                     @PathVariable String fieldName, GridSettings settings) {
         QueryParams queryParams = QueryParamsBuilder.buildQueryParams(settings);
-        return instanceService.getRelatedFieldValue(entityId, instanceId, fieldName, queryParams);
+        Records<EntityRecord> records = instanceService.getRelatedFieldValue(entityId, instanceId, fieldName,
+                queryParams);
+        processFieldsForUI(records);
+        return records;
     }
 
     /**
@@ -190,7 +202,9 @@ public class InstanceController extends MdsController {
     @RequestMapping(value = "/instances/{entityId}/field/{fieldId}/instance/{instanceId}", method = RequestMethod.GET)
     @ResponseBody
     public FieldRecord getInstanceValueAsRelatedField(@PathVariable Long entityId, @PathVariable Long fieldId, @PathVariable Long instanceId) {
-        return instanceService.getInstanceValueAsRelatedField(entityId, fieldId, instanceId);
+        FieldRecord record = instanceService.getInstanceValueAsRelatedField(entityId, fieldId, instanceId);
+        processFieldForUI(record);
+        return record;
     }
 
     @RequestMapping(value = "/entities/{entityId}/trash", method = RequestMethod.GET)
@@ -202,14 +216,18 @@ public class InstanceController extends MdsController {
         long recordCount = instanceService.countTrashRecords(entityId);
         int rowCount = (int) Math.ceil(recordCount / (double) queryParams.getPageSize());
 
-        return new Records<>(queryParams.getPage(), rowCount, (int) recordCount, trashRecordsList);
-
+        Records<EntityRecord> records = new Records<>(queryParams.getPage(), rowCount, (int) recordCount,
+                trashRecordsList);
+        processFieldsForUI(records);
+        return records;
     }
 
     @RequestMapping(value = "/entities/{entityId}/trash/{instanceId}", method = RequestMethod.GET)
     @ResponseBody
     public EntityRecord getSingleTrashInstance(@PathVariable Long entityId, @PathVariable Long instanceId) {
-        return instanceService.getSingleTrashRecord(entityId, instanceId);
+        EntityRecord entityRecord = instanceService.getSingleTrashRecord(entityId, instanceId);
+        processFieldsForUI(entityRecord);
+        return entityRecord;
     }
 
     @RequestMapping(value = "/entities/{entityId}/exportInstances", method = RequestMethod.GET)
@@ -247,7 +265,7 @@ public class InstanceController extends MdsController {
 
     @RequestMapping(value = "/entities/{entityId}/instances", method = RequestMethod.POST)
     @ResponseBody
-    public Records<?> getInstances(@PathVariable Long entityId, GridSettings settings) throws IOException {
+    public Records<EntityRecord> getInstances(@PathVariable Long entityId, GridSettings settings) throws IOException {
         String lookup = settings.getLookup();
         String filterStr = settings.getFilter();
         Map<String, Object> fieldMap = getFields(settings);
@@ -273,7 +291,9 @@ public class InstanceController extends MdsController {
 
         int rowCount = (int) Math.ceil(recordCount / (double) queryParams.getPageSize());
 
-        return new Records<>(queryParams.getPage(), rowCount, (int) recordCount, entityRecords);
+        Records<EntityRecord> records = new Records<>(queryParams.getPage(), rowCount, (int) recordCount, entityRecords);
+        processFieldsForUI(records);
+        return records;
     }
 
     @RequestMapping(value = "/instances/{entityId}/csvimport", method = RequestMethod.POST)
@@ -327,5 +347,36 @@ public class InstanceController extends MdsController {
         int index = ArrayUtils.indexOf(content, (byte) ',') + 1;
 
         return ArrayUtils.toObject(decoder.decode(ArrayUtils.subarray(content, index, content.length)));
+    }
+
+    private void processFieldsForUI(Records<EntityRecord> records) {
+        for (EntityRecord record : records.getRows()) {
+            processFieldsForUI(record);
+        }
+    }
+
+    private void processFieldsForUIinHistoryRecords(Records<HistoryRecord> records) {
+        for (HistoryRecord record : records.getRows()) {
+            processFieldsForUIInHistoryRecord(record);
+        }
+    }
+
+    private void processFieldsForUIInHistoryRecord(HistoryRecord record) {
+        for (FieldRecord fieldRecord : record.getFields()) {
+            processFieldForUI(fieldRecord);
+        }
+    }
+
+    private void processFieldsForUI(EntityRecord entityRecord) {
+        for (FieldRecord fieldRecord : entityRecord.getFields()) {
+            processFieldForUI(fieldRecord);
+        }
+    }
+
+    private void processFieldForUI(FieldRecord fieldRecord) {
+        SettingDto textAreaSetting = fieldRecord.getSettingByName(Constants.Settings.STRING_TEXT_AREA);
+        if (textAreaSetting != null && Constants.Util.TRUE.equalsIgnoreCase(textAreaSetting.getValueAsString())) {
+            fieldRecord.setType(textAreaUIType());
+        }
     }
 }

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/JarGeneratorController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/JarGeneratorController.java
@@ -3,6 +3,8 @@ package org.motechproject.mds.web.controller;
 import javassist.CannotCompileException;
 import javassist.NotFoundException;
 import org.apache.commons.io.IOUtils;
+import org.motechproject.mds.dto.SchemaHolder;
+import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -24,6 +26,7 @@ public class JarGeneratorController extends MdsController {
     private static final String APPLICATION_JAVA_ARCHIVE = "application/java-archive";
 
     private JarGeneratorService jarGeneratorService;
+    private EntityService entityService;
 
     @RequestMapping(value = "/jar", method = RequestMethod.GET)
     public void generateJar(HttpServletResponse response) throws IOException, NotFoundException, CannotCompileException {
@@ -35,7 +38,9 @@ public class JarGeneratorController extends MdsController {
         );
 
         OutputStream output = response.getOutputStream();
-        File jar = jarGeneratorService.generate();
+
+        SchemaHolder schemaHolder = entityService.getSchema();
+        File jar = jarGeneratorService.generate(schemaHolder);
 
         try (FileInputStream input = new FileInputStream(jar)) {
             IOUtils.copy(input, output);

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/MdsController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/MdsController.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.web.controller;
 
+import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.MdsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,5 +35,16 @@ public abstract class MdsController {
         } else {
             return String.format("key:%s\nparams:%s", exception.getMessageKey(), exception.getParams());
         }
+    }
+
+    protected TypeDto textAreaUIType() {
+        TypeDto textAreaType = new TypeDto();
+
+        textAreaType.setDefaultName("textArea");
+        textAreaType.setDisplayName("mds.field.textArea");
+        textAreaType.setDescription("mds.field.description.textArea");
+        textAreaType.setTypeClass("textArea");
+
+        return textAreaType;
     }
 }

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/it/MdsRestBundleIT.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/it/MdsRestBundleIT.java
@@ -29,6 +29,7 @@ import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.LookupFieldDto;
 import org.motechproject.mds.dto.LookupFieldType;
 import org.motechproject.mds.dto.RestOptionsDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.rest.RestProjection;
@@ -112,7 +113,9 @@ public class MdsRestBundleIT extends BasePaxIT {
             clearEntities();
             prepareEntity();
             prepareFilteredEntity();
-            jarGeneratorService.regenerateMdsDataBundle();
+
+            SchemaHolder schemaHolder = entityService.getSchema();
+            jarGeneratorService.regenerateMdsDataBundle(schemaHolder);
         }
 
         getDataService().deleteAll();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/MDSDataProvider.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/MDSDataProvider.java
@@ -8,6 +8,7 @@ import org.motechproject.mds.builder.MDSDataProviderBuilder;
 import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.ex.dataprovider.DataProviderException;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.lookup.LookupExecutor;
@@ -159,8 +160,8 @@ public class MDSDataProvider extends AbstractDataProvider {
         return "org.motechproject.mds.entity";
     }
 
-    public void updateDataProvider() {
-        setBody(mdsDataProviderBuilder.generateDataProvider());
+    public void updateDataProvider(SchemaHolder schemaHolder) {
+        setBody(mdsDataProviderBuilder.generateDataProvider(schemaHolder));
         // we unregister the service, then register again
         if (serviceRegistration != null) {
             serviceRegistration.unregister();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/annotations/internal/FieldProcessor.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/annotations/internal/FieldProcessor.java
@@ -96,7 +96,7 @@ import static org.motechproject.mds.util.Constants.Util.OWNER_FIELD_NAME;
  * By default all public fields (the field is public if it has public modifier or single methods
  * called 'getter and 'setter') will be added in the MDS definition of the entity. The field type
  * will be mapped on the appropriate type in the MDS system. If the appropriate mapping does not
- * exist an {@link org.motechproject.mds.ex.type.TypeNotFoundException} exception will be raised.
+ * exist an {@link org.motechproject.mds.ex.type.NoSuchTypeException} exception will be raised.
  * <p/>
  * Fields or acceptable methods with the {@link org.motechproject.mds.annotations.Ignore}
  * annotation are ignored by the processor and they are not added into entity definition.

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityBuilder.java
@@ -1,8 +1,11 @@
 package org.motechproject.mds.builder;
 
 import org.motechproject.mds.domain.ClassData;
-import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
 import org.osgi.framework.Bundle;
+
+import java.util.List;
 
 /**
  * An entity builder is responsible for building the entity class from an Entity schema.
@@ -12,9 +15,10 @@ public interface EntityBuilder {
     /**
      * Builds a class definition for a given entity. The class is not registered with any classloader.
      * @param entity the entity schema
+     * @param fields the field schema for this entity
      * @return bytes of the newly constructed class
      */
-    ClassData build(Entity entity);
+    ClassData build(EntityDto entity, List<FieldDto> fields);
 
     /**
      * Builds Developer Defined Entity. The main difference between regular build method and this one, is that
@@ -22,40 +26,43 @@ public interface EntityBuilder {
      * class from there, if possible, rather than building everything from scratch.
      *
      * @param entity the entity schema
+     * @param fields the field schema for this entity
      * @param bundle the bundle to fetch class definition from
      * @return bytes of the constructed class
      */
-    ClassData buildDDE(Entity entity, Bundle bundle);
+    ClassData buildDDE(EntityDto entity, List<FieldDto> fields, Bundle bundle);
 
     /**
      * Builds History class definition for the given entity. The history class definition contains
      * the same members as the entity class, plus some fields history-exclusive, like schema version.
      *
      * @param entity the entity schema
+     * @param fields the field schema for this entity
      * @return bytes of the constructed class
      */
-    ClassData buildHistory(Entity entity);
+    ClassData buildHistory(EntityDto entity, List<FieldDto> fields);
 
     /**
      * Builds Trash class definition for the given entity. The trash class definition contains
      * the same members as the entity class, plus some fields trash-exclusive.
      *
      * @param entity the entity schema
+     * @param fields the field schema for this entity
      * @return bytes of the constructed class
      */
-    ClassData buildTrash(Entity entity);
+    ClassData buildTrash(EntityDto entity, List<FieldDto> fields);
 
     /**
      * Builds empty history class definition for the given entity and adds it to the class pool.
      *
      * @param entity the entity schema
      */
-    void prepareHistoryClass(Entity entity);
+    void prepareHistoryClass(EntityDto entity);
 
     /**
      * Builds empty trash class definition for the given entity and adds it to the class pool.
      *
      * @param entity the entity schema
      */
-    void prepareTrashClass(Entity entity);
+    void prepareTrashClass(EntityDto entity);
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityInfrastructureBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityInfrastructureBuilder.java
@@ -1,7 +1,8 @@
 package org.motechproject.mds.builder;
 
 import org.motechproject.mds.domain.ClassData;
-import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.SchemaHolder;
 
 import java.util.List;
 
@@ -19,9 +20,10 @@ public interface EntityInfrastructureBuilder {
      * {@link org.motechproject.mds.util.ClassName#getServiceClassName(String)}, respectively.
      *
      * @param entity an instance of {@link org.motechproject.mds.domain.Entity}
+     * @param schemaHolder the current MDS schema holder
      * @return a list of classes that represents infrastructure for the given entity.
      */
-    List<ClassData> buildInfrastructure(Entity entity);
+    List<ClassData> buildInfrastructure(EntityDto entity, SchemaHolder schemaHolder);
 
     /**
      * Builds the repository, interface and implementation of this interface classes for the

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityMetadataBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/EntityMetadataBuilder.java
@@ -1,8 +1,9 @@
 package org.motechproject.mds.builder;
 
 import org.motechproject.mds.domain.ClassData;
-import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityType;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.SchemaHolder;
 
 import javax.jdo.metadata.JDOMetadata;
 
@@ -16,11 +17,12 @@ public interface EntityMetadataBuilder {
      * Adds information about package and class name to a {@link javax.jdo.metadata.JDOMetadata}
      * instance.
      *
-     * @param jdoMetadata a empty instance of {@link javax.jdo.metadata.JDOMetadata}.
-     * @param entity      a instance of {@link org.motechproject.mds.domain.Entity}
-     * @param definition  the definition of the class
+     * @param jdoMetadata  a empty instance of {@link javax.jdo.metadata.JDOMetadata}.
+     * @param entity       a instance of {@link org.motechproject.mds.domain.Entity}
+     * @param definition   the definition of the class
+     * @param schemaHolder the holder of the current schema
      */
-    void addEntityMetadata(JDOMetadata jdoMetadata, Entity entity, Class<?> definition);
+    void addEntityMetadata(JDOMetadata jdoMetadata, EntityDto entity, Class<?> definition, SchemaHolder schemaHolder);
 
     /**
      * Adds base information about package and class name to a
@@ -45,13 +47,15 @@ public interface EntityMetadataBuilder {
      * @param entity      an entity to fetch fields from
      * @param entityType type of the entity(history or trash)
      * @param definition  the definition of the parent class
+     * @param schemaHolder the holder of the current schema
      */
-    void addHelperClassMetadata(JDOMetadata jdoMetadata, ClassData classData, Entity entity,
-                                EntityType entityType, Class<?> definition);
+    void addHelperClassMetadata(JDOMetadata jdoMetadata, ClassData classData, EntityDto entity,
+                                EntityType entityType, Class<?> definition, SchemaHolder schemaHolder);
 
     /**
      * This updates the metadata after enhancement. Nucleus makes some "corrections" which do not work with
      * the runtime enhancer.
+     * @param jdoMetadata an empty instance of {@link javax.jdo.metadata.JDOMetadata}.
      */
-    void fixEnhancerIssuesInMetadata(JDOMetadata jdoMetadata);
+    void fixEnhancerIssuesInMetadata(JDOMetadata jdoMetadata, SchemaHolder schemaHolder);
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSConstructor.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSConstructor.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.builder;
 
+import org.motechproject.mds.dto.SchemaHolder;
+
 import java.util.Map;
 
 /**
@@ -21,12 +23,10 @@ public interface MDSConstructor {
      * An interface related with class definition should be created only for entities from outside
      * bundles and if the bundle does not define its own interface.
      *
-     * @param buildDDE {@code true} if class definitions for entities from outside bundles should
-     *                 also be created; otherwise {@code false}.
      * @return {@code true} if there were entities for which class definitions should be created;
      * otherwise {@code false}.
      */
-    boolean constructEntities();
+    boolean constructEntities(SchemaHolder schemaHolder);
 
     /**
      * Updates the field names of an entity. This method alters the database schema by changing

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSConstructor.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSConstructor.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.builder;
 
+import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.dto.SchemaHolder;
 
 import java.util.Map;
@@ -33,8 +34,8 @@ public interface MDSConstructor {
      * column names to the new value. This is done for the entity instances, history instances
      * and trash instances.
      *
-     * @param entityId The ID of an entity to update
+     * @param entity the entity to update
      * @param fieldNameChanges A map, indexed by current field names and values being updated field names.
      */
-    void updateFields(Long entityId, Map<String, String> fieldNameChanges);
+    void updateFields(Entity entity, Map<String, String> fieldNameChanges);
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSDataProviderBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/MDSDataProviderBuilder.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.builder;
 
+import org.motechproject.mds.dto.SchemaHolder;
+
 /**
  * The <code>MDSDataProviderBuilder</code> class is responsible for building the
  * MDS Data Provider JSON, required to register a data provider in the Tasks module.
@@ -11,8 +13,9 @@ public interface MDSDataProviderBuilder {
      * It contains all the information required by the task module to register a
      * data provider.
      *
+     * @param schemaHolder the current MDS schema
      * @return   JSON-formatted String, containing information about MDS Data Provider
      */
-    String generateDataProvider();
+    String generateDataProvider(SchemaHolder schemaHolder);
 
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityBuilderImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityBuilderImpl.java
@@ -8,14 +8,15 @@ import javassist.CtField;
 import javassist.CtMethod;
 import javassist.CtNewConstructor;
 import javassist.NotFoundException;
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.mds.builder.EntityBuilder;
 import org.motechproject.mds.domain.ClassData;
 import org.motechproject.mds.domain.ComboboxHolder;
-import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityType;
-import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.Relationship;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.entity.EntityCreationException;
 import org.motechproject.mds.ex.object.PropertyCreationException;
 import org.motechproject.mds.helper.EnumHelper;
@@ -24,7 +25,6 @@ import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.JavassistUtil;
 import org.motechproject.mds.util.MemberUtil;
-import org.motechproject.mds.util.TypeHelper;
 import org.osgi.framework.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.List;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.uncapitalize;
@@ -49,19 +50,19 @@ public class EntityBuilderImpl implements EntityBuilder {
     private final ClassPool classPool = MotechClassPool.getDefault();
 
     @Override
-    public ClassData build(Entity entity) {
+    public ClassData build(EntityDto entity, List<FieldDto> fields) {
         LOGGER.debug("Building EUDE: " + entity.getName());
-        return build(entity, EntityType.STANDARD, null);
+        return build(entity, fields, EntityType.STANDARD, null);
     }
 
     @Override
-    public ClassData buildDDE(Entity entity, Bundle bundle) {
+    public ClassData buildDDE(EntityDto entity, List<FieldDto> fields, Bundle bundle) {
         LOGGER.debug("Building DDE: " + entity.getClassName());
-        return build(entity, EntityType.STANDARD, bundle);
+        return build(entity, fields, EntityType.STANDARD, bundle);
     }
 
     @Override
-    public void prepareHistoryClass(Entity entity) {
+    public void prepareHistoryClass(EntityDto entity) {
         String className = entity.getClassName();
         LOGGER.debug("Building empty history class for: {}", className);
 
@@ -78,7 +79,7 @@ public class EntityBuilderImpl implements EntityBuilder {
     }
 
     @Override
-    public void prepareTrashClass(Entity entity) {
+    public void prepareTrashClass(EntityDto entity) {
         String className = entity.getClassName();
         LOGGER.debug("Building empty trash class for: {}", className);
 
@@ -94,32 +95,32 @@ public class EntityBuilderImpl implements EntityBuilder {
     }
 
     @Override
-    public ClassData buildHistory(Entity entity) {
+    public ClassData buildHistory(EntityDto entity, List<FieldDto> fields) {
         LOGGER.debug("Building history class for: {}", entity.getClassName());
-        return build(entity, EntityType.HISTORY, null);
+        return build(entity, fields, EntityType.HISTORY, null);
     }
 
     @Override
-    public ClassData buildTrash(Entity entity) {
+    public ClassData buildTrash(EntityDto entity, List<FieldDto> fields) {
         LOGGER.debug("Building trash class for: {}", entity.getClassName());
-        return build(entity, EntityType.TRASH, null);
+        return build(entity, fields, EntityType.TRASH, null);
     }
 
-    private ClassData build(Entity entity, EntityType type, Bundle bundle) {
+    private ClassData build(EntityDto entity, List<FieldDto> fields, EntityType type, Bundle bundle) {
         try {
-            CtClass declaring = makeClass(entity, type, bundle);
+            CtClass declaring = makeClass(entity, fields, type, bundle);
 
             switch (type) {
                 case HISTORY:
                     String className = type.getName(entity.getClassName());
                     String simpleName = ClassName.getSimpleName(className);
-                    Type idType = entity.getField("id").getType();
+                    TypeDto idType = TypeDto.LONG;
 
                     // add 4 extra fields to history class definition
 
                     // this field is related with id field in entity
                     addProperty(
-                            declaring, idType.getTypeClassName(), simpleName + "CurrentVersion",
+                            declaring, idType.getTypeClass(), simpleName + "CurrentVersion",
                             null
                     );
 
@@ -144,7 +145,7 @@ public class EntityBuilderImpl implements EntityBuilder {
         }
     }
 
-    private CtClass makeClass(Entity entity, EntityType type, Bundle bundle)
+    private CtClass makeClass(EntityDto entity, List<FieldDto> fields, EntityType type, Bundle bundle)
             throws NotFoundException, CannotCompileException, ReflectiveOperationException {
         // try to get declaring class
         CtClass declaring = getDeclaringClass(entity, type, bundle);
@@ -153,7 +154,8 @@ public class EntityBuilderImpl implements EntityBuilder {
         injectDefaultConstructor(declaring);
 
         // create properties (add fields, getters and setters)
-        for (Field field : entity.getFields()) {
+        for (FieldDto field : fields) {
+            String fieldName = field.getBasic().getName();
             try {
 
                 // We skip version fields for trash and history
@@ -161,14 +163,13 @@ public class EntityBuilderImpl implements EntityBuilder {
                     continue;
                 }
 
-                String fieldName = field.getName();
                 CtField ctField;
 
                 if (!shouldLeaveExistingField(field, declaring)) {
                     JavassistUtil.removeFieldIfExists(declaring, fieldName);
                     ctField = createField(declaring, entity, field, type);
 
-                    if (isBlank(field.getDefaultValue())) {
+                    if (isObjectNullOrBlankString(field.getBasic().getDefaultValue())) {
                         declaring.addField(ctField);
                     } else {
                         declaring.addField(ctField, createInitializer(entity, field));
@@ -188,7 +189,7 @@ public class EntityBuilderImpl implements EntityBuilder {
                     createSetter(declaring, fieldName, ctField);
                 }
             } catch (RuntimeException e) {
-                throw new EntityCreationException("Error while processing field " + field.getName(), e);
+                throw new EntityCreationException("Error while processing field " + fieldName, e);
             }
         }
 
@@ -230,7 +231,7 @@ public class EntityBuilderImpl implements EntityBuilder {
         }
     }
 
-    private CtClass getDeclaringClass(Entity entity, EntityType type, Bundle bundle)
+    private CtClass getDeclaringClass(EntityDto entity, EntityType type, Bundle bundle)
             throws NotFoundException {
         String className = type.getName(entity.getClassName());
         boolean isDDE = null != bundle;
@@ -277,10 +278,10 @@ public class EntityBuilderImpl implements EntityBuilder {
         }
     }
 
-    private CtField createField(CtClass declaring, Entity entity, Field field,
+    private CtField createField(CtClass declaring, EntityDto entity, FieldDto field,
                                 EntityType entityType)
-            throws IllegalAccessException, InstantiationException, CannotCompileException {
-        Type fieldType = field.getType();
+            throws IllegalAccessException, InstantiationException, CannotCompileException, ClassNotFoundException {
+        TypeDto fieldType = field.getType();
         String genericSignature = null;
         CtClass type = null;
 
@@ -303,15 +304,16 @@ public class EntityBuilderImpl implements EntityBuilder {
                 type = classPool.getOrNull(holder.getUnderlyingType());
             }
         } else if (fieldType.isRelationship()) {
-            Relationship relationshipType = (Relationship) fieldType.getTypeClass().newInstance();
+            Class fieldClass = getClass().getClassLoader().loadClass(fieldType.getTypeClass());
+            Relationship relationshipType = (Relationship) fieldClass.newInstance();
 
             genericSignature = relationshipType.getGenericSignature(field, entityType);
             type = classPool.getOrNull(relationshipType.getFieldType(field, entityType));
         } else {
-            type = classPool.getOrNull(fieldType.getTypeClassName());
+            type = classPool.getOrNull(fieldType.getTypeClass());
         }
 
-        return JavassistBuilder.createField(declaring, type, field.getName(), genericSignature);
+        return JavassistBuilder.createField(declaring, type, field.getBasic().getName(), genericSignature);
     }
 
     private void createGetter(CtClass declaring, String fieldName, CtField ctField)
@@ -328,50 +330,58 @@ public class EntityBuilderImpl implements EntityBuilder {
         declaring.addMethod(setter);
     }
 
-    private CtField.Initializer createInitializer(Entity entity, Field field) {
-        Type type = field.getType();
+    private CtField.Initializer createInitializer(EntityDto entity, FieldDto field) {
+        TypeDto type = field.getType();
         CtField.Initializer initializer = null;
 
         if (type.isCombobox()) {
             ComboboxHolder holder = new ComboboxHolder(entity, field);
 
             if (holder.isStringCollection()) {
-                Object defaultValue = TypeHelper.parse(field.getDefaultValue(), holder.getTypeClassName());
                 initializer = JavassistBuilder.createCollectionInitializer(
-                        holder.getUnderlyingType(), defaultValue
+                        holder.getUnderlyingType(), field.getBasic().getDefaultValue()
                 );
             } else if (holder.isEnumCollection()) {
-                Object defaultValue = TypeHelper.parse(field.getDefaultValue(), holder.getTypeClassName());
+                Object defaultValue = field.getBasic().getDefaultValue();
                 initializer = JavassistBuilder.createCollectionInitializer(
                         holder.getEnumName(), EnumHelper.prefixEnumValues((Collection) defaultValue)
                 );
             } else if (holder.isString()) {
                 initializer = JavassistBuilder.createInitializer(
-                        holder.getUnderlyingType(), field.getDefaultValue()
+                        holder.getUnderlyingType(), field.getBasic().getDefaultValue().toString()
                 );
             } else if (holder.isEnum()) {
                 initializer = JavassistBuilder.createEnumInitializer(
-                        holder.getEnumName(), EnumHelper.prefixEnumValue(field.getDefaultValue())
+                        holder.getEnumName(), EnumHelper.prefixEnumValue(field.getBasic().getDefaultValue().toString())
                 );
             }
         } else if (!type.isRelationship()) {
             initializer = JavassistBuilder.createInitializer(
-                    type.getTypeClassName(), field.getDefaultValue()
+                    type.getTypeClass(), field.getBasic().getDisplayName()
             );
         }
 
         return initializer;
     }
 
-    private boolean shouldLeaveExistingField(Field field, CtClass declaring) {
+    private boolean shouldLeaveExistingField(FieldDto field, CtClass declaring) {
         return field.isReadOnly()
-                && (JavassistUtil.containsField(declaring, field.getName()) ||
-                    JavassistUtil.containsDeclaredField(declaring, field.getName()));
+                && (JavassistUtil.containsField(declaring, field.getBasic().getName()) ||
+                    JavassistUtil.containsDeclaredField(declaring, field.getBasic().getName()));
     }
 
-    private boolean shouldLeaveExistingMethod(Field field, String methodName, CtClass declaring) {
+    private boolean shouldLeaveExistingMethod(FieldDto field, String methodName, CtClass declaring) {
         return field.isReadOnly()
                 && (JavassistUtil.containsMethod(declaring, methodName) ||
                     JavassistUtil.containsDeclaredMethod(declaring, methodName));
+    }
+
+    private boolean isObjectNullOrBlankString(Object obj) {
+        if (obj instanceof String) {
+            String str = (String) obj;
+            return StringUtils.isBlank(str);
+        } else {
+            return obj == null;
+        }
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityBuilderImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityBuilderImpl.java
@@ -357,7 +357,7 @@ public class EntityBuilderImpl implements EntityBuilder {
             }
         } else if (!type.isRelationship()) {
             initializer = JavassistBuilder.createInitializer(
-                    type.getTypeClass(), field.getBasic().getDisplayName()
+                    type.getTypeClass(), field.getBasic().getDefaultValue()
             );
         }
 

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderImpl.java
@@ -384,9 +384,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         SettingDto maxLengthSetting = field.getSetting(Constants.Settings.STRING_MAX_LENGTH);
         ColumnMetadata colMd = fmd.newColumnMetadata();
         // only set the metadata if the setting is different from default
-        // TODO: what's this about ??
-        if (maxLengthSetting != null // &&
-                /*!StringUtils.equals(maxLengthSetting.getValue(), maxLengthSetting.getDetails().getDefaultValue())*/) {
+        if (maxLengthSetting != null) {
             colMd.setLength(Integer.parseInt(maxLengthSetting.getValueAsString()));
         }
 

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderImpl.java
@@ -9,23 +9,23 @@ import org.motechproject.commons.date.model.Time;
 import org.motechproject.mds.builder.EntityMetadataBuilder;
 import org.motechproject.mds.domain.ClassData;
 import org.motechproject.mds.domain.ComboboxHolder;
-import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityType;
-import org.motechproject.mds.domain.Field;
-import org.motechproject.mds.domain.FieldSetting;
 import org.motechproject.mds.domain.RelationshipHolder;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.SchemaHolder;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.dto.SettingDto;
+import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.MdsException;
 import org.motechproject.mds.helper.ClassTableName;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.reflections.ReflectionsUtil;
-import org.motechproject.mds.repository.AllEntities;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.TypeHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +58,7 @@ import javax.jdo.metadata.MemberMetadata;
 import javax.jdo.metadata.PackageMetadata;
 import javax.jdo.metadata.ValueMetadata;
 import javax.jdo.metadata.VersionMetadata;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
@@ -94,10 +95,8 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
 
     private static final String ID_SUFFIX = "_ID";
 
-    private AllEntities allEntities;
-
     @Override
-    public void addEntityMetadata(JDOMetadata jdoMetadata, Entity entity, Class<?> definition) {
+    public void addEntityMetadata(JDOMetadata jdoMetadata, EntityDto entity, Class<?> definition, SchemaHolder schemaHolder) {
         String className = (entity.isDDE()) ? entity.getClassName() : ClassName.getEntityClassName(entity.getClassName());
         String packageName = ClassName.getPackage(className);
         String tableName = ClassTableName.getTableName(entity.getClassName(), entity.getModule(), entity.getNamespace(), entity.getTableName(), null);
@@ -113,17 +112,18 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         addInheritanceMetadata(cmd, definition);
 
         if (!entity.isSubClassOfMdsEntity() && !entity.isSubClassOfMdsVersionedEntity()) {
-            addIdField(cmd, entity);
+            addIdField(cmd, entity, schemaHolder);
             //we add versioning metadata only for Standard class.
             addVersioningMetadata(cmd, definition);
         }
 
-        addMetadataForFields(cmd, null, entity, EntityType.STANDARD, definition);
+        addMetadataForFields(cmd, null, entity, EntityType.STANDARD, definition, schemaHolder);
     }
 
     @Override
-    public void addHelperClassMetadata(JDOMetadata jdoMetadata, ClassData classData, Entity entity,
-                                       EntityType entityType, Class<?> definition) {
+    public void addHelperClassMetadata(JDOMetadata jdoMetadata, ClassData classData,
+                                       EntityDto entity, EntityType entityType, Class<?> definition,
+                                       SchemaHolder schemaHolder) {
         String packageName = ClassName.getPackage(classData.getClassName());
         String simpleName = ClassName.getSimpleName(classData.getClassName());
         String tableName = ClassTableName.getTableName(classData.getClassName(), classData.getModule(), classData.getNamespace(),
@@ -143,13 +143,13 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         addIdField(cmd, classData.getClassName());
 
         if (entity != null) {
-            addMetadataForFields(cmd, classData, entity, entityType, definition);
+            addMetadataForFields(cmd, classData, entity, entityType, definition, schemaHolder);
         }
     }
 
     @Override
     @Transactional
-    public void fixEnhancerIssuesInMetadata(JDOMetadata jdoMetadata) {
+    public void fixEnhancerIssuesInMetadata(JDOMetadata jdoMetadata, SchemaHolder schemaHolder) {
         for (PackageMetadata pmd : jdoMetadata.getPackages()) {
             for (ClassMetadata cmd : pmd.getClasses()) {
                 String className = String.format("%s.%s", pmd.getName(), cmd.getName());
@@ -157,12 +157,12 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
 
                 if (entityType == EntityType.STANDARD) {
 
-                    Entity entity = allEntities.retrieveByClassName(className);
+                    EntityDto entity = schemaHolder.getEntityByClassName(className);
 
                     if (null != entity) {
                         for (MemberMetadata mmd : cmd.getMembers()) {
                             CollectionMetadata collMd = mmd.getCollectionMetadata();
-                            Field field = entity.getField(mmd.getName());
+                            FieldDto field = schemaHolder.getFieldByName(entity, mmd.getName());
 
                             if (null != collMd) {
                                 fixCollectionMetadata(collMd, field);
@@ -183,7 +183,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
 
     @Override
     public void addBaseMetadata(JDOMetadata jdoMetadata, ClassData classData, EntityType entityType, Class<?> definition) {
-        addHelperClassMetadata(jdoMetadata, classData, null, entityType, definition);
+        addHelperClassMetadata(jdoMetadata, classData, null, entityType, definition, null);
     }
 
     private void addVersioningMetadata(ClassMetadata cmd, Class<?> definition) {
@@ -203,7 +203,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
     }
 
 
-    private void fixCollectionMetadata(CollectionMetadata collMd, Field field) {
+    private void fixCollectionMetadata(CollectionMetadata collMd, FieldDto field) {
         String elementType = collMd.getElementType();
         RelationshipHolder holder = new RelationshipHolder(field);
 
@@ -215,7 +215,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
     }
 
-    private void fixRelationMetadata(PackageMetadata pmd, Field field) {
+    private void fixRelationMetadata(PackageMetadata pmd, FieldDto field) {
         RelationshipHolder holder = new RelationshipHolder(field);
 
         //for bidirectional 1:1 and 1:N relationship we're letting RDBMS take care of cascade deletion
@@ -271,25 +271,27 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
     }
 
-    private void addMetadataForFields(ClassMetadata cmd, ClassData classData, Entity entity, EntityType entityType,
-                                      Class<?> definition) {
-        for (Field field : entity.getFields()) {
+    private void addMetadataForFields(ClassMetadata cmd, ClassData classData, EntityDto entity,
+                                      EntityType entityType, Class<?> definition, SchemaHolder schemaHolder) {
+        List<FieldDto> fields = schemaHolder.getFields(entity);
+
+        for (FieldDto field : fields) {
             if (field.isVersionField() && entityType != EntityType.STANDARD) {
                 continue;
             }
 
             String fieldName = getNameForMetadata(field);
-            processField(cmd, classData, entity, entityType, definition, fieldName, field);
+            processField(cmd, classData, entity, entityType, definition, fieldName, field, schemaHolder);
         }
     }
 
-    public void processField(ClassMetadata cmd, ClassData classData, Entity entity, EntityType entityType,
-                             Class<?> definition, String fieldName, Field field) {
+    public void processField(ClassMetadata cmd, ClassData classData, EntityDto entity, EntityType entityType,
+                             Class<?> definition, String fieldName, FieldDto field, SchemaHolder schemaHolder) {
         // Metadata for ID field has been added earlier in addIdField() method
         if (!fieldName.equals(ID_FIELD_NAME)) {
             FieldMetadata fmd = null;
 
-            if (isFieldNotInherited(fieldName, entity)) {
+            if (isFieldNotInherited(fieldName, entity, schemaHolder)) {
                 fmd = setFieldMetadata(cmd, classData, entity, entityType, field, definition);
             }
             // when field is in Lookup, we set field metadata indexed to retrieve instance faster
@@ -308,41 +310,40 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
     }
 
-    private boolean isFieldRequired(Field field, EntityType entityType) {
-        return field.isRequired() && !(entityType.equals(EntityType.TRASH) && field.getType().isRelationship());
+    private boolean isFieldRequired(FieldDto field, EntityType entityType) {
+        return field.getBasic().isRequired() && !(entityType.equals(EntityType.TRASH) && field.getType().isRelationship());
     }
 
-    private boolean isFieldNotInherited(String fieldName, Entity entity) {
+    private boolean isFieldNotInherited(String fieldName, EntityDto entity, SchemaHolder schemaHolder) {
         if ((entity.isSubClassOfMdsEntity() || entity.isSubClassOfMdsVersionedEntity()) && (ArrayUtils.contains(FIELD_VALUE_GENERATOR, fieldName))
                 || isVersionFieldFromMdsVersionedEntity(entity, fieldName)) {
             return false;
         } else {
             // return false if it is inherited field from superclass
-            return entity.isBaseEntity() || !isFieldFromSuperClass(entity.getSuperClass(), fieldName);
+            return entity.isBaseEntity() || !isFieldFromSuperClass(entity.getSuperClass(), fieldName, schemaHolder);
         }
     }
 
-    private boolean isVersionFieldFromMdsVersionedEntity(Entity entity, String fieldName) {
+    private boolean isVersionFieldFromMdsVersionedEntity(EntityDto entity, String fieldName) {
         return entity.isSubClassOfMdsVersionedEntity() && INSTANCE_VERSION_FIELD_NAME.equals(fieldName);
     }
-    private boolean isFieldFromSuperClass(String className, String fieldName) {
-        Entity entity = allEntities.retrieveByClassName(className);
-        return entity.getField(fieldName) != null;
+    private boolean isFieldFromSuperClass(String className, String fieldName, SchemaHolder schemaHolder) {
+        return schemaHolder.getFieldByName(className, fieldName) != null;
     }
 
-    private FieldMetadata setFieldMetadata(ClassMetadata cmd, ClassData classData, Entity entity,
-                                           EntityType entityType, Field field, Class<?> definition) {
+    private FieldMetadata setFieldMetadata(ClassMetadata cmd, ClassData classData, EntityDto entity,
+                                           EntityType entityType, FieldDto field, Class<?> definition) {
         String name = getNameForMetadata(field);
 
-        Type type = field.getType();
-        Class<?> typeClass = type.getTypeClass();
+        TypeDto type = field.getType();
+        Class<?> typeClass = type.getClassObjectForType();
 
         if (ArrayUtils.contains(FIELD_VALUE_GENERATOR, name)) {
             return setAutoGenerationMetadata(cmd, name);
         } else if (type.isCombobox()) {
             return setComboboxMetadata(cmd, entity, field, definition);
         } else if (type.isRelationship()) {
-            return setRelationshipMetadata(cmd, classData, field, entityType, definition);
+            return setRelationshipMetadata(cmd, classData, entity, field, entityType, definition);
         } else if (Map.class.isAssignableFrom(typeClass)) {
             return setMapMetadata(cmd, field, definition);
         } else if (Time.class.isAssignableFrom(typeClass)) {
@@ -365,32 +366,33 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return fmd;
     }
 
-    private void setColumnParameters(FieldMetadata fmd, Field field, Class<?> definition) {
+    private void setColumnParameters(FieldMetadata fmd, FieldDto field, Class<?> definition) {
         Value valueAnnotation = null;
-        java.lang.reflect.Field fieldDefinition = FieldUtils.getDeclaredField(definition, field.getName(), true);
+        java.lang.reflect.Field fieldDefinition = FieldUtils.getDeclaredField(definition, field.getBasic().getName(), true);
         //@Value in datanucleus is used with maps.
-        if (fieldDefinition != null && java.util.Map.class.isAssignableFrom(field.getType().getTypeClass())) {
+        if (fieldDefinition != null && java.util.Map.class.isAssignableFrom(field.getType().getClassObjectForType())) {
             valueAnnotation = ReflectionsUtil.getAnnotationSelfOrAccessor(fieldDefinition, Value.class);
         }
 
-        if ((field.getMetadata(DATABASE_COLUMN_NAME) != null || field.getSettingByName(Constants.Settings.STRING_MAX_LENGTH) != null
-                || field.getSettingByName(Constants.Settings.STRING_TEXT_AREA) != null) || (valueAnnotation != null)) {
+        if ((field.getMetadata(DATABASE_COLUMN_NAME) != null || field.getSetting(Constants.Settings.STRING_MAX_LENGTH) != null
+                || field.getSetting(Constants.Settings.STRING_TEXT_AREA) != null) || (valueAnnotation != null)) {
             addColumnMetadata(fmd, field, valueAnnotation);
         }
     }
 
-    private void addColumnMetadata(FieldMetadata fmd, Field field, Value valueAnnotation) {
-        FieldSetting maxLengthSetting = field.getSettingByName(Constants.Settings.STRING_MAX_LENGTH);
+    private void addColumnMetadata(FieldMetadata fmd, FieldDto field, Value valueAnnotation) {
+        SettingDto maxLengthSetting = field.getSetting(Constants.Settings.STRING_MAX_LENGTH);
         ColumnMetadata colMd = fmd.newColumnMetadata();
         // only set the metadata if the setting is different from default
-        if (maxLengthSetting != null && !StringUtils.equals(maxLengthSetting.getValue(),
-                maxLengthSetting.getDetails().getDefaultValue())) {
-            colMd.setLength(Integer.parseInt(maxLengthSetting.getValue()));
+        // TODO: what's this about ??
+        if (maxLengthSetting != null // &&
+                /*!StringUtils.equals(maxLengthSetting.getValue(), maxLengthSetting.getDetails().getDefaultValue())*/) {
+            colMd.setLength(Integer.parseInt(maxLengthSetting.getValueAsString()));
         }
 
         // if TextArea then change length
-        if (field.getSettingByName(Constants.Settings.STRING_TEXT_AREA) != null &&
-                "true".equalsIgnoreCase(field.getSettingByName(Constants.Settings.STRING_TEXT_AREA).getValue())) {
+        if (field.getSetting(Constants.Settings.STRING_TEXT_AREA) != null &&
+                "true".equalsIgnoreCase(field.getSetting(Constants.Settings.STRING_TEXT_AREA).getValueAsString())) {
             fmd.setIndexed(false);
             colMd.setSQLType("CLOB");
         }
@@ -427,11 +429,11 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return fmd;
     }
 
-    private FieldMetadata setMapMetadata(ClassMetadata cmd, Field field, Class<?> definition) {
+    private FieldMetadata setMapMetadata(ClassMetadata cmd, FieldDto field, Class<?> definition) {
         FieldMetadata fmd = cmd.newFieldMetadata(getNameForMetadata(field));
 
-        org.motechproject.mds.domain.FieldMetadata keyMetadata = field.getMetadata(MAP_KEY_TYPE);
-        org.motechproject.mds.domain.FieldMetadata valueMetadata = field.getMetadata(MAP_VALUE_TYPE);
+        MetadataDto keyMetadata = field.getMetadata(MAP_KEY_TYPE);
+        MetadataDto valueMetadata = field.getMetadata(MAP_VALUE_TYPE);
 
         boolean serialized = shouldSerializeMap(keyMetadata, valueMetadata);
 
@@ -457,16 +459,16 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return fmd;
     }
 
-    private boolean shouldSerializeMap(org.motechproject.mds.domain.FieldMetadata keyMetadata,
-                                       org.motechproject.mds.domain.FieldMetadata valueMetadata) {
+    private boolean shouldSerializeMap(MetadataDto keyMetadata, MetadataDto valueMetadata) {
         // If generics types of map are not supported in MDS, we serialized the field in DB.
         return keyMetadata == null || valueMetadata == null ||
                 ! (TypeHelper.isTypeSupportedInMap(keyMetadata.getValue(), true) &&
                         TypeHelper.isTypeSupportedInMap(valueMetadata.getValue(), false));
     }
 
-    private FieldMetadata setRelationshipMetadata(ClassMetadata cmd, ClassData classData, Field field,
-                                         EntityType entityType, Class<?> definition) {
+    private FieldMetadata setRelationshipMetadata(ClassMetadata cmd, ClassData classData,
+                                                  EntityDto entity, FieldDto field,
+                                                  EntityType entityType, Class<?> definition) {
 
         RelationshipHolder holder = new RelationshipHolder(classData, field);
         FieldMetadata fmd = cmd.newFieldMetadata(getNameForMetadata(field));
@@ -474,7 +476,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         addDefaultFetchGroupMetadata(fmd, definition);
 
         if (entityType == EntityType.STANDARD) {
-            processRelationship(fmd, holder, field, definition);
+            processRelationship(fmd, holder, entity, field, definition);
         } else {
             processHistoryTrashRelationship(cmd, fmd, holder);
         }
@@ -482,7 +484,9 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return fmd;
     }
 
-    private void processRelationship(FieldMetadata fmd, RelationshipHolder holder, Field field, Class<?> definition) {
+    private void processRelationship(FieldMetadata fmd, RelationshipHolder holder,
+                                     EntityDto entity, FieldDto field,
+                                     Class<?> definition) {
         String relatedClass = holder.getRelatedClass();
 
         fmd.newExtensionMetadata(DATANUCLEUS, "cascade-persist", holder.isCascadePersist() ? TRUE : FALSE);
@@ -500,7 +504,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
 
         if (holder.isManyToMany()) {
-            addManyToManyMetadata(fmd, holder, field, definition);
+            addManyToManyMetadata(fmd, holder, entity, field, definition);
         }
     }
 
@@ -522,8 +526,9 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
     }
 
-    private void addManyToManyMetadata(FieldMetadata fmd, RelationshipHolder holder, Field field, Class<?> definition) {
-        java.lang.reflect.Field fieldDefinition = FieldUtils.getDeclaredField(definition, field.getName(), true);
+    private void addManyToManyMetadata(FieldMetadata fmd, RelationshipHolder holder, EntityDto entity, FieldDto field,
+                                       Class<?> definition) {
+        java.lang.reflect.Field fieldDefinition = FieldUtils.getDeclaredField(definition, field.getBasic().getName(), true);
         Join join = fieldDefinition.getAnnotation(Join.class);
 
         // If tables and column names have been specified in annotations, do not set their metadata
@@ -539,11 +544,11 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
             Persistent persistent = fieldDefinition.getAnnotation(Persistent.class);
             Element element = fieldDefinition.getAnnotation(Element.class);
 
-            setTableNameMetadata(fmd, persistent, field, holder, EntityType.STANDARD);
+            setTableNameMetadata(fmd, persistent, entity, field, holder, EntityType.STANDARD);
             setElementMetadata(fmd, element, holder);
 
             if (join == null || StringUtils.isEmpty(join.column())) {
-                setJoinMetadata(jmd, fmd, ClassName.getSimpleName(field.getEntity().getClassName()).toUpperCase() + ID_SUFFIX);
+                setJoinMetadata(jmd, fmd, ClassName.getSimpleName(entity.getClassName()).toUpperCase() + ID_SUFFIX);
            }
         }
     }
@@ -568,11 +573,13 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         joinMetadata.newColumnMetadata().setName(column);
     }
 
-    private void setTableNameMetadata(FieldMetadata fmd, Persistent persistent, Field field, RelationshipHolder holder, EntityType entityType) {
+    private void setTableNameMetadata(FieldMetadata fmd, Persistent persistent, EntityDto entity, FieldDto field,
+                                      RelationshipHolder holder, EntityType entityType) {
         if (persistent != null && StringUtils.isNotEmpty(persistent.table()) && entityType != EntityType.STANDARD) {
             fmd.setTable(entityType.getTableName(persistent.table()));
         } else if (persistent == null || StringUtils.isEmpty(persistent.table())) {
-            fmd.setTable(getJoinTableName(field.getEntity().getModule(), field.getEntity().getNamespace(), field.getName(), holder.getRelatedField()));
+            fmd.setTable(getJoinTableName(entity.getModule(), entity.getNamespace(), field.getBasic().getName(),
+                    holder.getRelatedField()));
         }
     }
 
@@ -592,7 +599,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         }
     }
 
-    private FieldMetadata setComboboxMetadata(ClassMetadata cmd, Entity entity, Field field, Class<?> definition) {
+    private FieldMetadata setComboboxMetadata(ClassMetadata cmd, EntityDto entity, FieldDto field, Class<?> definition) {
         ComboboxHolder holder = new ComboboxHolder(entity, field);
         String fieldName = getNameForMetadata(field);
         FieldMetadata fmd = cmd.newFieldMetadata(fieldName);
@@ -644,8 +651,8 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return jdoMetadata.newPackageMetadata(packageName);
     }
 
-    private void addIdField(ClassMetadata cmd, Entity entity) {
-        boolean containsID = null != entity.getField(ID_FIELD_NAME);
+    private void addIdField(ClassMetadata cmd, EntityDto entity, SchemaHolder schemaHolder) {
+        boolean containsID = null != schemaHolder.getFieldByName(entity, ID_FIELD_NAME);
         boolean isBaseClass = entity.isBaseEntity();
 
         if (containsID && isBaseClass) {
@@ -712,12 +719,7 @@ public class EntityMetadataBuilderImpl implements EntityMetadataBuilder {
         return false;
     }
 
-    private String getNameForMetadata(Field field) {
-        return StringUtils.uncapitalize(field.getName());
-    }
-
-    @Autowired
-    public void setAllEntities(AllEntities allEntities) {
-        this.allEntities = allEntities;
+    private String getNameForMetadata(FieldDto field) {
+        return StringUtils.uncapitalize(field.getBasic().getName());
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/LookupBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/LookupBuilder.java
@@ -80,7 +80,8 @@ class LookupBuilder {
             String fieldName = fieldOrder.get(i);
 
             FieldDto field = getLookupField(fieldName);
-            LookupFieldDto lookupField = lookup.getLookupField(fieldName);
+            // don't use fieldName for fetching fields, as it can contain dots, etc.
+            LookupFieldDto lookupField = lookup.getLookupField(field.getBasic().getName());
 
             FieldDto relationField = null;
             EntityDto relatedEntity = null;
@@ -132,7 +133,8 @@ class LookupBuilder {
             boolean appendJdoVariableName = false;
 
             FieldDto field = getLookupField(lookupFieldName);
-            LookupFieldDto lookupField = lookup.getLookupField(lookupFieldName);
+            // don't use lookupFieldName for fetching fields, as it can contain dots, etc.
+            LookupFieldDto lookupField = lookup.getLookupField(field.getBasic().getName());
 
             FieldDto relationField = null;
 
@@ -346,7 +348,8 @@ class LookupBuilder {
             String fieldName = fieldsOrder.get(i);
 
             FieldDto field = getLookupField(fieldName);
-            LookupFieldDto lookupField = lookup.getLookupField(fieldName);
+            // don't use fieldName for fetching fields, as it can contain dots, etc.
+            LookupFieldDto lookupField = lookup.getLookupField(field.getBasic().getName());
 
             FieldDto relationField = null;
             EntityDto relatedEntity = null;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/LookupBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/LookupBuilder.java
@@ -8,17 +8,18 @@ import javassist.NotFoundException;
 import org.apache.commons.lang.StringUtils;
 import org.motechproject.commons.api.Range;
 import org.motechproject.mds.domain.ComboboxHolder;
-import org.motechproject.mds.domain.Entity;
-import org.motechproject.mds.domain.Field;
-import org.motechproject.mds.domain.Lookup;
 import org.motechproject.mds.domain.RelationshipHolder;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.LookupDto;
+import org.motechproject.mds.dto.LookupFieldDto;
+import org.motechproject.mds.dto.LookupFieldType;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TypeDto;
-import org.motechproject.mds.repository.AllEntities;
-import org.motechproject.mds.util.JavassistUtil;
 import org.motechproject.mds.query.CollectionProperty;
 import org.motechproject.mds.query.PropertyBuilder;
 import org.motechproject.mds.query.QueryParams;
+import org.motechproject.mds.util.JavassistUtil;
 import org.motechproject.mds.util.LookupName;
 import org.motechproject.mds.util.TypeHelper;
 
@@ -26,8 +27,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import static org.motechproject.mds.builder.impl.LookupType.COUNT;
 import static org.motechproject.mds.builder.impl.LookupType.SIMPLE;
@@ -40,23 +42,26 @@ import static org.motechproject.mds.builder.impl.LookupType.WITH_QUERY_PARAMS;
  */
 class LookupBuilder {
     private String className;
-    private Lookup lookup;
+    private EntityDto entity;
+    private LookupDto lookup;
     private String lookupName;
     private CtClass definition;
     private LookupType lookupType;
-    private AllEntities allEntities;
+    private SchemaHolder schemaHolder;
 
-    LookupBuilder(Entity entity, Lookup lookup, CtClass definition,
-                  LookupType lookupType, AllEntities allEntities) {
+    LookupBuilder(EntityDto entity, LookupDto lookup, CtClass definition,
+                  LookupType lookupType, SchemaHolder schemaHolder) {
         this.definition = definition;
-        this.allEntities = allEntities;
         this.className = entity.getClassName();
+        this.entity = entity;
 
         this.lookup = lookup;
         this.lookupType = lookupType;
         this.lookupName = (lookupType == COUNT)
                 ? LookupName.lookupCountMethod(lookup.getMethodName())
                 : lookup.getMethodName();
+
+        this.schemaHolder = schemaHolder;
     }
 
     CtMethod buildSignature() throws CannotCompileException, NotFoundException {
@@ -72,13 +77,25 @@ class LookupBuilder {
         List<String> fieldOrder = lookup.getFieldsOrder();
 
         for (int i = 0; i < fieldOrder.size(); i++) {
-            Field field = lookup.getLookupFieldByName(LookupName.getFieldName(fieldOrder.get(i)));
-            Field relationField = null;
+            String fieldName = fieldOrder.get(i);
+
+            FieldDto field = getLookupField(fieldName);
+            LookupFieldDto lookupField = lookup.getLookupField(fieldName);
+
+            FieldDto relationField = null;
+            EntityDto relatedEntity = null;
             if (fieldOrder.get(i).contains(".")) {
-                Entity relatedEntity = allEntities.retrieveByClassName(new RelationshipHolder(field).getRelatedClass());
-                relationField = relatedEntity.getField(LookupName.getRelatedFieldName(fieldOrder.get(i)));
+                relatedEntity = schemaHolder.getEntityByClassName(
+                        new RelationshipHolder(field).getRelatedClass());
+
+                relationField = schemaHolder.getFieldByName(relatedEntity,
+                        LookupName.getRelatedFieldName(fieldOrder.get(i)));
             }
-            String type = getTypeForParam(i, relationField == null ? field : relationField, fieldOrder.get(i));
+
+            String type = getTypeForParam(i,
+                    resolveEntity(entity, relatedEntity),
+                    resolveField(field, relationField),
+                    lookupField);
 
             String param = String.format("%s %s", type, fieldOrder.get(i).replace(".", ""));
             paramCollection.add(param);
@@ -113,31 +130,42 @@ class LookupBuilder {
         Map<String, String> jdoQueryVariables = new HashMap<>();
         for (String lookupFieldName : lookup.getFieldsOrder()) {
             boolean appendJdoVariableName = false;
-            Field field = lookup.getLookupFieldByName(LookupName.getFieldName(lookupFieldName));
-            Field relationField = null;
+
+            FieldDto field = getLookupField(lookupFieldName);
+            LookupFieldDto lookupField = lookup.getLookupField(lookupFieldName);
+
+            FieldDto relationField = null;
+
 
             if (lookupFieldName.contains(".")) {
-                Entity relatedEntity = allEntities.retrieveByClassName(new RelationshipHolder(field).getRelatedClass());
-                relationField = relatedEntity.getField(LookupName.getRelatedFieldName(lookupFieldName));
+                EntityDto relatedEntity = schemaHolder.getEntityByClassName(
+                        new RelationshipHolder(field).getRelatedClass());
+
+                relationField = schemaHolder.getFieldByName(relatedEntity,
+                        LookupName.getRelatedFieldName(lookupFieldName));
             }
 
-            Type type = field.getType();
+            TypeDto type = field.getType();
             String typeClassName = resolveClassName(type, relationField);
 
             body.append("properties.add(");
 
             if (type.isCombobox()) {
-                ComboboxHolder holder = new ComboboxHolder(field);
+                ComboboxHolder holder = new ComboboxHolder(entity, field);
                 typeClassName = holder.getUnderlyingType();
                 body.append(resolvePropertyForCombobox(holder, type));
             } else if (relationField != null && relationField.getType().isCombobox()) {
-                ComboboxHolder holder = new ComboboxHolder(relationField);
+                RelationshipHolder relationshipHolder = new RelationshipHolder(field);
+                EntityDto relatedEntity = schemaHolder.getEntityByClassName(relationshipHolder.getRelatedClass());
+
+                ComboboxHolder holder = new ComboboxHolder(relatedEntity, relationField);
+
                 typeClassName = holder.getUnderlyingType();
                 body.append(resolvePropertyForCombobox(holder, type));
                 addJdoVariableName(jdoQueryVariables, lookupFieldName);
                 appendJdoVariableName = needsJdoVariable(type);
-            } else if (relationField != null && (type.getTypeClassName().equals(TypeDto.MANY_TO_MANY_RELATIONSHIP.getTypeClass())
-                    || type.getTypeClassName().equals(TypeDto.ONE_TO_MANY_RELATIONSHIP.getTypeClass()))) {
+            } else if (relationField != null && (type.getTypeClass().equals(TypeDto.MANY_TO_MANY_RELATIONSHIP.getTypeClass())
+                    || type.getTypeClass().equals(TypeDto.ONE_TO_MANY_RELATIONSHIP.getTypeClass()))) {
                 //related class collection
                 body.append(PropertyBuilder.class.getName());
                 body.append(".createRelationProperty");
@@ -148,7 +176,8 @@ class LookupBuilder {
                 body.append(".create");
             }
 
-            body.append(buildPropertyParameters(appendJdoVariableName, lookupFieldName, typeClassName, jdoQueryVariables));
+            body.append(buildPropertyParameters(appendJdoVariableName, lookupFieldName, lookupField,
+                    typeClassName, jdoQueryVariables));
         }
         body.append(buildReturn());
         return body.toString();
@@ -160,11 +189,13 @@ class LookupBuilder {
         }
     }
 
-    private String resolveClassName(Type type, Field relationField) {
-        return relationField == null ? type.getTypeClassName() : relationField.getType().getTypeClassName();
+    private String resolveClassName(TypeDto type, FieldDto relationField) {
+        return relationField == null ? type.getTypeClass() : relationField.getType().getTypeClass();
     }
 
-    private String buildPropertyParameters(boolean appendJdoVariableName, String lookupFieldName, String typeClassName, Map<String, String> jdoQueryVariables) {
+    private String buildPropertyParameters(boolean appendJdoVariableName, String lookupFieldName,
+                                           LookupFieldDto lookupField, String typeClassName,
+                                           Map<String, String> jdoQueryVariables) {
         StringBuilder sb = new StringBuilder();
         sb.append("(\""); // open constructor or create method
         if (appendJdoVariableName) {
@@ -178,7 +209,7 @@ class LookupBuilder {
         sb.append(", \"").append(typeClassName).append('\"');
 
         // append a custom operator for the lookup field, if defined
-        String customOperator = lookup.getCustomOperators().get(lookupFieldName);
+        String customOperator = lookupField.getCustomOperator();
         if (StringUtils.isNotBlank(customOperator)) {
             sb.append(",\"").append(customOperator).append('"');
         }
@@ -189,7 +220,7 @@ class LookupBuilder {
         return sb.toString();
     }
 
-    private String resolvePropertyForCombobox(ComboboxHolder holder, Type type) {
+    private String resolvePropertyForCombobox(ComboboxHolder holder, TypeDto type) {
         StringBuilder sb = new StringBuilder();
         if (holder.isCollection()) {
             if (needsJdoVariable(type)) {
@@ -211,9 +242,9 @@ class LookupBuilder {
         return sb.toString();
     }
 
-    private boolean needsJdoVariable(Type type) {
-        return (type.getTypeClassName().equals(TypeDto.MANY_TO_MANY_RELATIONSHIP.getTypeClass())
-                || type.getTypeClassName().equals(TypeDto.ONE_TO_MANY_RELATIONSHIP.getTypeClass()));
+    private boolean needsJdoVariable(TypeDto type) {
+        return (type.getTypeClass().equals(TypeDto.MANY_TO_MANY_RELATIONSHIP.getTypeClass())
+                || type.getTypeClass().equals(TypeDto.ONE_TO_MANY_RELATIONSHIP.getTypeClass()));
     }
 
     private String buildReturn() {
@@ -237,7 +268,7 @@ class LookupBuilder {
             sb.append(");");
 
             if (lookup.isSingleObjectReturn()) {
-                sb.append("return (" + className + ") result;");
+                sb.append("return (").append(className).append(") result;");
             } else {
                 sb.append("return list;");
             }
@@ -260,11 +291,12 @@ class LookupBuilder {
         }
     }
 
-    private String getTypeForParam(int idx, Field field, String lookupFieldName) throws NotFoundException {
+    private String getTypeForParam(int idx, EntityDto targetEntity, FieldDto field, LookupFieldDto lookupFieldDto)
+            throws NotFoundException {
         // firstly we check if field is Range or Set
-        if (lookup.isRangeParam(lookupFieldName)) {
+        if (lookupFieldDto.getType() == LookupFieldType.RANGE) {
             return Range.class.getName();
-        } else if (lookup.isSetParam(lookupFieldName)) {
+        } else if (lookupFieldDto.getType() == LookupFieldType.SET) {
             return Set.class.getName();
         }
         // we try to copy type param from existing method signature...
@@ -275,22 +307,22 @@ class LookupBuilder {
         // .. if method with type param on idx position does not exist then we will return
         // type based on field type
         if (field.getType().isCombobox()) {
-            ComboboxHolder holder = new ComboboxHolder(field);
+            ComboboxHolder holder = new ComboboxHolder(targetEntity, field);
 
             return holder.getTypeClassName();
         } else {
-            return field.getType().getTypeClassName();
+            return field.getType().getTypeClass();
         }
     }
 
-    private String copyParamTypeFromMethod(int idx, Field field) throws NotFoundException {
+    private String copyParamTypeFromMethod(int idx, FieldDto field) throws NotFoundException {
         for (CtMethod method : definition.getMethods()) {
             if (method.getName().equalsIgnoreCase(lookupName) ||
                     LookupName.lookupCountMethod(method.getName()).equalsIgnoreCase(lookupName)) {
                 CtClass[] types = method.getParameterTypes();
 
                 if (types.length > idx) {
-                    if (lookup.isReadOnly() || types[idx].getName() == field.getType().getTypeClassName()) {
+                    if (lookup.isReadOnly() || Objects.equals(types[idx].getName(), field.getType().getTypeClass())) {
                         return types[idx].getName();
                     }
                 }
@@ -311,24 +343,38 @@ class LookupBuilder {
 
         List<String> fieldsOrder = lookup.getFieldsOrder();
         for (int i = 0; i < fieldsOrder.size(); ++i) {
-            Field field = lookup.getLookupFieldByName(LookupName.getFieldName(fieldsOrder.get(i)));
+            String fieldName = fieldsOrder.get(i);
 
-            Field relationField = null;
+            FieldDto field = getLookupField(fieldName);
+            LookupFieldDto lookupField = lookup.getLookupField(fieldName);
+
+            FieldDto relationField = null;
+            EntityDto relatedEntity = null;
             if (fieldsOrder.get(i).contains(".")) {
-                Entity relatedEntity = allEntities.retrieveByClassName(new RelationshipHolder(field).getRelatedClass());
-                relationField = relatedEntity.getField(LookupName.getRelatedFieldName(fieldsOrder.get(i)));
+                relatedEntity = schemaHolder.getEntityByClassName(
+                        new RelationshipHolder(field).getRelatedClass());
+
+                relationField = schemaHolder.getFieldByName(relatedEntity,
+                        LookupName.getRelatedFieldName(fieldsOrder.get(i)));
             }
 
-            String paramType = getTypeForParam(i, resolveField(field, relationField), fieldsOrder.get(i));
+            String paramType = getTypeForParam(i,
+                    resolveEntity(entity, relatedEntity),
+                    resolveField(field, relationField),
+                    lookupField);
             String genericType;
 
-            Type type = resolveField(field, relationField).getType();
+            TypeDto type = resolveField(field, relationField).getType();
 
             if (type.isCombobox()) {
-                ComboboxHolder holder = new ComboboxHolder(resolveField(field, relationField));
+                ComboboxHolder holder = new ComboboxHolder(
+                        resolveEntity(entity, relatedEntity),
+                        resolveField(field, relationField)
+                );
+
                 genericType = holder.getUnderlyingType();
             } else {
-                genericType = type.getTypeClassName();
+                genericType = type.getTypeClass();
             }
 
             if (StringUtils.equals(paramType, genericType) || TypeHelper.isPrimitive(paramType)) {
@@ -350,8 +396,15 @@ class LookupBuilder {
         return sb.toString();
     }
 
-    private Field resolveField(Field field, Field relationField) {
+    private EntityDto resolveEntity(EntityDto entity, EntityDto relatedEntity) {
+        return relatedEntity == null ? entity : relatedEntity;
+    }
+
+    private FieldDto resolveField(FieldDto field, FieldDto relationField) {
         return relationField == null ? field : relationField;
     }
 
+    private FieldDto getLookupField(String name) {
+        return schemaHolder.getFieldByName(className, LookupName.getFieldName(name));
+    }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSConstructorImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSConstructorImpl.java
@@ -16,9 +16,9 @@ import org.motechproject.mds.domain.ClassData;
 import org.motechproject.mds.domain.ComboboxHolder;
 import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityType;
-import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.enhancer.MdsJDOEnhancer;
 import org.motechproject.mds.ex.entity.EntityCreationException;
@@ -27,7 +27,6 @@ import org.motechproject.mds.helper.EntitySorter;
 import org.motechproject.mds.helper.MdsBundleHelper;
 import org.motechproject.mds.javassist.JavassistLoader;
 import org.motechproject.mds.javassist.MotechClassPool;
-import org.motechproject.mds.repository.AllEntities;
 import org.motechproject.mds.repository.MetadataHolder;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
@@ -66,9 +65,6 @@ import java.util.Properties;
 public class MDSConstructorImpl implements MDSConstructor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MDSConstructorImpl.class);
-
-    @Autowired
-    private AllEntities allEntities;
 
     private MdsConfig mdsConfig;
     private EntityBuilder entityBuilder;
@@ -302,9 +298,7 @@ public class MDSConstructorImpl implements MDSConstructor {
 
     @Override
     @Transactional
-    public void updateFields(Long entityId, Map<String, String> fieldNameChanges) {
-        Entity entity = allEntities.retrieveById(entityId);
-
+    public void updateFields(Entity entity, Map<String, String> fieldNameChanges) {
         for (String key : fieldNameChanges.keySet()) {
             String tableName = ClassTableName.getTableName(entity.getClassName(), entity.getModule(), entity.getNamespace(), entity.getTableName(), null);
             updateFieldName(key, fieldNameChanges.get(key), tableName);

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSConstructorImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSConstructorImpl.java
@@ -67,7 +67,6 @@ public class MDSConstructorImpl implements MDSConstructor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MDSConstructorImpl.class);
 
-    // TODO: stays or goes?
     @Autowired
     private AllEntities allEntities;
 

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSDataProviderBuilderImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/builder/impl/MDSDataProviderBuilderImpl.java
@@ -2,8 +2,7 @@ package org.motechproject.mds.builder.impl;
 
 import org.apache.velocity.app.VelocityEngine;
 import org.motechproject.mds.builder.MDSDataProviderBuilder;
-import org.motechproject.mds.service.EntityService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.velocity.VelocityEngineUtils;
 
@@ -20,13 +19,12 @@ public class MDSDataProviderBuilderImpl implements MDSDataProviderBuilder {
 
     private static final String MDS_TASK_DATA_PROVIDER = "/velocity/templates/task-data-provider.vm";
 
-    private EntityService entityService;
     private VelocityEngine velocityEngine;
 
     @Override
-    public String generateDataProvider() {
+    public String generateDataProvider(SchemaHolder schemaHolder) {
         Map<String, Object> model = new HashMap<>();
-        model.put("service", entityService);
+        model.put("schema", schemaHolder);
         StringWriter writer = new StringWriter();
 
         VelocityEngineUtils.mergeTemplate(velocityEngine, MDS_TASK_DATA_PROVIDER, model, writer);
@@ -34,17 +32,8 @@ public class MDSDataProviderBuilderImpl implements MDSDataProviderBuilder {
         return writer.toString();
     }
 
-    @Autowired
-    public void setEntityService(EntityService entityService) {
-        this.entityService = entityService;
-    }
-
     @Resource(name = "mdsVelocityEngine")
     public void setVelocityEngine(VelocityEngine velocityEngine) {
         this.velocityEngine = velocityEngine;
-    }
-
-    public EntityService getEntityService() {
-        return entityService;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ClassData.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ClassData.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.domain;
 
 import org.apache.commons.lang.StringUtils;
+import org.motechproject.mds.dto.EntityDto;
 
 import java.util.Arrays;
 
@@ -26,6 +27,10 @@ public class ClassData {
 
     public ClassData(Entity entity, byte[] bytecode) {
         this(entity, bytecode, false);
+    }
+
+    public ClassData(EntityDto entity, byte[] bytecode) {
+        this(entity.getClassName(), entity.getModule(), entity.getNamespace(), bytecode);
     }
 
     public ClassData(Entity entity, byte[] bytecode, boolean interfaceClass) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Entity.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Entity.java
@@ -12,6 +12,7 @@ import org.motechproject.mds.dto.TrackingDto;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.LookupName;
 import org.motechproject.mds.util.SecurityMode;
+import org.motechproject.mds.util.TypeHelper;
 import org.motechproject.mds.util.ValidationUtil;
 
 import javax.jdo.annotations.Discriminator;
@@ -324,12 +325,14 @@ public class Entity {
         this.superClass = superClass;
     }
 
+    @NotPersistent
     public boolean isSubClassOfMdsEntity () {
-        return MdsEntity.class.getName().equalsIgnoreCase(getSuperClass()) || MdsVersionedEntity.class.getName().equalsIgnoreCase(getSuperClass());
+        return TypeHelper.isSubclassOfMdsEntity(getSuperClass());
     }
 
+    @NotPersistent
     public boolean isSubClassOfMdsVersionedEntity () {
-        return MdsVersionedEntity.class.getName().equalsIgnoreCase(getSuperClass());
+        return TypeHelper.isSubclassOfMdsVersionedEntity(getSuperClass());
     }
 
     public boolean isAbstractClass() {
@@ -358,9 +361,7 @@ public class Entity {
 
     @NotPersistent
     public boolean isBaseEntity() {
-        return Object.class.getName().equalsIgnoreCase(getSuperClass()) ||
-                MdsEntity.class.getName().equalsIgnoreCase(getSuperClass()) ||
-                MdsVersionedEntity.class.getName().equalsIgnoreCase(getSuperClass());
+        return TypeHelper.isBaseEntity(getSuperClass());
     }
 
     @NotPersistent

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
@@ -189,14 +189,8 @@ public class Field {
 
         List<SettingDto> settingsDto = new ArrayList<>();
 
-
         for (FieldSetting setting : settings) {
-            // since textArea setting is used only to distinguish between TextArea and String fields we don't display it on UI
-            if (setting.getDetails().getName().equalsIgnoreCase("mds.form.label.textarea")) {
-                typeDto = generateTypeForTextArea(setting);
-            } else {
-                settingsDto.add(setting.toDto());
-            }
+            settingsDto.add(setting.toDto());
         }
 
 
@@ -211,18 +205,6 @@ public class Field {
 
         return new FieldDto(id, entity == null ? null : entity.getId(), typeDto, basic, readOnly, nonEditable,
                 nonDisplayable, uiFilterable, uiChanged, metaDto, validationDto, settingsDto, lookupDtos);
-    }
-
-    private TypeDto generateTypeForTextArea(FieldSetting setting) {
-        if (setting.getValue().equalsIgnoreCase("false")) {
-            return null;
-        }
-        TypeDto typeDto = new TypeDto();
-        typeDto.setDefaultName("textArea");
-        typeDto.setDisplayName("mds.field.textArea");
-        typeDto.setDescription("mds.field.description.textArea");
-        typeDto.setTypeClass("textArea");
-        return typeDto;
     }
 
     private Object parseDefaultValue() {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ManyToManyRelationship.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ManyToManyRelationship.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.domain;
 
 import javassist.bytecode.Descriptor;
+import org.motechproject.mds.dto.FieldDto;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ import static org.motechproject.mds.util.Constants.MetadataKeys.RELATIONSHIP_COL
 public class ManyToManyRelationship extends Relationship {
 
     @Override
-    public String getFieldType(Field field, EntityType type) {
+    public String getFieldType(FieldDto field, EntityType type) {
         if (isNotBlank(field.getMetadataValue(RELATIONSHIP_COLLECTION_TYPE))) {
             return field.getMetadataValue(RELATIONSHIP_COLLECTION_TYPE);
         }
@@ -22,7 +23,7 @@ public class ManyToManyRelationship extends Relationship {
     }
 
     @Override
-    public String getGenericSignature(Field field, EntityType type) {
+    public String getGenericSignature(FieldDto field, EntityType type) {
         String elementClass = type == EntityType.STANDARD ?
                 getRelatedClassName(field, type) :
                 Long.class.getName();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ManyToOneRelationship.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ManyToOneRelationship.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.domain;
 
+import org.motechproject.mds.dto.FieldDto;
+
 /**
  * A specialization of the {@link org.motechproject.mds.domain.Relationship} class.
  * Represents a many-to-one relationship.
@@ -7,7 +9,7 @@ package org.motechproject.mds.domain;
 public class ManyToOneRelationship extends Relationship {
 
     @Override
-    public String getFieldType(Field field, EntityType type) {
+    public String getFieldType(FieldDto field, EntityType type) {
         if (type == EntityType.STANDARD) {
             return getRelatedClassName(field, type);
         } else {
@@ -16,7 +18,7 @@ public class ManyToOneRelationship extends Relationship {
     }
 
     @Override
-    public String getGenericSignature(Field field, EntityType type) {
+    public String getGenericSignature(FieldDto field, EntityType type) {
         return null;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/OneToManyRelationship.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/OneToManyRelationship.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.domain;
 
 import javassist.bytecode.Descriptor;
+import org.motechproject.mds.dto.FieldDto;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ import static org.motechproject.mds.util.Constants.MetadataKeys.RELATIONSHIP_COL
 public class OneToManyRelationship extends Relationship {
 
     @Override
-    public String getFieldType(Field field, EntityType type) {
+    public String getFieldType(FieldDto field, EntityType type) {
         if (isNotBlank(field.getMetadataValue(RELATIONSHIP_COLLECTION_TYPE))) {
             return field.getMetadataValue(RELATIONSHIP_COLLECTION_TYPE);
         }
@@ -22,7 +23,7 @@ public class OneToManyRelationship extends Relationship {
     }
 
     @Override
-    public String getGenericSignature(Field field, EntityType type) {
+    public String getGenericSignature(FieldDto field, EntityType type) {
         String elementClass = type == EntityType.STANDARD ?
                 getRelatedClassName(field, type) :
                 Long.class.getName();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/OneToOneRelationship.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/OneToOneRelationship.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.domain;
 
+import org.motechproject.mds.dto.FieldDto;
+
 /**
  * A specialization of the {@link Relationship} class.
  * Represents a one-to-one relationship.
@@ -7,7 +9,7 @@ package org.motechproject.mds.domain;
 public class OneToOneRelationship extends Relationship {
 
     @Override
-    public String getFieldType(Field field, EntityType type) {
+    public String getFieldType(FieldDto field, EntityType type) {
         if (type == EntityType.STANDARD) {
             return getRelatedClassName(field, type);
         } else {
@@ -16,7 +18,7 @@ public class OneToOneRelationship extends Relationship {
     }
 
     @Override
-    public String getGenericSignature(Field field, EntityType type) {
+    public String getGenericSignature(FieldDto field, EntityType type) {
         return null;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Relationship.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Relationship.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.domain;
 
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.util.Constants;
 
 /**
@@ -8,20 +10,20 @@ import org.motechproject.mds.util.Constants;
  */
 public class Relationship {
 
-    public String getFieldType(Field field, EntityType type) {
+    public String getFieldType(FieldDto field, EntityType type) {
         return getRelatedClassName(field, type);
     }
 
-    public String getGenericSignature(Field field, EntityType type) {
+    public String getGenericSignature(FieldDto field, EntityType type) {
         return null;
     }
 
-    protected String getRelatedClassName(Field field, EntityType type) {
-        FieldMetadata fmd = field.getMetadata(Constants.MetadataKeys.RELATED_CLASS);
+    protected String getRelatedClassName(FieldDto field, EntityType type) {
+        MetadataDto fmd = field.getMetadata(Constants.MetadataKeys.RELATED_CLASS);
 
         if (fmd == null) {
-            throw new IllegalStateException(String.format("Unknown type for relationship %s in entity %s",
-                    field.getName(), field.getEntity().getName()));
+            throw new IllegalStateException(String.format("Unknown type for relationship %s",
+                    field.getBasic().getName()));
         }
 
         return type.getName(fmd.getValue());

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/RelationshipHolder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/RelationshipHolder.java
@@ -1,6 +1,8 @@
 package org.motechproject.mds.domain;
 
 import org.apache.commons.lang.StringUtils;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.util.Constants;
 
 import java.util.List;
@@ -15,7 +17,7 @@ import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_FIELD;
  * relationship type.
  */
 public class RelationshipHolder extends FieldHolder {
-    private Type fieldType;
+    private TypeDto fieldType;
     private EntityType entityType;
     private String fieldName;
 
@@ -23,11 +25,21 @@ public class RelationshipHolder extends FieldHolder {
         this(null, field);
     }
 
-    public RelationshipHolder(ClassData data, Field field) {
+    public RelationshipHolder(FieldDto fieldDto) {
+        this(null, fieldDto);
+    }
+
+    public RelationshipHolder(ClassData data, FieldDto field) {
         super(field);
         this.fieldType = field.getType();
         this.entityType = null == data ? EntityType.STANDARD : data.getType();
-        this.fieldName = field.getName();
+        this.fieldName = field.getBasic().getName();
+    }
+
+    public RelationshipHolder(ClassData data, Field field) {
+        super(field);
+        this.fieldType = field.getType().toDto();
+        this.entityType = null == data ? EntityType.STANDARD : data.getType();
     }
 
     /**
@@ -53,19 +65,19 @@ public class RelationshipHolder extends FieldHolder {
     }
 
     public boolean isOneToMany() {
-        return OneToManyRelationship.class.isAssignableFrom(fieldType.getTypeClass());
+        return OneToManyRelationship.class.getName().equals((fieldType.getTypeClass()));
     }
 
     public boolean isOneToOne() {
-        return OneToOneRelationship.class.isAssignableFrom(fieldType.getTypeClass());
+        return OneToOneRelationship.class.getName().equals(fieldType.getTypeClass());
     }
 
     public boolean isManyToMany() {
-        return ManyToManyRelationship.class.isAssignableFrom(fieldType.getTypeClass());
+        return ManyToManyRelationship.class.getName().equals(fieldType.getTypeClass());
     }
 
     public boolean isManyToOne() {
-        return ManyToOneRelationship.class.isAssignableFrom(fieldType.getTypeClass());
+        return ManyToOneRelationship.class.getName().equals(fieldType.getTypeClass());
     }
 
     public boolean isCascadePersist() {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Type.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Type.java
@@ -2,6 +2,7 @@ package org.motechproject.mds.domain;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.TypeValidationDto;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.TypeHelper;
 
@@ -13,6 +14,7 @@ import javax.jdo.annotations.NotPersistent;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -125,6 +127,15 @@ public class Type {
 
     public List<TypeValidation> getValidations() {
         return validations;
+    }
+
+    @NotPersistent
+    public List<TypeValidationDto> getTypeValidationDtos() {
+        List<TypeValidationDto> dtos = new ArrayList<>();
+        for (TypeValidation validation : getValidations()) {
+            dtos.add(validation.toDto());
+        }
+        return dtos;
     }
 
     public void setValidations(List<TypeValidation> validations) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/TypeValidation.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/TypeValidation.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.domain;
 
+import org.motechproject.mds.dto.TypeValidationDto;
+
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -71,6 +73,17 @@ public class TypeValidation {
 
     public void setAnnotations(List<Class<? extends Annotation>> annotations) {
         this.annotations = annotations;
+    }
+
+    public TypeValidationDto toDto() {
+        TypeValidationDto dto = new TypeValidationDto();
+
+        dto.setId(id);
+        dto.setDisplayName(displayName);
+        dto.setValueType(valueType.getTypeClassName());
+        dto.setAnnotations(annotations);
+
+        return dto;
     }
 
     @Override

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UIDisplayFieldComparator.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UIDisplayFieldComparator.java
@@ -1,15 +1,13 @@
 
 package org.motechproject.mds.domain;
 
-import org.motechproject.mds.domain.Field;
-
 import java.util.Comparator;
 
 /**
  * <code>UIDisplayFieldComparator</code> compares positions
  * added in UIDisplayable annotation. Fields without annotation are placed at the end.
  */
-public class UIDisplayFieldComparator implements Comparator<Field> {
+public class UIDisplayFieldComparator implements Comparator<Field>{
 
     @Override
     public int compare(Field o1, Field o2) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,6 +76,12 @@ public class AdvancedSettingsDto {
 
     public void setBrowsing(BrowsingSettingsDto browsing) {
         this.browsing = browsing;
+    }
+
+    @JsonIgnore
+    public boolean isFieldExposedByRest(String fieldName) {
+        return restOptions != null && restOptions.getFieldNames() != null &&
+                restOptions.getFieldNames().contains(fieldName);
     }
 
     /**

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/EntityDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/EntityDto.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.SecurityMode;
+import org.motechproject.mds.util.TypeHelper;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -275,6 +276,21 @@ public class EntityDto {
     @JsonIgnore
     public boolean isDDE() {
         return StringUtils.isNotBlank(module);
+    }
+
+    @JsonIgnore
+    public boolean isBaseEntity() {
+        return TypeHelper.isBaseEntity(getSuperClass());
+    }
+
+    @JsonIgnore
+    public boolean isSubClassOfMdsEntity () {
+        return TypeHelper.isSubclassOfMdsEntity(getSuperClass());
+    }
+
+    @JsonIgnore
+    public boolean isSubClassOfMdsVersionedEntity () {
+        return TypeHelper.isSubclassOfMdsVersionedEntity(getSuperClass());
     }
 
     /**

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
@@ -10,6 +10,7 @@ import org.motechproject.mds.util.Constants;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -233,6 +234,15 @@ public class FieldDto {
         }
 
         return false;
+    }
+
+    public void removeSetting(String key) {
+        Iterator<SettingDto> it = settings.iterator();
+        while (it.hasNext()) {
+            if (StringUtils.equals(key, it.next().getKey())) {
+                it.remove();
+            }
+        }
     }
 
     public List<SettingDto> getSettings() {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
@@ -229,7 +229,7 @@ public class FieldDto {
         MetadataDto md = getMetadata(Constants.MetadataKeys.VERSION_FIELD);
         String metadataValue = md == null ? null : md.getValue();
         if (StringUtils.isNotBlank(metadataValue)) {
-            return new Boolean(metadataValue);
+            return Boolean.valueOf(metadataValue);
         }
 
         return false;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/LookupDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/LookupDto.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.motechproject.mds.util.LookupName;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ public class LookupDto {
 
     public LookupDto(String lookupName, boolean singleObjectReturn, boolean exposedViaRest,
                      List<LookupFieldDto> lookupFields, boolean readOnly) {
-        this(lookupName, singleObjectReturn, exposedViaRest, lookupFields, readOnly, null, new ArrayList<String>());
+        this(lookupName, singleObjectReturn, exposedViaRest, lookupFields, readOnly, null, new ArrayList<>());
     }
 
     public LookupDto(String lookupName, boolean singleObjectReturn, boolean exposedViaRest, List<LookupFieldDto> lookupFields,
@@ -201,6 +202,16 @@ public class LookupDto {
 
     public void setFieldsOrder(List<String> fieldsOrder) {
         this.fieldsOrder = fieldsOrder;
+    }
+
+    @JsonIgnore
+    public LookupFieldDto getLookupField(String fieldName) {
+        for (LookupFieldDto lookupField : lookupFields) {
+            if (StringUtils.equals(fieldName, lookupField.getName())) {
+                return lookupField;
+            }
+        }
+        return null;
     }
 
     /**

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/SchemaHolder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/SchemaHolder.java
@@ -11,6 +11,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * A class that holds the MDS schema - entities, types, fields, lookups, advanced settings and so on.
+ * Used during MDS processing in order to avoid repeatedly querying the database.
+ */
 public class SchemaHolder {
 
     private Map<String, EntityHolder> entityMap = new HashMap<>();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/SchemaHolder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/SchemaHolder.java
@@ -1,0 +1,188 @@
+package org.motechproject.mds.dto;
+
+import org.apache.commons.lang.StringUtils;
+import org.motechproject.mds.ex.entity.EntityNotFoundException;
+import org.motechproject.mds.util.TypeHelper;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class SchemaHolder {
+
+    private Map<String, EntityHolder> entityMap = new HashMap<>();
+    private Map<String, TypeDto> types = new HashMap<>();
+    private Map<String, List<TypeValidationDto>> typeValidations = new HashMap<>();
+
+    public void addEntity(EntityDto entity, AdvancedSettingsDto advancedSettings,
+                          List<FieldDto> fields, List<LookupDto> lookups) {
+        EntityHolder entityHolder = new EntityHolder(entity, advancedSettings, fields, lookups);
+        entityMap.put(entityHolder.getEntityClassName(), entityHolder);
+    }
+
+    public void addType(TypeDto type) {
+        types.put(type.getTypeClass(), type);
+    }
+
+    public void addTypeValidation(TypeDto type, List<TypeValidationDto> validations) {
+        typeValidations.put(type.getTypeClass(), validations);
+    }
+
+    public TypeDto getType(Class typeClass) {
+        String className = TypeHelper.getClassNameForMdsType(typeClass);
+        return types.get(className);
+    }
+
+    public TypeDto getType(String typeClass) {
+        return types.get(typeClass);
+    }
+
+    public List<EntityDto> getAllEntities() {
+        List<EntityDto> entities = new ArrayList<>();
+        for (EntityHolder entityHolder : entityMap.values()) {
+            entities.add(entityHolder.getEntity());
+        }
+        return entities;
+    }
+
+    public EntityDto getEntityByClassName(String className) {
+        EntityHolder entityHolder = entityMap.get(className);
+        return entityHolder == null ? null : entityHolder.getEntity();
+    }
+
+    public AdvancedSettingsDto getAdvancedSettings(EntityDto entity) {
+        return getAdvancedSettings(entity.getClassName());
+    }
+
+    public AdvancedSettingsDto getAdvancedSettings(String className) {
+        EntityHolder entityHolder = entityMap.get(className);
+        return entityHolder == null ? null : entityHolder.getAdvancedSettings();
+    }
+
+    public List<FieldDto> getFields(EntityDto entity) {
+        return getFields(entity.getClassName());
+    }
+
+    public List<FieldDto> getFields(String entityClassName) {
+        EntityHolder entityHolder = entityMap.get(entityClassName);
+        return entityHolder == null ? null : entityHolder.getFields();
+    }
+
+    public List<LookupDto> getLookups(EntityDto entity) {
+        return getLookups(entity.getClassName());
+    }
+
+    public List<LookupDto> getLookups(String entityClassName) {
+        EntityHolder entityHolder = entityMap.get(entityClassName);
+        return entityHolder == null ? null : entityHolder.getLookups();
+    }
+
+    public FieldDto getFieldByName(EntityDto entity, String fieldName) {
+        return getFieldByName(entity.getClassName(), fieldName);
+    }
+
+    public FieldDto getFieldByName(String entityClassName, String fieldName) {
+        List<FieldDto> fields = getFields(entityClassName);
+
+        if (fields == null) {
+            throw new EntityNotFoundException(entityClassName);
+        }
+
+        for (FieldDto field : fields) {
+            if (StringUtils.equals(fieldName, field.getBasic().getName())) {
+                return field;
+            }
+        }
+
+        return null;
+    }
+
+    public List<TypeValidationDto> findValidations(String typeClass, Class<? extends Annotation> aClass) {
+        List<TypeValidationDto> result = new ArrayList<>();
+
+        if (typeValidations.containsKey(typeClass)) {
+            for (TypeValidationDto validation : typeValidations.get(typeClass)) {
+                if (validation.getAnnotations().contains(aClass)) {
+                    result.add(validation);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private class EntityHolder {
+
+        private EntityDto entity;
+        private AdvancedSettingsDto advancedSettings;
+        private List<FieldDto> fields;
+        private List<LookupDto> lookups;
+
+        public EntityHolder(EntityDto entity, AdvancedSettingsDto advancedSettings,
+                            List<FieldDto> fields, List<LookupDto> lookups) {
+            this.entity = entity;
+            this.advancedSettings = advancedSettings;
+            this.fields = fields;
+            this.lookups = lookups;
+        }
+
+        public EntityDto getEntity() {
+            return entity;
+        }
+
+        public void setEntity(EntityDto entity) {
+            this.entity = entity;
+        }
+
+        public AdvancedSettingsDto getAdvancedSettings() {
+            return advancedSettings;
+        }
+
+        public void setAdvancedSettings(AdvancedSettingsDto advancedSettings) {
+            this.advancedSettings = advancedSettings;
+        }
+
+        public List<FieldDto> getFields() {
+            return fields;
+        }
+
+        public void setFields(List<FieldDto> fields) {
+            this.fields = fields;
+        }
+
+        public final String getEntityClassName() {
+            return entity.getClassName();
+        }
+
+        public final Long getEntityId() {
+            return entity.getId();
+        }
+
+        public List<LookupDto> getLookups() {
+            return lookups;
+        }
+
+        public void setLookups(List<LookupDto> lookups) {
+            this.lookups = lookups;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof EntityHolder)) {
+                return false;
+            }
+
+            EntityHolder that = (EntityHolder) o;
+
+            return StringUtils.equals(getEntityClassName(), that.getEntityClassName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getEntityClassName());
+        }
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
@@ -246,6 +246,11 @@ public class TypeDto {
 
     @JsonIgnore
     public Class<?> getClassObjectForType() {
+        // arrays won't work with the classloader
+        if (Byte[].class.getName().equals(typeClass)) {
+            return Byte[].class;
+        }
+
         try {
             return getClass().getClassLoader().loadClass(typeClass);
         } catch (ClassNotFoundException e) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeDto.java
@@ -244,6 +244,15 @@ public class TypeDto {
         return clazz.getName().equals(typeClass);
     }
 
+    @JsonIgnore
+    public Class<?> getClassObjectForType() {
+        try {
+            return getClass().getClassLoader().loadClass(typeClass);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to load class for type " + typeClass + ". Illegal type.", e);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeValidationDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeValidationDto.java
@@ -3,6 +3,9 @@ package org.motechproject.mds.dto;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
+/**
+ * Dto class representing a validation for a given type.
+ */
 public class TypeValidationDto {
 
     private Long id;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeValidationDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/TypeValidationDto.java
@@ -1,0 +1,52 @@
+package org.motechproject.mds.dto;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+public class TypeValidationDto {
+
+    private Long id;
+    private String displayName;
+    private String valueType;
+    private List<Class<? extends Annotation>> annotations;
+
+    public TypeValidationDto() {
+    }
+
+    public TypeValidationDto(String displayName, String valueType) {
+        this.displayName = displayName;
+        this.valueType = valueType;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public List<Class<? extends Annotation>> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(List<Class<? extends Annotation>> annotations) {
+        this.annotations = annotations;
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UIDisplayFieldComparator.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UIDisplayFieldComparator.java
@@ -1,0 +1,50 @@
+
+package org.motechproject.mds.dto;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * <code>UIDisplayFieldComparator</code> compares positions
+ * added in UIDisplayable annotation. Fields without annotation are placed at the end.
+ */
+public class UIDisplayFieldComparator implements Comparator<FieldDto>{
+
+    private static final int NOT_DISPLAYABLE = -1;
+
+    private final List<Number> displayableFieldIds;
+
+    public UIDisplayFieldComparator(List<Number> displayableFieldIds) {
+        this.displayableFieldIds = displayableFieldIds;
+    }
+
+    @Override
+    public int compare(FieldDto o1, FieldDto o2) {
+        // check if one is displayable and the other isn't
+        if (isUIDisplayable(o1) && !isUIDisplayable(o2)) {
+            return -1;
+        } else if (!isUIDisplayable(o1) && isUIDisplayable(o2)) {
+            return 1;
+        }
+
+        // compare positions
+        int position1 = getUIDisplayPosition(o1);
+        int position2 = getUIDisplayPosition(o2);
+
+        if (position1 == NOT_DISPLAYABLE) {
+            return 1;
+        } else if (position2 == NOT_DISPLAYABLE) {
+            return -1;
+        } else {
+            return (position1 > position2) ? 1 : -1;
+        }
+    }
+
+    private boolean isUIDisplayable(FieldDto fieldDto) {
+        return displayableFieldIds.contains(fieldDto.getId());
+    }
+
+    private int getUIDisplayPosition(FieldDto fieldDto) {
+        return displayableFieldIds.indexOf(fieldDto.getId());
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UIDisplayFieldComparator.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UIDisplayFieldComparator.java
@@ -1,4 +1,3 @@
-
 package org.motechproject.mds.dto;
 
 import java.util.Comparator;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/helper/ActionParameterTypeResolver.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/helper/ActionParameterTypeResolver.java
@@ -1,8 +1,9 @@
 package org.motechproject.mds.helper;
 
 import org.motechproject.mds.domain.ComboboxHolder;
-import org.motechproject.mds.domain.Field;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.TypeDto;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,10 +61,10 @@ public final class ActionParameterTypeResolver {
      * @param field MDS field
      * @return matching task parameter type
      */
-    public static String resolveType(Field field) {
-        Type type = field.getType();
+    public static String resolveType(EntityDto entity, FieldDto field) {
+        TypeDto type = field.getType();
         if (type.isCombobox()) {
-            return resolveComboboxType(new ComboboxHolder(field));
+            return resolveComboboxType(new ComboboxHolder(entity, field));
         } else {
             String matchedType = TYPE_MAPPING.get(type.getDisplayName());
             return null != matchedType ? matchedType : UNKNOWN;

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/helper/EntitySorter.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/helper/EntitySorter.java
@@ -42,7 +42,7 @@ public final class EntitySorter {
         for (int i = 0; i < sorted.size(); ++i) {
             EntityDto entity = sorted.get(i);
             List<FieldDto> fields = (List<FieldDto>) CollectionUtils.select(
-                    schemaHolder.getFields(entity.getClassName()),
+                    schemaHolder.getFields(entity),
                     new Predicate() {
                 @Override
                 public boolean evaluate(Object object) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/helper/EntitySorter.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/helper/EntitySorter.java
@@ -3,9 +3,10 @@ package org.motechproject.mds.helper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
 import org.apache.commons.lang.StringUtils;
-import org.motechproject.mds.domain.Entity;
-import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.RelationshipHolder;
+import org.motechproject.mds.dto.SchemaHolder;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.ex.entity.InvalidEntitySettingsException;
 import org.motechproject.mds.ex.entity.InvalidRelationshipException;
 import org.springframework.util.LinkedMultiValueMap;
@@ -28,41 +29,43 @@ public final class EntitySorter {
      * behind the entity they are related with. The bi-directional relationships are not sorted,
      * moreover if invalid bi-directional relationship is found, an exception is thrown.
      *
-     * @param list Initial list of entities to sort
+     * @param schemaHolder the holder of the current MDS schema
      * @return List of entities, sorted by relationship
      */
-    public static List<Entity> sortByHasARelation(List<Entity> list) {
-        List<Entity> sorted = new ArrayList<>(list);
+    public static List<EntityDto> sortByHasARelation(List<EntityDto> allEntities, SchemaHolder schemaHolder) {
+        List<EntityDto> sorted = new ArrayList<>(allEntities);
         MultiValueMap<String, String> unresolvedRelations = new LinkedMultiValueMap<>();
 
         // we need to check if classes have 'has-a' relation
         // these classes should be later in list
         // we do that after all entities will be added to sorted list
         for (int i = 0; i < sorted.size(); ++i) {
-            Entity entity = sorted.get(i);
-            List<Field> fields = (List<Field>) CollectionUtils.select(entity.getFields(), new Predicate() {
+            EntityDto entity = sorted.get(i);
+            List<FieldDto> fields = (List<FieldDto>) CollectionUtils.select(
+                    schemaHolder.getFields(entity.getClassName()),
+                    new Predicate() {
                 @Override
                 public boolean evaluate(Object object) {
-                    return object instanceof Field && ((Field) object).getType().isRelationship();
+                    return object instanceof FieldDto && ((FieldDto) object).getType().isRelationship();
                 }
             });
 
             if (CollectionUtils.isNotEmpty(fields)) {
                 int max = i;
 
-                for (Field field : fields) {
+                for (FieldDto field : fields) {
                     final RelationshipHolder holder = new RelationshipHolder(field);
 
                     // For each field we perform a validation to spot circular, unresolvable relations,
                     // which means the data model is incorrect
-                    unresolvedRelations = validateRelationship(unresolvedRelations, field, holder);
-                    assertRelationshipIsHistoryCompatible(field, holder, list);
+                    unresolvedRelations = validateRelationship(unresolvedRelations, entity, holder);
+                    assertRelationshipIsHistoryCompatible(entity, holder, allEntities);
 
-                    Entity relation = (Entity) CollectionUtils.find(sorted, new Predicate() {
+                    EntityDto relation = (EntityDto) CollectionUtils.find(sorted, new Predicate() {
                         @Override
                         public boolean evaluate(Object object) {
-                            return object instanceof Entity
-                                    && ((Entity) object).getClassName().equalsIgnoreCase(holder.getRelatedClass());
+                            return object instanceof EntityDto
+                                    && ((EntityDto) object).getClassName().equalsIgnoreCase(holder.getRelatedClass());
                         }
                     });
 
@@ -97,12 +100,12 @@ public final class EntitySorter {
      * @param list Initial list of entities to sort
      * @return List of entities, sorted by inheritance tree
      */
-    public static List<Entity> sortByInheritance(List<Entity> list) {
-        List<Entity> sorted = new ArrayList<>(list.size());
+    public static List<EntityDto> sortByInheritance(List<EntityDto> list) {
+        List<EntityDto> sorted = new ArrayList<>(list.size());
 
         // firstly we add entities with base class equal to Object class or MdsEntity class
-        for (Iterator<Entity> iterator = list.iterator(); iterator.hasNext(); ) {
-            Entity entity = iterator.next();
+        for (Iterator<EntityDto> iterator = list.iterator(); iterator.hasNext(); ) {
+            EntityDto entity = iterator.next();
 
             if (entity.isBaseEntity()) {
                 sorted.add(entity);
@@ -113,13 +116,13 @@ public final class EntitySorter {
         // then we add entities which base classes are in sorted list
         // we do that after all entities will be added to sorted list
         while (!list.isEmpty()) {
-            for (Iterator<Entity> iterator = list.iterator(); iterator.hasNext(); ) {
-                final Entity entity = iterator.next();
-                Entity superClass = (Entity) CollectionUtils.find(sorted, new Predicate() {
+            for (Iterator<EntityDto> iterator = list.iterator(); iterator.hasNext(); ) {
+                final EntityDto entity = iterator.next();
+                EntityDto superClass = (EntityDto) CollectionUtils.find(sorted, new Predicate() {
                     @Override
                     public boolean evaluate(Object object) {
-                        return object instanceof Entity
-                                && ((Entity) object).getClassName().equals(entity.getSuperClass());
+                        return object instanceof EntityDto
+                                && ((EntityDto) object).getClassName().equals(entity.getSuperClass());
                     }
                 });
 
@@ -134,32 +137,34 @@ public final class EntitySorter {
     }
 
     private static MultiValueMap<String, String> validateRelationship(MultiValueMap<String, String> unresolvedRelations,
-                                                               Field field, RelationshipHolder holder) {
+                                                               EntityDto entity, RelationshipHolder holder) {
         List<String> relatedClasses = unresolvedRelations.get(holder.getRelatedClass());
 
-        if (relatedClasses != null && relatedClasses.contains(field.getEntity().getClassName()) &&
+        if (relatedClasses != null && relatedClasses.contains(entity.getClassName()) &&
                 StringUtils.isEmpty(holder.getRelatedField())) {
-            throw new InvalidRelationshipException(holder.getRelatedClass(), field.getEntity().getClassName());
+            throw new InvalidRelationshipException(holder.getRelatedClass(), entity.getClassName());
         }
 
-        if (holder.hasUnresolvedRelation() && !field.getEntity().getClassName().equals(holder.getRelatedClass())) {
-            unresolvedRelations.add(field.getEntity().getClassName(), holder.getRelatedClass());
+        if (holder.hasUnresolvedRelation() && !entity.getClassName().equals(holder.getRelatedClass())) {
+            unresolvedRelations.add(entity.getClassName(), holder.getRelatedClass());
         }
 
         return unresolvedRelations;
     }
 
-    private static void assertRelationshipIsHistoryCompatible(Field field, RelationshipHolder holder, List<Entity> allEntities) {
-        Entity relatedEntity = findEntityByName(holder.getRelatedClass(), allEntities);
+    private static void assertRelationshipIsHistoryCompatible(EntityDto entity, RelationshipHolder holder,
+                                                              List<EntityDto> allEntities) {
+        EntityDto relatedEntity = findEntityByName(holder.getRelatedClass(), allEntities);
 
-        if (!hasCorrectTrackingSettings(field, relatedEntity, holder)) {
+        if (!hasCorrectTrackingSettings(entity, relatedEntity, holder)) {
             String relatedClassName = relatedEntity == null ? "null" : relatedEntity.getClassName();
-            throw new InvalidEntitySettingsException(field.getEntity().getClassName(), relatedClassName);
+            throw new InvalidEntitySettingsException(entity.getClassName(), relatedClassName);
         }
     }
 
-    private static boolean hasCorrectTrackingSettings(Field field, Entity relatedEntity, RelationshipHolder holder) {
-        boolean recordsHistory = field.getEntity().isRecordHistory();
+    private static boolean hasCorrectTrackingSettings(EntityDto entity, EntityDto relatedEntity,
+                                                      RelationshipHolder holder) {
+        boolean recordsHistory = entity.isRecordHistory();
         boolean relatedRecordsHistory = relatedEntity.isRecordHistory();
 
         if (holder.isBiDirectional()) {
@@ -172,8 +177,8 @@ public final class EntitySorter {
         }
     }
 
-    private static Entity findEntityByName(String name, List<Entity> allEntities) {
-        for (Entity entity : allEntities) {
+    private static EntityDto findEntityByName(String name, List<EntityDto> allEntities) {
+        for (EntityDto entity : allEntities) {
             if (entity.getClassName().equals(name)) {
                 return entity;
             }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/helper/JavassistBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/helper/JavassistBuilder.java
@@ -122,7 +122,7 @@ public final class JavassistBuilder {
     public static CtField.Initializer createInitializer(String typeClass, Object defaultValue) {
         //The distinction made in order to avoid the cyclomatic complexity error
         if(typeClass.startsWith("java")) {
-            return createInitializerForJavaPlatformPackages(typeClass, defaultValue, defaultValue);
+            return createInitializerForJavaPlatformPackages(typeClass, defaultValue);
         } else {
             return createInitializerForThirdPartyPackages(typeClass, defaultValue);
         }
@@ -130,8 +130,7 @@ public final class JavassistBuilder {
 
 
     private static CtField.Initializer createInitializerForJavaPlatformPackages(String typeClass,
-                                                                                Object defaultValue,
-                                                                                Object defaultValueg) {
+                                                                                Object defaultValue) {
         switch (typeClass) {
             case "java.lang.Integer":
             case "java.lang.Double":
@@ -149,7 +148,7 @@ public final class JavassistBuilder {
                 java.time.LocalDate javaLocalDate = (java.time.LocalDate) defaultValue;
                 return createJavaTimeInitializer(typeClass, javaLocalDate.toString());
             case "java.util.Locale":
-                return createLocaleInitializer(defaultValueg);
+                return createLocaleInitializer(defaultValue);
             default:
                 return null;
         }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/helper/JavassistBuilder.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/helper/JavassistBuilder.java
@@ -109,18 +109,29 @@ public final class JavassistBuilder {
      */
     public static CtField.Initializer createInitializer(String typeClass, String defaultValueAsString) {
         Object defaultValue = TypeHelper.parse(defaultValueAsString, typeClass);
+        return createInitializer(typeClass, defaultValue);
+    }
 
+    /**
+     * Creates a field initializer for the given type and default value.
+     *
+     * @param typeClass the field type
+     * @param defaultValue the default value for the field
+     * @return field initializer
+     */
+    public static CtField.Initializer createInitializer(String typeClass, Object defaultValue) {
         //The distinction made in order to avoid the cyclomatic complexity error
         if(typeClass.startsWith("java")) {
-            return createInitializerForJavaPlatformPackages(typeClass, defaultValue, defaultValueAsString);
+            return createInitializerForJavaPlatformPackages(typeClass, defaultValue, defaultValue);
         } else {
             return createInitializerForThirdPartyPackages(typeClass, defaultValue);
         }
     }
 
+
     private static CtField.Initializer createInitializerForJavaPlatformPackages(String typeClass,
                                                                                 Object defaultValue,
-                                                                                String defaultValueAsString) {
+                                                                                Object defaultValueg) {
         switch (typeClass) {
             case "java.lang.Integer":
             case "java.lang.Double":
@@ -138,7 +149,7 @@ public final class JavassistBuilder {
                 java.time.LocalDate javaLocalDate = (java.time.LocalDate) defaultValue;
                 return createJavaTimeInitializer(typeClass, javaLocalDate.toString());
             case "java.util.Locale":
-                return createLocaleInitializer(defaultValueAsString);
+                return createLocaleInitializer(defaultValueg);
             default:
                 return null;
         }
@@ -310,7 +321,7 @@ public final class JavassistBuilder {
      * @param defaultValue the default value
      * @return {@link java.util.Locale} initializer
      */
-    public static CtField.Initializer createLocaleInitializer(String defaultValue) {
+    public static CtField.Initializer createLocaleInitializer(Object defaultValue) {
         return CtField.Initializer.byExpr(String.format("%s.toLocale(\"%s\")", LocaleUtils.class.getName(), defaultValue));
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/osgi/MdsBundleWatcher.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/osgi/MdsBundleWatcher.java
@@ -299,7 +299,7 @@ public class MdsBundleWatcher implements SynchronousBundleListener {
 
         // we generate the entities bundle but not start it to avoid exceptions when the framework
         // will refresh bundles
-        jarGeneratorService.regenerateMdsDataBundle(false);
+        jarGeneratorService.regenerateMdsDataBundle(entityService.getSchema(), false);
 
         FrameworkWiring framework = bundleContext.getBundle(0).adapt(FrameworkWiring.class);
         framework.refreshBundles(bundles);

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/EntityService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/EntityService.java
@@ -487,5 +487,10 @@ public interface EntityService {
      */
     List<FieldDto> getEntityFieldsForUI(Long entityId);
 
+    /**
+     * Retrieves the current MDS schema - entities, fields, lookups, advanced settings etc. This schema can be
+     * processed outside of a transacton.
+     * @return the current MDS schema
+     */
     SchemaHolder getSchema();
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/EntityService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/EntityService.java
@@ -8,6 +8,7 @@ import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.RestOptionsDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TrackingDto;
 import org.motechproject.mds.util.SecurityMode;
 
@@ -485,4 +486,6 @@ public interface EntityService {
      * @return the list of fields for the UI
      */
     List<FieldDto> getEntityFieldsForUI(Long entityId);
+
+    SchemaHolder getSchema();
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/JarGeneratorService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/JarGeneratorService.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds.service;
 
+import org.motechproject.mds.dto.SchemaHolder;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -29,17 +31,19 @@ public interface JarGeneratorService {
      * implementations of these interfaces. The jar should also contains class related with
      * historical data and trash.
      *
+     * @param schemaHolder the holder of the MDS that should be built
      * @return file that points to the entities bundle jar.
      * @throws IOException if an I/O error occurs while creating the jar file.
      */
-    File generate() throws IOException;
+    File generate(SchemaHolder schemaHolder) throws IOException;
 
     /**
      * Constructs entities, builds and starts the entities bundle jar
      *
-     * @see #generate()
+     * @param schemaHolder the holder of the MDS that should be built
+     * @see #generate(SchemaHolder)
      */
-    void regenerateMdsDataBundle();
+    void regenerateMdsDataBundle(SchemaHolder schemaHolder);
 
 
     /**
@@ -47,18 +51,20 @@ public interface JarGeneratorService {
      * This method should be used after DDE enhancement. It will build all DDE classes
      * and refresh modules from which the DDE being enhanced comes from.
      *
+     * @param schemaHolder the holder of the MDS that should be built
      * @param moduleNames modules names of the entities from which the enhanced DDE comes from
-     * @see #generate()
+     * @see #generate(SchemaHolder)
      */
-    void regenerateMdsDataBundleAfterDdeEnhancement(String... moduleNames);
+    void regenerateMdsDataBundleAfterDdeEnhancement(SchemaHolder schemaHolder, String... moduleNames);
 
     /**
      * Constructs entities, builds the entities bundle jar. The generated bundle will start only if
      * the <strong>startBundle</strong> will be set to {@code true}.
      *
+     * @param schemaHolder the holder of the MDS that should be built
      * @param startBundle {@code true} if the generated bundle should start;
      *                    otherwise {@code false}.
-     * @see #generate()
+     * @see #generate(SchemaHolder)
      */
-    void regenerateMdsDataBundle(boolean startBundle);
+    void regenerateMdsDataBundle(SchemaHolder schemaHolder, boolean startBundle);
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
@@ -401,7 +401,7 @@ public class EntityServiceImpl implements EntityService {
         Entity parent = draft.getParentEntity();
         String username = draft.getDraftOwnerUsername();
 
-        mdsConstructor.updateFields(parent.getId(), draft.getFieldNameChanges());
+        mdsConstructor.updateFields(parent, draft.getFieldNameChanges());
         comboboxDataMigrationHelper.migrateComboboxDataIfNecessary(parent, draft);
 
         configureRelatedFields(parent, draft, modulesToRefresh);

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
@@ -347,7 +347,7 @@ public class EntityServiceImpl implements EntityService {
         }
 
         if ("textArea".equalsIgnoreCase(typeClass)) {
-            setMetadataForTextArea(field);
+            setSettingForTextArea(field);
         }
 
         FieldHelper.addMetadataForRelationship(typeClass, field);
@@ -357,10 +357,10 @@ public class EntityServiceImpl implements EntityService {
         allEntityDrafts.update(draft);
     }
 
-    private void setMetadataForTextArea(Field field) {
+    private void setSettingForTextArea(Field field) {
         if (field != null) {
             for (FieldSetting setting : field.getSettings()) {
-                if ("mds.form.label.textarea".equalsIgnoreCase(setting.getDetails().getName())) {
+                if (Constants.Settings.STRING_TEXT_AREA.equalsIgnoreCase(setting.getDetails().getName())) {
                     setting.setValue("true");
                 }
             }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/JarGeneratorServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/JarGeneratorServiceImpl.java
@@ -12,19 +12,21 @@ import org.motechproject.mds.MDSDataProvider;
 import org.motechproject.mds.builder.MDSConstructor;
 import org.motechproject.mds.domain.ClassData;
 import org.motechproject.mds.domain.ComboboxHolder;
-import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityInfo;
-import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.FieldInfo;
-import org.motechproject.mds.domain.RestOptions;
-import org.motechproject.mds.domain.UIDisplayFieldComparator;
+import org.motechproject.mds.dto.AdvancedSettingsDto;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.RestOptionsDto;
+import org.motechproject.mds.dto.SchemaHolder;
+import org.motechproject.mds.dto.TrackingDto;
+import org.motechproject.mds.dto.UIDisplayFieldComparator;
 import org.motechproject.mds.event.CrudEventBuilder;
 import org.motechproject.mds.ex.MdsException;
 import org.motechproject.mds.helper.ActionParameterTypeResolver;
 import org.motechproject.mds.helper.MdsBundleHelper;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.osgi.EntitiesBundleMonitor;
-import org.motechproject.mds.repository.AllEntities;
 import org.motechproject.mds.repository.MetadataHolder;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.motechproject.mds.service.JdoListenerRegistryService;
@@ -43,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.velocity.VelocityEngineUtils;
 
 import javax.annotation.Resource;
@@ -101,28 +102,25 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
     private MDSDataProvider mdsDataProvider;
     private EntitiesBundleMonitor monitor;
     private BundleContext bundleContext;
-    private AllEntities allEntities;
     private final Object lock = new Object();
     private boolean moduleRefreshed;
 
     @Override
-    @Transactional
-    public synchronized void regenerateMdsDataBundle() {
-        regenerateMdsDataBundle(true);
+    public synchronized void regenerateMdsDataBundle(SchemaHolder schemaHolder) {
+        regenerateMdsDataBundle(schemaHolder, true);
     }
 
     @Override
-    @Transactional
-    public void regenerateMdsDataBundleAfterDdeEnhancement(String... moduleNames) {
-        regenerateMdsDataBundle(true, null == moduleNames ? new String[0] : moduleNames);
+    public void regenerateMdsDataBundleAfterDdeEnhancement(SchemaHolder schemaHolder, String... moduleNames) {
+        regenerateMdsDataBundle(schemaHolder, true, null == moduleNames ? new String[0] : moduleNames);
     }
 
-    @Transactional
-    public void regenerateMdsDataBundle(boolean startBundle) {
-        regenerateMdsDataBundle(startBundle, new String[0]);
+    @Override
+    public void regenerateMdsDataBundle(SchemaHolder schemaHolder, boolean startBundle) {
+        regenerateMdsDataBundle(schemaHolder, startBundle, new String[0]);
     }
 
-    private synchronized void regenerateMdsDataBundle(boolean startBundle, String... moduleNames) {
+    private synchronized void regenerateMdsDataBundle(SchemaHolder schemaHolder, boolean startBundle, String... moduleNames) {
         LOGGER.info("Regenerating the mds entities bundle");
 
         ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
@@ -132,14 +130,14 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
             clearModulesCache(moduleNames);
             cleanEntitiesBundleCachedClasses();
 
-            boolean constructed = mdsConstructor.constructEntities();
+            boolean constructed = mdsConstructor.constructEntities(schemaHolder);
 
             if (!constructed) {
                 return;
             }
 
             LOGGER.info("Updating mds data provider");
-            mdsDataProvider.updateDataProvider();
+            mdsDataProvider.updateDataProvider(schemaHolder);
 
             File dest = new File(monitor.bundleLocation());
             if (dest.exists()) {
@@ -152,7 +150,7 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
 
             try {
                 LOGGER.info("Generating bundle jar");
-                tmpBundleFile = generate();
+                tmpBundleFile = generate(schemaHolder);
                 LOGGER.info("Generated bundle jar");
             } catch (IOException e) {
                 throw new MdsException("Unable to generate entities bundle", e);
@@ -271,8 +269,7 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
     }
 
     @Override
-    @Transactional
-    public File generate() throws IOException {
+    public File generate(SchemaHolder schemaHolder) throws IOException {
         Path tempDir = Files.createTempDirectory("mds");
         Path tempFile = Files.createTempFile(tempDir, "mds-entities", ".jar");
 
@@ -308,7 +305,11 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
                 }
 
                 if (!classData.isEnumClassData()) {
-                    EntityInfo info = buildEntityInfo(classData);
+                    EntityDto entity = schemaHolder.getEntityByClassName(classData.getClassName());
+                    List<FieldDto> fields = schemaHolder.getFields(entity);
+                    AdvancedSettingsDto advancedSettings = schemaHolder.getAdvancedSettings(entity);
+
+                    EntityInfo info = buildEntityInfo(classData, entity, fields, advancedSettings);
 
                     // we keep the name to construct a file containing all entity names
                     // the file is required for schema generation
@@ -339,13 +340,6 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
                         }
                     }
 
-                    Entity entity = allEntities.retrieveByClassName(classData.getClassName());
-
-                    info.setFieldsInfo(getFieldsInfo(entity));
-                    info.setEntityName(entity.getName());
-                    setAllowedEvents(info, entity);
-                    updateRestOptions(info, entity);
-
                     information.add(info);
                 }
             }
@@ -357,37 +351,46 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
             jdoListenerRegistryService.removeInactiveListeners(entityNamesSb.toString());
             String entityWithListenersNames = jdoListenerRegistryService.getEntitiesListenerStr();
 
-            addEntries(output, blueprint, context, channel, entityNamesSb.toString(), historyEntitySb.toString(), entityWithListenersNames);
+            addEntries(output, blueprint, context, channel, entityNamesSb.toString(), historyEntitySb.toString(),
+                    entityWithListenersNames);
 
             return tempFile.toFile();
         }
     }
 
-    private EntityInfo buildEntityInfo(ClassData classData) {
+    private EntityInfo buildEntityInfo(ClassData classData, EntityDto entity, List<FieldDto> fields,
+                                       AdvancedSettingsDto advancedSettings) {
         EntityInfo info = new EntityInfo();
 
         info.setClassName(classData.getClassName());
         info.setModule(classData.getModule());
         info.setNamespace(classData.getNamespace());
 
+        info.setFieldsInfo(getFieldsInfo(entity, fields, advancedSettings));
+        info.setEntityName(entity.getName());
+        setAllowedEvents(info, advancedSettings);
+        updateRestOptions(info, advancedSettings);
+
         return info;
     }
 
-    private void updateRestOptions(EntityInfo info, Entity entity) {
-        RestOptions restOptions = entity.getRestOptions();
+    private void updateRestOptions(EntityInfo info, AdvancedSettingsDto advancedSettings) {
+        RestOptionsDto restOptions = advancedSettings.getRestOptions();
 
         if (restOptions != null) {
-            info.setRestCreateEnabled(restOptions.isAllowCreate());
-            info.setRestReadEnabled(restOptions.isAllowRead());
-            info.setRestUpdateEnabled(restOptions.isAllowUpdate());
-            info.setRestDeleteEnabled(restOptions.isAllowDelete());
+            info.setRestCreateEnabled(restOptions.isCreate());
+            info.setRestReadEnabled(restOptions.isRead());
+            info.setRestUpdateEnabled(restOptions.isUpdate());
+            info.setRestDeleteEnabled(restOptions.isDelete());
         }
     }
 
-    private void setAllowedEvents(EntityInfo info, Entity entity) {
-        info.setCreateEventFired(entity.isAllowCreateEvent());
-        info.setUpdateEventFired(entity.isAllowUpdateEvent());
-        info.setDeleteEventFired(entity.isAllowDeleteEvent());
+    private void setAllowedEvents(EntityInfo info, AdvancedSettingsDto advancedSettings) {
+        TrackingDto tracking = advancedSettings.getTracking();
+
+        info.setCreateEventFired(tracking.isAllowCreateEvent());
+        info.setUpdateEventFired(tracking.isAllowUpdateEvent());
+        info.setDeleteEventFired(tracking.isAllowDeleteEvent());
     }
 
     private void addEntries(JarOutputStream output, String blueprint, String context, String channel,
@@ -564,27 +567,31 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
         return sb.toString();
     }
 
-    private List<FieldInfo> getFieldsInfo(Entity entity) {
+    private List<FieldInfo> getFieldsInfo(EntityDto entity, List<FieldDto> fields,
+                                          AdvancedSettingsDto advancedSettings) {
         List<FieldInfo> fieldsInfo = new ArrayList<>();
-        List<Field> fields = new ArrayList<>(entity.getFields());
-        Collections.sort(fields, new UIDisplayFieldComparator());
-        for (Field field : fields) {
+
+        Collections.sort(fields, new UIDisplayFieldComparator(advancedSettings.getBrowsing().getDisplayedFields()));
+
+        for (FieldDto field : fields) {
             FieldInfo fieldInfo = new FieldInfo();
 
-            fieldInfo.setName(field.getName());
-            fieldInfo.setDisplayName(field.getDisplayName());
-            fieldInfo.setRequired(field.isRequired());
-            fieldInfo.setRestExposed(field.isExposedViaRest());
+            fieldInfo.setName(field.getBasic().getName());
+            fieldInfo.setDisplayName(field.getBasic().getDisplayName());
+            fieldInfo.setRequired(field.getBasic().isRequired());
             fieldInfo.setAutoGenerated(TRUE.equals(field.getMetadataValue(AUTO_GENERATED)));
 
+            boolean exposedByRest = advancedSettings.isFieldExposedByRest(field.getBasic().getName());
+            fieldInfo.setRestExposed(exposedByRest);
+
             FieldInfo.TypeInfo typeInfo = fieldInfo.getTypeInfo();
-            typeInfo.setType(field.getType().getTypeClassName());
-            typeInfo.setTaskType(ActionParameterTypeResolver.resolveType(field));
+            typeInfo.setType(field.getType().getTypeClass());
+            typeInfo.setTaskType(ActionParameterTypeResolver.resolveType(entity, field));
 
             // combobox values
             typeInfo.setCombobox(field.getType().isCombobox());
             if (field.getType().isCombobox()) {
-                ComboboxHolder cbHolder = new ComboboxHolder(field);
+                ComboboxHolder cbHolder = new ComboboxHolder(entity, field);
                 String[] items = cbHolder.getValues();
                 if (ArrayUtils.isNotEmpty(items)) {
                     typeInfo.setItems(Arrays.asList(items));
@@ -673,11 +680,6 @@ public class JarGeneratorServiceImpl implements JarGeneratorService {
     @Autowired
     public void setMonitor(EntitiesBundleMonitor monitor) {
         this.monitor = monitor;
-    }
-
-    @Autowired
-    public void setAllEntities(AllEntities allEntities) {
-        this.allEntities = allEntities;
     }
 
     @Autowired

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
@@ -540,7 +540,7 @@ public final class Constants {
         public static final String ALLOW_USER_SUPPLIED = "mds.form.label.allowUserSupplied";
         public static final String COMBOBOX_VALUES = "mds.form.label.values";
         public static final String STRING_MAX_LENGTH = "mds.form.label.maxTextLength";
-        public static final String STRING_TEXT_AREA = "mds.form.label.textArea";
+        public static final String STRING_TEXT_AREA = "mds.form.label.textarea";
         public static final String TEXT_AREA_SQL_TYPE = "TEXT";
 
         public static final String CASCADE_PERSIST = "mds.form.label.cascadePersist";

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/TypeHelper.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/TypeHelper.java
@@ -18,8 +18,6 @@ import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
 import org.motechproject.commons.api.Range;
 import org.motechproject.commons.date.model.Time;
-import org.motechproject.mds.domain.MdsEntity;
-import org.motechproject.mds.domain.MdsVersionedEntity;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -917,19 +915,21 @@ public final class TypeHelper {
         }
     }
 
+    // class names as strings below in order to avoid package cycles
+
     public static boolean isBaseEntity(String entitySuperClass) {
         return Object.class.getName().equalsIgnoreCase(entitySuperClass) ||
-                MdsEntity.class.getName().equalsIgnoreCase(entitySuperClass) ||
-                MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
+                "org.motechproject.mds.domain.MdsEntity".equalsIgnoreCase(entitySuperClass) ||
+                "org.motechproject.mds.domain.MdsVersionedEntity".equalsIgnoreCase(entitySuperClass);
     }
 
     public static boolean isSubclassOfMdsEntity(String entitySuperClass) {
-        return MdsEntity.class.getName().equalsIgnoreCase(entitySuperClass)
-                || MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
+        return "org.motechproject.mds.domain.MdsEntity".equalsIgnoreCase(entitySuperClass)
+                || "org.motechproject.mds.domain.MdsVersionedEntity".equalsIgnoreCase(entitySuperClass);
     }
 
     public static boolean isSubclassOfMdsVersionedEntity(String entitySuperClass) {
-        return MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
+        return "org.motechproject.mds.domain.MdsVersionedEntity".equalsIgnoreCase(entitySuperClass);
     }
 
     private static boolean bothNumbers(Object val, String toClass) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/TypeHelper.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/TypeHelper.java
@@ -18,6 +18,8 @@ import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
 import org.motechproject.commons.api.Range;
 import org.motechproject.commons.date.model.Time;
+import org.motechproject.mds.domain.MdsEntity;
+import org.motechproject.mds.domain.MdsVersionedEntity;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -731,6 +733,17 @@ public final class TypeHelper {
         return (Class<?>) PRIMITIVE_TYPE_MAP.getKey(clazz);
     }
 
+    public static String getClassNameForMdsType(Class<?> clazz) {
+        Class<?> chosenClass = clazz;
+
+        // box primitives
+        if (clazz.isPrimitive() || byte[].class.equals(clazz)) {
+            chosenClass = TypeHelper.getWrapperForPrimitive(clazz);
+        }
+
+        return chosenClass.getName();
+    }
+
     /**
      * Parses given value to {@link org.motechproject.commons.api.Range}. If passed value is assignable
      * neither to range nor to map, it throws {@link java.lang.IllegalArgumentException}. If value is a map,
@@ -902,6 +915,21 @@ public final class TypeHelper {
         } else {
             return new ArrayList<>();
         }
+    }
+
+    public static boolean isBaseEntity(String entitySuperClass) {
+        return Object.class.getName().equalsIgnoreCase(entitySuperClass) ||
+                MdsEntity.class.getName().equalsIgnoreCase(entitySuperClass) ||
+                MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
+    }
+
+    public static boolean isSubclassOfMdsEntity(String entitySuperClass) {
+        return MdsEntity.class.getName().equalsIgnoreCase(entitySuperClass)
+                || MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
+    }
+
+    public static boolean isSubclassOfMdsVersionedEntity(String entitySuperClass) {
+        return MdsVersionedEntity.class.getName().equalsIgnoreCase(entitySuperClass);
     }
 
     private static boolean bothNumbers(Object val, String toClass) {

--- a/platform/mds/mds/src/main/resources/velocity/templates/task-data-provider.vm
+++ b/platform/mds/mds/src/main/resources/velocity/templates/task-data-provider.vm
@@ -1,15 +1,15 @@
 #if ( ! $service.listEntities().isEmpty() )
 {
     "name": "data-services",
-    "objects": [ #foreach ( $entity in $service.listEntities() )
+    "objects": [ #foreach ( $entity in $schema.getAllEntities() )
         {
             "displayName": "$entity.getName()",
             "type": "$entity.getClassName()",
-            "lookupFields": [ #foreach ( $lookup in $service.getEntityLookups($entity.getId()) )
+            "lookupFields": [ #foreach ( $lookup in $schema.getLookups($entity) )
                 {
                     "displayName": "$lookup.getLookupName()",
                     "fields": [
-                        #foreach ( $field in $lookup.getLookupFields() ) "$field.getLookupFieldName()" #if( $velocityHasNext ) , #end #end
+                        #foreach ( $field in $lookup.getLookupFields() ) "$field.getName()" #if( $velocityHasNext ) , #end #end
                     ]
                 },#end
                 {
@@ -20,7 +20,7 @@
                 }
             ],
             "fields": [
-                #foreach ( $field in $service.getEntityFields($entity.getId()) )
+                #foreach ( $field in $schema.getFields($entity) )
                 {
                     "displayName": "$field.getBasic().getDisplayName()",
                     "fieldKey": "$field.getBasic().getName()"

--- a/platform/mds/mds/src/main/resources/velocity/templates/task-data-provider.vm
+++ b/platform/mds/mds/src/main/resources/velocity/templates/task-data-provider.vm
@@ -1,4 +1,4 @@
-#if ( ! $service.listEntities().isEmpty() )
+#if ( ! $schema.getAllEntities().isEmpty() )
 {
     "name": "data-services",
     "objects": [ #foreach ( $entity in $schema.getAllEntities() )

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityBuilderTest.java
@@ -12,13 +12,12 @@ import org.motechproject.commons.date.model.Time;
 import org.motechproject.commons.date.util.DateUtil;
 import org.motechproject.mds.builder.EntityBuilder;
 import org.motechproject.mds.domain.ClassData;
-import org.motechproject.mds.domain.Entity;
-import org.motechproject.mds.domain.Field;
-import org.motechproject.mds.domain.FieldMetadata;
-import org.motechproject.mds.domain.FieldSetting;
 import org.motechproject.mds.domain.OneToManyRelationship;
 import org.motechproject.mds.domain.OneToOneRelationship;
-import org.motechproject.mds.domain.TypeSetting;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.testutil.EntBuilderTestClass;
 import org.motechproject.mds.testutil.RelatedClass;
 import org.motechproject.mds.util.Constants;
@@ -34,6 +33,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +43,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
-import static org.motechproject.mds.testutil.FieldTestHelper.field;
+import static org.motechproject.mds.testutil.FieldTestHelper.fieldDto;
+import static org.motechproject.mds.testutil.FieldTestHelper.fieldDtoWithDefVal;
 import static org.motechproject.mds.testutil.FieldTestHelper.newVal;
 import static org.motechproject.mds.util.Constants.Util.MODIFICATION_DATE_FIELD_NAME;
 import static org.motechproject.mds.util.Constants.Util.MODIFIED_BY_FIELD_NAME;
@@ -60,7 +61,9 @@ public class EntityBuilderTest {
     private MDSClassLoader mdsClassLoader;
 
     @Mock
-    private Entity entity;
+    private EntityDto entity;
+
+    private List<FieldDto> fields;
 
     @Mock
     private Bundle bundle;
@@ -69,23 +72,31 @@ public class EntityBuilderTest {
     public void setUp() {
         mdsClassLoader = MDSClassLoader.getStandaloneInstance(getClass().getClassLoader());
         when(entity.getClassName()).thenReturn(ENTITY_NAME);
-        when(entity.getField(MODIFICATION_DATE_FIELD_NAME)).thenReturn(field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true));
-        when(entity.getField(MODIFIED_BY_FIELD_NAME)).thenReturn(field(MODIFIED_BY_FIELD_NAME, String.class, true));
+
+        fields = new ArrayList<>();
+
+        FieldDto modificationDateField = fieldDto(MODIFICATION_DATE_FIELD_NAME, DateTime.class);
+        FieldDto modifiedByField = fieldDto(MODIFIED_BY_FIELD_NAME, String.class);
+
+        modificationDateField.setReadOnly(true);
+        modifiedByField.setReadOnly(true);
+
+        fields.add(modificationDateField);
+        fields.add(modifiedByField);
     }
 
     @Test
     public void shouldBuildAnEntityWithFields() throws Exception {
-        Field enumListField = field("enumList", List.class);
-        enumListField.addMetadata(new FieldMetadata(enumListField, Constants.MetadataKeys.ENUM_CLASS_NAME, FieldEnum.class.getName()));
+        FieldDto enumListField = fieldDto("enumList", List.class);
+        enumListField.addMetadata(new MetadataDto(Constants.MetadataKeys.ENUM_CLASS_NAME, FieldEnum.class.getName()));
         enumListField.getType().setDisplayName("mds.field.combobox");
-        enumListField.addSetting(new FieldSetting(enumListField, new TypeSetting(Constants.Settings.ALLOW_MULTIPLE_SELECTIONS), "true"));
+        enumListField.addSetting(new SettingDto(Constants.Settings.ALLOW_MULTIPLE_SELECTIONS, "true"));
 
-        when(entity.getFields()).thenReturn(asList(field("count", Integer.class),
-                field("time", Time.class), field("str", String.class), field("dec", Double.class),
-                field("bool", Boolean.class), field("date", Date.class), field("dt", DateTime.class),
-                field("ld", LocalDate.class), field("locale", Locale.class), enumListField, field("CapitalizedName", String.class),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true),
-                field("jd", java.time.LocalDate.class), field("jdt", LocalDateTime.class)));
+        fields.addAll(asList(fieldDto("count", Integer.class),
+                fieldDto("time", Time.class), fieldDto("str", String.class), fieldDto("dec", Double.class),
+                fieldDto("bool", Boolean.class), fieldDto("date", Date.class), fieldDto("dt", DateTime.class),
+                fieldDto("ld", LocalDate.class), fieldDto("locale", Locale.class), enumListField, fieldDto("CapitalizedName", String.class),
+                fieldDto("jd", java.time.LocalDate.class), fieldDto("jdt", LocalDateTime.class)));
 
         Class<?> clazz = buildClass();
 
@@ -113,13 +124,17 @@ public class EntityBuilderTest {
         final LocalDateTime javaLocalDateTime = LocalDateTime.now().plusDays(1);
         final java.time.LocalDate javaLocalDate = java.time.LocalDate.now().plusDays(1);
 
-        when(entity.getFields()).thenReturn(asList(field("count", Integer.class, 1),
-                field("time", Time.class, new Time(10, 10)), field("str", String.class, "defStr"),
-                field("dec", Double.class, 3.1), field("bool", Boolean.class, (Object) true),
-                field("date", Date.class, date), field("dt", DateTime.class, dateTime),
-                field("ld", LocalDate.class, localDate), field("locale", Locale.class, Locale.CANADA_FRENCH),
-                field("jd", java.time.LocalDate.class, javaLocalDate), field("jdt", LocalDateTime.class, javaLocalDateTime),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        fields.addAll(asList(fieldDtoWithDefVal("count", Integer.class, 1),
+                fieldDtoWithDefVal("time", Time.class, new Time(10, 10)),
+                fieldDtoWithDefVal("str", String.class, "defStr"),
+                fieldDtoWithDefVal("dec", Double.class, 3.1),
+                fieldDtoWithDefVal("bool", Boolean.class, true),
+                fieldDtoWithDefVal("date", Date.class, date),
+                fieldDtoWithDefVal("dt", DateTime.class, dateTime),
+                fieldDtoWithDefVal("ld", LocalDate.class, localDate),
+                fieldDtoWithDefVal("locale", Locale.class, Locale.CANADA_FRENCH),
+                fieldDtoWithDefVal("jd", java.time.LocalDate.class, javaLocalDate),
+                fieldDtoWithDefVal("jdt", LocalDateTime.class, javaLocalDateTime)));
 
         Class<?> clazz = buildClass();
 
@@ -139,12 +154,14 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldEditClasses() throws Exception {
-        when(entity.getFields()).thenReturn(asList(field("name", Integer.class), field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        FieldDto firstField = fieldDto("name", Integer.class);
+        fields.add(firstField);
 
         Class<?> clazz = buildClass();
         assertField(clazz, "name", Integer.class);
 
-        when(entity.getFields()).thenReturn(asList(field("name2", String.class), field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true), field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        fields.remove(firstField);
+        fields.add(fieldDto("name2", String.class));
 
         // reload the classloader for class edit
         mdsClassLoader = MDSClassLoader.getStandaloneInstance(getClass().getClassLoader());
@@ -163,18 +180,14 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldBuildHistoryClass() throws Exception {
-        when(entity.getFields()).thenReturn(asList(field("id", Long.class),
-                field("count", Integer.class), field("time", Time.class),
-                field("str", String.class), field("dec", Double.class),
-                field("bool", Boolean.class), field("date", Date.class),
-                field("dt", DateTime.class), field("list", List.class),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true),
-                field(MODIFIED_BY_FIELD_NAME, String.class, true),
-                field("jd", java.time.LocalDate.class), field("jld", LocalDateTime.class)));
+        fields.addAll(asList(fieldDto("id", Long.class),
+                fieldDto("count", Integer.class), fieldDto("time", Time.class),
+                fieldDto("str", String.class), fieldDto("dec", Double.class),
+                fieldDto("bool", Boolean.class), fieldDto("date", Date.class),
+                fieldDto("dt", DateTime.class), fieldDto("list", List.class),
+                fieldDto("jd", java.time.LocalDate.class), fieldDto("jld", LocalDateTime.class)));
 
-        when(entity.getField("id")).thenReturn(field("id", Long.class));
-
-        ClassData classData = entityBuilder.buildHistory(entity);
+        ClassData classData = entityBuilder.buildHistory(entity, fields);
         assertEquals("xx.yy.history.BuilderTest__History", classData.getClassName());
 
         Class<?> clazz = mdsClassLoader.safeDefineClass(classData.getClassName(), classData.getBytecode());
@@ -196,17 +209,14 @@ public class EntityBuilderTest {
 
     @Test(expected = NoSuchFieldException.class)
     public void shouldNotAddVersionFieldToTheHistoryClass() throws Exception {
-        Field versionField = field("version", Long.class);
-        versionField.addMetadata(new FieldMetadata(versionField, Constants.MetadataKeys.VERSION_FIELD, "true"));
-        when(entity.getFields()).thenReturn(asList(
-                field("id", Long.class), versionField,
-                field("count", Integer.class), field("str", String.class),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true),
-                field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        FieldDto versionField = fieldDto("version", Long.class);
+        versionField.addMetadata(new MetadataDto(Constants.MetadataKeys.VERSION_FIELD, "true"));
+        fields.addAll(asList(
+                fieldDto("id", Long.class), versionField,
+                fieldDto("count", Integer.class), fieldDto("str", String.class)
+        ));
 
-        when(entity.getField("id")).thenReturn(field("id", Long.class));
-
-        ClassData classData = entityBuilder.buildHistory(entity);
+        ClassData classData = entityBuilder.buildHistory(entity, fields);
         assertEquals("xx.yy.history.BuilderTest__History", classData.getClassName());
 
         Class<?> clazz = mdsClassLoader.safeDefineClass(classData.getClassName(), classData.getBytecode());
@@ -226,18 +236,17 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldBuildEnhancedDDE() throws Exception {
-        Field strField = field("testStr", String.class);
-        Field boolField = field("testBool", Boolean.class);
+        FieldDto strField = fieldDto("testStr", String.class);
+        FieldDto boolField = fieldDto("testBool", Boolean.class);
         strField.setReadOnly(true);
         boolField.setReadOnly(true);
 
-        when(entity.getFields()).thenReturn(asList(
-                strField, boolField, field("fromUser", DateTime.class),
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true),
-                field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        fields.addAll(asList(
+                strField, boolField, fieldDto("fromUser", DateTime.class)
+        ));
         when(entity.getClassName()).thenReturn(EntBuilderTestClass.class.getName());
 
-        ClassData classData = entityBuilder.buildDDE(entity, bundle);
+        ClassData classData = entityBuilder.buildDDE(entity, fields, bundle);
         Class<?> builtClass = MDSClassLoader.getStandaloneInstance()
                 .defineClass(classData.getClassName(), classData.getBytecode());
 
@@ -253,21 +262,17 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldBuildRelationshipFields() throws Exception {
-        Field oneToOneField = field("oto", OneToOneRelationship.class);
+        FieldDto oneToOneField = fieldDto("oto", OneToOneRelationship.class);
         oneToOneField.setReadOnly(true);
-        oneToOneField.addMetadata(new FieldMetadata(oneToOneField,
-                Constants.MetadataKeys.RELATED_CLASS, RelatedClass.class.getName()));
-        Field oneToManyField = field("otm", OneToManyRelationship.class);
+        oneToOneField.addMetadata(new MetadataDto(Constants.MetadataKeys.RELATED_CLASS, RelatedClass.class.getName()));
+        FieldDto oneToManyField = fieldDto("otm", OneToManyRelationship.class);
         oneToManyField.setReadOnly(true);
-        oneToManyField.addMetadata(new FieldMetadata(oneToManyField,
-                Constants.MetadataKeys.RELATED_CLASS, RelatedClass.class.getName()));
+        oneToManyField.addMetadata(new MetadataDto(Constants.MetadataKeys.RELATED_CLASS, RelatedClass.class.getName()));
 
-        when(entity.getFields()).thenReturn(asList(oneToOneField, oneToManyField,
-                field(MODIFICATION_DATE_FIELD_NAME, DateTime.class, true),
-                field(MODIFIED_BY_FIELD_NAME, String.class, true)));
+        fields.addAll(asList(oneToOneField, oneToManyField));
         when(entity.getClassName()).thenReturn(EntBuilderTestClass.class.getName());
 
-        ClassData classData = entityBuilder.buildDDE(entity, bundle);
+        ClassData classData = entityBuilder.buildDDE(entity, fields, bundle);
         Class<?> builtClass = MDSClassLoader.getStandaloneInstance()
                 .defineClass(classData.getClassName(), classData.getBytecode());
 
@@ -278,12 +283,12 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldBuildEnumListFieldProperly() throws Exception {
-        Field enumListField = field("enumList", List.class);
-        enumListField.addMetadata(new FieldMetadata(enumListField, Constants.MetadataKeys.ENUM_CLASS_NAME, FieldEnum.class.getName()));
+        FieldDto enumListField = fieldDto("enumList", List.class);
+        enumListField.addMetadata(new MetadataDto(Constants.MetadataKeys.ENUM_CLASS_NAME, FieldEnum.class.getName()));
         enumListField.getType().setDisplayName("mds.field.combobox");
-        enumListField.addSetting(new FieldSetting(enumListField, new TypeSetting(Constants.Settings.ALLOW_MULTIPLE_SELECTIONS), "true"));
+        enumListField.addSetting(new SettingDto(Constants.Settings.ALLOW_MULTIPLE_SELECTIONS, "true"));
 
-        when(entity.getFields()).thenReturn(asList(enumListField));
+        fields.add(enumListField);
 
         Class<?> clazz = buildClass();
 
@@ -304,7 +309,7 @@ public class EntityBuilderTest {
     }
 
     private Class<?> buildClass() {
-        ClassData classData = entityBuilder.build(entity);
+        ClassData classData = entityBuilder.build(entity, fields);
 
         assertEquals(ENTITY_NAME, classData.getClassName());
 

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityBuilderTest.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -95,8 +96,9 @@ public class EntityBuilderTest {
         fields.addAll(asList(fieldDto("count", Integer.class),
                 fieldDto("time", Time.class), fieldDto("str", String.class), fieldDto("dec", Double.class),
                 fieldDto("bool", Boolean.class), fieldDto("date", Date.class), fieldDto("dt", DateTime.class),
-                fieldDto("ld", LocalDate.class), fieldDto("locale", Locale.class), enumListField, fieldDto("CapitalizedName", String.class),
-                fieldDto("jd", java.time.LocalDate.class), fieldDto("jdt", LocalDateTime.class)));
+                fieldDto("ld", LocalDate.class), fieldDto("locale", Locale.class), enumListField,
+                fieldDto("CapitalizedName", String.class), fieldDto("jd", java.time.LocalDate.class),
+                fieldDto("jdt", LocalDateTime.class), fieldDto("blob", Byte[].class.getName())));
 
         Class<?> clazz = buildClass();
 
@@ -112,6 +114,7 @@ public class EntityBuilderTest {
         assertField(clazz, "locale", Locale.class);
         assertField(clazz, "jd", java.time.LocalDate.class);
         assertField(clazz, "jdt", LocalDateTime.class);
+        assertField(clazz, "blob", Byte[].class);
         // should use uncapitalized version
         assertField(clazz, "capitalizedName", String.class);
     }
@@ -283,9 +286,8 @@ public class EntityBuilderTest {
 
     @Test
     public void shouldBuildEnumListFieldProperly() throws Exception {
-        FieldDto enumListField = fieldDto("enumList", List.class);
+        FieldDto enumListField = fieldDto("enumList", Collection.class);
         enumListField.addMetadata(new MetadataDto(Constants.MetadataKeys.ENUM_CLASS_NAME, FieldEnum.class.getName()));
-        enumListField.getType().setDisplayName("mds.field.combobox");
         enumListField.addSetting(new SettingDto(Constants.Settings.ALLOW_MULTIPLE_SELECTIONS, "true"));
 
         fields.add(enumListField);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityInfrastructureBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityInfrastructureBuilderTest.java
@@ -104,11 +104,11 @@ public class EntityInfrastructureBuilderTest {
         FieldDto dateField = fieldDto("dateField", "Display names should not affect methods", DateTime.class);
         FieldDto timeField = fieldDto("timeField", Time.class);
 
-        List<FieldDto> fields = new ArrayList<>();
-        fields.add(testField);
-        fields.add(testField2);
-        fields.add(dateField);
-        fields.add(timeField);
+        when(schemaHolder.getFieldByName(SampleWithLookups.class.getName(), "TestField")).thenReturn(testField);
+        when(schemaHolder.getFieldByName(SampleWithLookups.class.getName(), "TestField2")).thenReturn(testField2);
+        when(schemaHolder.getFieldByName(SampleWithLookups.class.getName(), "dateField")).thenReturn(dateField);
+        when(schemaHolder.getFieldByName(SampleWithLookups.class.getName(), "timeField")).thenReturn(timeField);
+
         lookup.setFieldsOrder(asList("TestField", "TestField2", "dateField", "timeField"));
         lookup.setSingleObjectReturn(true);
         when(schemaHolder.getLookups(entity)).thenReturn(singletonList(lookup));

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderTest.java
@@ -17,12 +17,13 @@ import org.motechproject.mds.annotations.internal.samples.AnotherSample;
 import org.motechproject.mds.builder.EntityMetadataBuilder;
 import org.motechproject.mds.builder.Sample;
 import org.motechproject.mds.domain.ClassData;
-import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.EntityType;
-import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.OneToManyRelationship;
 import org.motechproject.mds.domain.OneToOneRelationship;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -39,11 +40,10 @@ import javax.jdo.metadata.InheritanceMetadata;
 import javax.jdo.metadata.JDOMetadata;
 import javax.jdo.metadata.PackageMetadata;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.motechproject.mds.testutil.FieldTestHelper.fieldDto;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_CLASS;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_FIELD;
 import static org.motechproject.mds.util.Constants.Util.CREATION_DATE_DISPLAY_FIELD_NAME;
@@ -88,10 +89,10 @@ public class EntityMetadataBuilderTest {
     private EntityMetadataBuilder entityMetadataBuilder = new EntityMetadataBuilderImpl();
 
     @Mock
-    private Entity entity;
+    private EntityDto entity;
 
     @Mock
-    private Field idField;
+    private FieldDto idField;
 
     @Mock
     private JDOMetadata jdoMetadata;
@@ -108,6 +109,9 @@ public class EntityMetadataBuilderTest {
     @Mock
     private InheritanceMetadata inheritanceMetadata;
 
+    @Mock
+    private SchemaHolder schemaHolder;
+
     @Before
     public void setUp() {
         initMocks(this);
@@ -115,7 +119,6 @@ public class EntityMetadataBuilderTest {
         when(entity.getClassName()).thenReturn(CLASS_NAME);
         when(classMetadata.newFieldMetadata("id")).thenReturn(idMetadata);
         when(classMetadata.newInheritanceMetadata()).thenReturn(inheritanceMetadata);
-        when(entity.getField("id")).thenReturn(idField);
         when(entity.isBaseEntity()).thenReturn(true);
     }
 
@@ -128,7 +131,7 @@ public class EntityMetadataBuilderTest {
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verify(jdoMetadata).newPackageMetadata(PACKAGE);
         verify(packageMetadata).newClassMetadata(ENTITY_NAME);
@@ -144,7 +147,7 @@ public class EntityMetadataBuilderTest {
         when(packageMetadata.getName()).thenReturn(PACKAGE);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verify(jdoMetadata, never()).newPackageMetadata(PACKAGE);
         verify(jdoMetadata).getPackages();
@@ -160,15 +163,15 @@ public class EntityMetadataBuilderTest {
         when(jdoMetadata.newPackageMetadata(anyString())).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(anyString())).thenReturn(classMetadata);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
         verify(classMetadata).setTable(TABLE_NAME_1);
 
         when(entity.getModule()).thenReturn(MODULE);
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
         verify(classMetadata).setTable(TABLE_NAME_2);
 
         when(entity.getNamespace()).thenReturn(NAMESPACE);
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
         verify(classMetadata).setTable(TABLE_NAME_3);
     }
 
@@ -204,25 +207,14 @@ public class EntityMetadataBuilderTest {
 
     @Test
     public void shouldAddOneToManyRelationshipMetadata() {
-        Field oneToManyField = mock(Field.class);
-        org.motechproject.mds.domain.FieldMetadata entityFmd = mock(org.motechproject.mds.domain.FieldMetadata.class);
-        Type oneToManyType = mock(Type.class);
-
-        when(entityFmd.getKey()).thenReturn(RELATED_CLASS);
-        when(entityFmd.getValue()).thenReturn("org.motechproject.test.MyClass");
-
-        when(oneToManyType.getTypeClass()).thenReturn((Class) OneToManyRelationship.class);
-        when(oneToManyType.isRelationship()).thenReturn(true);
-
-        when(oneToManyField.getName()).thenReturn("oneToManyName");
-        when(oneToManyField.getMetadata()).thenReturn(asList(entityFmd));
-        when(oneToManyField.getType()).thenReturn(oneToManyType);
+        FieldDto oneToManyField = fieldDto("oneToManyName", OneToManyRelationship.class);
+        oneToManyField.addMetadata(new MetadataDto(RELATED_CLASS, "org.motechproject.test.MyClass"));
 
         FieldMetadata fmd = mock(FieldMetadata.class);
         CollectionMetadata collMd = mock(CollectionMetadata.class);
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(entity.getFields()).thenReturn(asList(oneToManyField));
+        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(singletonList(oneToManyField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
@@ -230,7 +222,7 @@ public class EntityMetadataBuilderTest {
         when(fmd.getCollectionMetadata()).thenReturn(collMd);
         when(fmd.getName()).thenReturn("oneToManyName");
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verifyCommonClassMetadata();
         verify(fmd).setDefaultFetchGroup(true);
@@ -241,33 +233,18 @@ public class EntityMetadataBuilderTest {
 
     @Test
     public void shouldAddOneToOneRelationshipMetadata() throws NotFoundException, CannotCompileException {
-        final String myClassName = "org.motechproject.test.MyClass";
-        final String myFieldName = "myField";
+        final String relClassName = "org.motechproject.test.MyClass";
+        final String relFieldName = "myField";
 
-        Field oneToOneField = mock(Field.class);
-        org.motechproject.mds.domain.FieldMetadata relatedClassFmd = mock(org.motechproject.mds.domain.FieldMetadata.class);
-        org.motechproject.mds.domain.FieldMetadata relatedFieldFmd = mock(org.motechproject.mds.domain.FieldMetadata.class);
-
-        Type oneToOneType = mock(Type.class);
-
-        when(relatedClassFmd.getKey()).thenReturn(RELATED_CLASS);
-        when(relatedClassFmd.getValue()).thenReturn(myClassName);
-
-        when(relatedFieldFmd.getKey()).thenReturn(RELATED_FIELD);
-        when(relatedFieldFmd.getValue()).thenReturn(myFieldName);
-
-        when(oneToOneType.getTypeClass()).thenReturn((Class) OneToOneRelationship.class);
-        when(oneToOneType.isRelationship()).thenReturn(true);
-
-        when(oneToOneField.getName()).thenReturn("oneToOneName");
-        when(oneToOneField.getMetadata(RELATED_FIELD)).thenReturn(relatedFieldFmd);
-        when(oneToOneField.getType()).thenReturn(oneToOneType);
+        FieldDto oneToOneField = fieldDto(relFieldName, OneToOneRelationship.class);
+        oneToOneField.addMetadata(new MetadataDto(RELATED_CLASS, relClassName));
+        oneToOneField.addMetadata(new MetadataDto(RELATED_FIELD, relFieldName));
 
         FieldMetadata fmd = mock(FieldMetadata.class);
         when(fmd.getName()).thenReturn("oneToOneName");
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(entity.getFields()).thenReturn(asList(oneToOneField));
+        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(asList(oneToOneField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
@@ -280,16 +257,16 @@ public class EntityMetadataBuilderTest {
         CtField myField = mock(CtField.class);
         CtField relatedField = mock(CtField.class);
 
-        when(myClass.getName()).thenReturn(myClassName);
+        when(myClass.getName()).thenReturn(relClassName);
         when(myClass.getDeclaredFields()).thenReturn(new CtField[]{myField});
 
         when(myField.getType()).thenReturn(relatedClass);
-        when(myField.getName()).thenReturn(myFieldName);
+        when(myField.getName()).thenReturn(relFieldName);
 
         when(relatedClass.getDeclaredFields()).thenReturn(new CtField[]{relatedField});
         when(relatedClass.getName()).thenReturn(CLASS_NAME);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verifyCommonClassMetadata();
         verify(fmd).setDefaultFetchGroup(true);
@@ -298,19 +275,12 @@ public class EntityMetadataBuilderTest {
 
     @Test
     public void shouldSetIndexOnMetadataLookupField() throws Exception {
-        Field lookupField = mock(Field.class);
-        Type string = new Type(String.class);
-        Set<org.motechproject.mds.domain.Lookup> lookups = new HashSet<>();
-        lookups.add(new org.motechproject.mds.domain.Lookup());
-
-        when(lookupField.getName()).thenReturn("lookupField");
-        when(lookupField.getType()).thenReturn(string);
-        when(lookupField.getLookups()).thenReturn(lookups);
+        FieldDto lookupField = fieldDto("lookupField", String.class);
 
         FieldMetadata fmd = mock(FieldMetadata.class);
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(entity.getFields()).thenReturn(asList(lookupField));
+        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(singletonList(lookupField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
@@ -318,7 +288,7 @@ public class EntityMetadataBuilderTest {
         PowerMockito.mockStatic(FieldUtils.class);
         when(FieldUtils.getDeclaredField(eq(Sample.class), anyString(), eq(true))).thenReturn(Sample.class.getDeclaredField("notInDefFg"));
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verifyCommonClassMetadata();
         verify(fmd).setIndexed(true);
@@ -331,18 +301,15 @@ public class EntityMetadataBuilderTest {
         when(jdoMetadata.newPackageMetadata(anyString())).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(anyString())).thenReturn(classMetadata);
 
-        Type string = new Type(String.class);
-        Type dateTime = new Type(DateTime.class);
-
-        List<Field> fields = new ArrayList<>();
+        List<FieldDto> fields = new ArrayList<>();
         // for these fields the appropriate generator should be added
-        fields.add(new Field(entity, CREATOR_FIELD_NAME, CREATOR_DISPLAY_FIELD_NAME, string, true, true));
-        fields.add(new Field(entity, OWNER_FIELD_NAME, OWNER_DISPLAY_FIELD_NAME, string, true, true));
-        fields.add(new Field(entity, CREATION_DATE_FIELD_NAME, CREATION_DATE_DISPLAY_FIELD_NAME, dateTime, true, true));
-        fields.add(new Field(entity, MODIFIED_BY_FIELD_NAME, MODIFIED_BY_DISPLAY_FIELD_NAME, string, true, true));
-        fields.add(new Field(entity, MODIFICATION_DATE_FIELD_NAME, MODIFICATION_DATE_DISPLAY_FIELD_NAME, dateTime, true, true));
+        fields.add(fieldDto(1L, CREATOR_FIELD_NAME, String.class.getName(), CREATOR_DISPLAY_FIELD_NAME, null));
+        fields.add(fieldDto(2L, OWNER_FIELD_NAME, String.class.getName(), OWNER_DISPLAY_FIELD_NAME, null));
+        fields.add(fieldDto(3L, CREATION_DATE_FIELD_NAME, DateTime.class.getName(), CREATION_DATE_DISPLAY_FIELD_NAME, null));
+        fields.add(fieldDto(4L, MODIFIED_BY_FIELD_NAME, String.class.getName(), MODIFIED_BY_DISPLAY_FIELD_NAME, null));
+        fields.add(fieldDto(5L, MODIFICATION_DATE_FIELD_NAME, DateTime.class.getName(), MODIFICATION_DATE_DISPLAY_FIELD_NAME, null));
 
-        doReturn(fields).when(entity).getFields();
+        doReturn(fields).when(schemaHolder).getFields(CLASS_NAME);
 
         final List<FieldMetadata> list = new ArrayList<>();
 
@@ -365,7 +332,7 @@ public class EntityMetadataBuilderTest {
         PowerMockito.mockStatic(FieldUtils.class);
         when(FieldUtils.getDeclaredField(eq(Sample.class), anyString(), eq(true))).thenReturn(Sample.class.getDeclaredField("notInDefFg"));
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         for (FieldMetadata metadata : list) {
             String name = metadata.getName();
@@ -387,7 +354,7 @@ public class EntityMetadataBuilderTest {
         when(jdoMetadata.newPackageMetadata(anyString())).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(anyString())).thenReturn(classMetadata);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, AnotherSample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, AnotherSample.class, schemaHolder);
 
         verifyZeroInteractions(inheritanceMetadata);
     }
@@ -399,16 +366,14 @@ public class EntityMetadataBuilderTest {
         when(jdoMetadata.newPackageMetadata(anyString())).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(anyString())).thenReturn(classMetadata);
 
-        Field field = mock(Field.class);
-        when(field.getName()).thenReturn("notInDefFg");
-        when(field.getType()).thenReturn(new Type(OneToOneRelationship.class));
-        when(entity.getFields()).thenReturn(asList(field));
+        FieldDto field = fieldDto("notInDefFg", OneToOneRelationship.class);
+        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(singletonList(field));
 
         FieldMetadata fmd = mock(FieldMetadata.class);
         when(fmd.getName()).thenReturn("notInDefFg");
         when(classMetadata.newFieldMetadata("notInDefFg")).thenReturn(fmd);
 
-        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class);
+        entityMetadataBuilder.addEntityMetadata(jdoMetadata, entity, Sample.class, schemaHolder);
 
         verify(fmd, never()).setDefaultFetchGroup(anyBoolean());
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/EntityMetadataBuilderTest.java
@@ -22,6 +22,9 @@ import org.motechproject.mds.domain.OneToManyRelationship;
 import org.motechproject.mds.domain.OneToOneRelationship;
 import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.LookupDto;
+import org.motechproject.mds.dto.LookupFieldDto;
+import org.motechproject.mds.dto.LookupFieldType;
 import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.javassist.MotechClassPool;
@@ -42,7 +45,6 @@ import javax.jdo.metadata.PackageMetadata;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -119,6 +121,7 @@ public class EntityMetadataBuilderTest {
         when(entity.getClassName()).thenReturn(CLASS_NAME);
         when(classMetadata.newFieldMetadata("id")).thenReturn(idMetadata);
         when(classMetadata.newInheritanceMetadata()).thenReturn(inheritanceMetadata);
+        when(schemaHolder.getFieldByName(entity, "id")).thenReturn(idField);
         when(entity.isBaseEntity()).thenReturn(true);
     }
 
@@ -214,7 +217,7 @@ public class EntityMetadataBuilderTest {
         CollectionMetadata collMd = mock(CollectionMetadata.class);
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(singletonList(oneToManyField));
+        when(schemaHolder.getFields(entity)).thenReturn(singletonList(oneToManyField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
@@ -236,7 +239,7 @@ public class EntityMetadataBuilderTest {
         final String relClassName = "org.motechproject.test.MyClass";
         final String relFieldName = "myField";
 
-        FieldDto oneToOneField = fieldDto(relFieldName, OneToOneRelationship.class);
+        FieldDto oneToOneField = fieldDto("oneToOneName", OneToOneRelationship.class);
         oneToOneField.addMetadata(new MetadataDto(RELATED_CLASS, relClassName));
         oneToOneField.addMetadata(new MetadataDto(RELATED_FIELD, relFieldName));
 
@@ -244,7 +247,7 @@ public class EntityMetadataBuilderTest {
         when(fmd.getName()).thenReturn("oneToOneName");
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(asList(oneToOneField));
+        when(schemaHolder.getFields(entity)).thenReturn(singletonList(oneToOneField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);
@@ -277,10 +280,15 @@ public class EntityMetadataBuilderTest {
     public void shouldSetIndexOnMetadataLookupField() throws Exception {
         FieldDto lookupField = fieldDto("lookupField", String.class);
 
+        LookupDto lookup = new LookupDto();
+        lookup.setLookupName("A lookup");
+        lookup.setLookupFields(singletonList(new LookupFieldDto("lookupField", LookupFieldType.VALUE)));
+        lookupField.setLookups(singletonList(lookup));
+
         FieldMetadata fmd = mock(FieldMetadata.class);
 
         when(entity.getName()).thenReturn(ENTITY_NAME);
-        when(schemaHolder.getFields(CLASS_NAME)).thenReturn(singletonList(lookupField));
+        when(schemaHolder.getFields(entity)).thenReturn(singletonList(lookupField));
         when(entity.getTableName()).thenReturn(TABLE_NAME);
         when(jdoMetadata.newPackageMetadata(PACKAGE)).thenReturn(packageMetadata);
         when(packageMetadata.newClassMetadata(ENTITY_NAME)).thenReturn(classMetadata);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/MdsDataProviderBuilderImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/builder/impl/MdsDataProviderBuilderImplTest.java
@@ -4,44 +4,32 @@ import org.apache.velocity.app.VelocityEngine;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldBasicDto;
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.LookupFieldDto;
-import org.motechproject.mds.service.EntityService;
-import org.motechproject.mds.service.impl.EntityServiceImpl;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.testutil.FieldTestHelper;
 
 import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MdsDataProviderBuilderImplTest {
 
     private MDSDataProviderBuilderImpl mdsDataProviderBuilder = new MDSDataProviderBuilderImpl();
 
-    private List<EntityDto> entityList = new LinkedList<>();
     private List<LookupDto> lookupList = new LinkedList<>();
     private List<FieldDto> fieldList = new LinkedList<>();
-
-    @Mock
-    private EntityService entityService = new EntityServiceImpl();
 
     private VelocityEngine velocityEngine = new VelocityEngine();
 
     @Before
     public void setUp() {
-        when(entityService.listEntities()).thenReturn(entityList);
-        when(entityService.getEntityLookups(Long.valueOf("1"))).thenReturn(lookupList);
-        when(entityService.getEntityFields(Long.valueOf("1"))).thenReturn(fieldList);
-        mdsDataProviderBuilder.setEntityService(entityService);
-
         velocityEngine.addProperty("resource.loader", "classpath");
         velocityEngine.addProperty("classpath.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
         mdsDataProviderBuilder.setVelocityEngine(velocityEngine);
@@ -49,7 +37,7 @@ public class MdsDataProviderBuilderImplTest {
 
     @Test
     public void shouldGenerateEmptyJson() {
-        String generatedJson = mdsDataProviderBuilder.generateDataProvider();
+        String generatedJson = mdsDataProviderBuilder.generateDataProvider(new SchemaHolder());
         assertEquals("", generatedJson);
     }
 
@@ -97,9 +85,11 @@ public class MdsDataProviderBuilderImplTest {
         lookupFields.add(FieldTestHelper.lookupFieldDto("TestFieldName"));
         lookup.setLookupFields(lookupFields);
         lookupList.add(lookup);
-        entityList.add(entity);
 
-        String generatedJson = mdsDataProviderBuilder.generateDataProvider();
+        SchemaHolder schema = new SchemaHolder();
+        schema.addEntity(entity, null, fieldList, lookupList);
+
+        String generatedJson = mdsDataProviderBuilder.generateDataProvider(schema);
 
         assertEquals(json, generatedJson.replace("\r\n", "\n"));
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/helper/EntitySorterTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/helper/EntitySorterTest.java
@@ -3,38 +3,49 @@ package org.motechproject.mds.helper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.motechproject.mds.domain.Entity;
-import org.motechproject.mds.domain.Field;
-import org.motechproject.mds.domain.FieldMetadata;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.motechproject.mds.domain.ManyToManyRelationship;
 import org.motechproject.mds.domain.OneToOneRelationship;
-import org.motechproject.mds.domain.Tracking;
-import org.motechproject.mds.domain.Type;
+import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.ex.entity.InvalidEntitySettingsException;
 import org.motechproject.mds.ex.entity.InvalidRelationshipException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.when;
+import static org.motechproject.mds.testutil.FieldTestHelper.fieldDto;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_CLASS;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_FIELD;
 
+@RunWith(MockitoJUnitRunner.class)
 public class EntitySorterTest {
 
-    private Entity childEntity;
-    private Entity parentEntity;
-    private Entity entity1;
-    private Entity entity2;
-    private Entity entity3;
-    private Entity book;
-    private Entity author;
+    private EntityDto childEntity;
+    private EntityDto parentEntity;
+    private EntityDto entity1;
+    private EntityDto entity2;
+    private EntityDto entity3;
+    private EntityDto book;
+    private EntityDto author;
 
-    private Entity binaryTree;
+    private EntityDto binaryTree;
+
+    private FieldDto authorFieldInBook;
+
+    @Mock
+    private SchemaHolder schemaHolder;
 
     @Test
     public void shouldProperlySortByHasARelation() {
-        List<Entity> entities = EntitySorter.sortByHasARelation(getValidDataModel());
+        List<EntityDto> entities = EntitySorter.sortByHasARelation(getValidDataModel(), schemaHolder);
 
         Assert.assertTrue(entities.indexOf(entity3) < entities.indexOf(entity2));
         Assert.assertTrue(entities.indexOf(entity3) < entities.indexOf(entity1));
@@ -45,22 +56,22 @@ public class EntitySorterTest {
 
     @Test
     public void shouldProperlySortByInheritance() {
-        List<Entity> initialList = new ArrayList<>();
+        List<EntityDto> initialList = new ArrayList<>();
         initialList.add(childEntity);
         initialList.add(parentEntity);
 
-        List<Entity> entities = EntitySorter.sortByInheritance(initialList);
+        List<EntityDto> entities = EntitySorter.sortByInheritance(initialList);
 
         Assert.assertTrue(entities.indexOf(parentEntity) < entities.indexOf(childEntity));
     }
 
     @Test
     public void shouldNotSignalErrorOnSelfRelation() {
-        List<Entity> initialList = new ArrayList<>();
+        List<EntityDto> initialList = new ArrayList<>();
         initialList.addAll(getValidDataModel());
         initialList.add(binaryTree);
 
-        List<Entity> sortingResult = EntitySorter.sortByHasARelation(initialList);
+        List<EntityDto> sortingResult = EntitySorter.sortByHasARelation(initialList, schemaHolder);
 
         Assert.assertEquals(sortingResult.size(), 6);
         Assert.assertTrue(sortingResult.contains(binaryTree));
@@ -68,88 +79,77 @@ public class EntitySorterTest {
 
     @Test(expected = InvalidRelationshipException.class)
     public void shouldSignalInvalidBidirectionalRelationship() {
-        EntitySorter.sortByHasARelation(getInvalidDataModel());
+        EntitySorter.sortByHasARelation(getInvalidDataModel(), schemaHolder);
     }
 
     @Test(expected = InvalidEntitySettingsException.class)
     public void shouldSignalInvalidHistoryTrackingSettings() {
-        List<Entity> entities = getValidDataModel();
+        List<EntityDto> entities = getValidDataModel();
+        entities.get(0).setRecordHistory(false);
 
-        Tracking noHistory = new Tracking(entities.get(0));
-        noHistory.setRecordHistory(false);
-        entities.get(0).setTracking(noHistory);
-
-        EntitySorter.sortByHasARelation(entities);
+        EntitySorter.sortByHasARelation(entities, schemaHolder);
     }
 
-    private List<Entity> getInvalidDataModel() {
-        return Arrays.asList(book, author, entity1, entity2, entity3);
+    private List<EntityDto> getInvalidDataModel() {
+        return asList(book, author, entity1, entity2, entity3);
     }
 
-    private List<Entity> getValidDataModel() {
+    private List<EntityDto> getValidDataModel() {
         //Get invalid data model and fix it, by adding necessary metadata to bi-directional relationship
-        List<Entity> entities = getInvalidDataModel();
+        List<EntityDto> entities = getInvalidDataModel();
 
-        Field authorField = entities.get(0).getField("author");
-        authorField.addMetadata(new FieldMetadata(authorField, RELATED_FIELD, "book"));
+        authorFieldInBook.addMetadata(new MetadataDto(RELATED_FIELD, "book"));
 
         return entities;
     }
 
     @Before
     public void setUpEntities() {
-        book = new Entity("Book");
-        author = new Entity("Author");
+        book = new EntityDto("Book");
+        author = new EntityDto("Author");
 
-        Field bookField = new Field(book, "author", "author", new Type(ManyToManyRelationship.class));
-        bookField.addMetadata(new FieldMetadata(bookField, RELATED_CLASS, "Author"));
+        authorFieldInBook = fieldDto("author", ManyToManyRelationship.class);
+        authorFieldInBook.addMetadata(new MetadataDto(RELATED_CLASS, "Author"));
 
-        Field authorField = new Field(author, "book", "book", new Type(ManyToManyRelationship.class));
-        authorField.addMetadata(new FieldMetadata(authorField, RELATED_CLASS, "Book"));
+        FieldDto authorField = fieldDto("book", ManyToManyRelationship.class);
+        authorField.addMetadata(new MetadataDto(RELATED_CLASS, "Book"));
 
-        book.addField(bookField);
-        author.addField(authorField);
+        when(schemaHolder.getFields(book)).thenReturn(singletonList(authorFieldInBook));
+        when(schemaHolder.getFields(author)).thenReturn(singletonList(authorField));
 
-        entity1 = new Entity("Entity1");
-        entity2 = new Entity("Entity2");
-        entity3 = new Entity("Entity3");
+        entity1 = new EntityDto("Entity1");
+        entity2 = new EntityDto("Entity2");
+        entity3 = new EntityDto("Entity3");
 
-        Field entity1Field = new Field(entity1, "entity1", "entity1", new Type(OneToOneRelationship.class));
-        entity1Field.addMetadata(new FieldMetadata(entity1Field, RELATED_CLASS, "Entity2"));
+        FieldDto entity1Field = fieldDto("entity1", OneToOneRelationship.class);
+        entity1Field.addMetadata(new MetadataDto(RELATED_CLASS, "Entity2"));
 
-        Field entity2Field = new Field(entity2, "entity2", "entity2", new Type(OneToOneRelationship.class));
-        entity2Field.addMetadata(new FieldMetadata(entity2Field, RELATED_CLASS, "Entity3"));
+        FieldDto entity2Field = fieldDto("entity2", OneToOneRelationship.class);
+        entity2Field.addMetadata(new MetadataDto(RELATED_CLASS, "Entity3"));
 
-        entity1.addField(entity1Field);
-        entity2.addField(entity2Field);
+        when(schemaHolder.getFields(entity1)).thenReturn(singletonList(entity1Field));
+        when(schemaHolder.getFields(entity2)).thenReturn(singletonList(entity2Field));
 
-        parentEntity = new Entity("Parent");
-        childEntity = new Entity("Child");
+        parentEntity = new EntityDto("Parent");
+        childEntity = new EntityDto("Child");
         childEntity.setSuperClass("Parent");
 
-        binaryTree = new Entity("Binary tree");
-        Field leftChild = new Field(binaryTree, "leftChild", "Left child", new Type(OneToOneRelationship.class));
-        leftChild.addMetadata(new FieldMetadata(leftChild, RELATED_CLASS, "Binary tree"));
+        binaryTree = new EntityDto("Binary tree");
+        FieldDto leftChild = fieldDto("leftChild", "Left child", OneToOneRelationship.class);
+        leftChild.addMetadata(new MetadataDto(RELATED_CLASS, "Binary tree"));
 
-        Field rightChild = new Field(binaryTree, "rightChild", "Right child", new Type(OneToOneRelationship.class));
-        rightChild.addMetadata(new FieldMetadata(rightChild, RELATED_CLASS, "Binary tree"));
+        FieldDto rightChild = fieldDto("rightChild", "Right child", OneToOneRelationship.class);
+        rightChild.addMetadata(new MetadataDto(RELATED_CLASS, "Binary tree"));
 
-        binaryTree.addField(leftChild);
-        binaryTree.addField(rightChild);
+        when(schemaHolder.getFields(binaryTree)).thenReturn(asList(leftChild, rightChild));
 
-        setHistoryTracking(entity1);
-        setHistoryTracking(entity2);
-        setHistoryTracking(entity3);
-        setHistoryTracking(book);
-        setHistoryTracking(author);
-        setHistoryTracking(parentEntity);
-        setHistoryTracking(childEntity);
-        setHistoryTracking(binaryTree);
-    }
-
-    private void setHistoryTracking(Entity entity) {
-        Tracking tracking = new Tracking(entity);
-        tracking.setRecordHistory(true);
-        entity.setTracking(tracking);
+        entity1.setRecordHistory(true);
+        entity2.setRecordHistory(true);
+        entity3.setRecordHistory(true);
+        book.setRecordHistory(true);
+        author.setRecordHistory(true);
+        parentEntity.setRecordHistory(true);
+        childEntity.setRecordHistory(true);
+        binaryTree.setRecordHistory(true);
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/helper/EntitySorterTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/helper/EntitySorterTest.java
@@ -45,7 +45,8 @@ public class EntitySorterTest {
 
     @Test
     public void shouldProperlySortByHasARelation() {
-        List<EntityDto> entities = EntitySorter.sortByHasARelation(getValidDataModel(), schemaHolder);
+        fixDataModel();
+        List<EntityDto> entities = EntitySorter.sortByHasARelation(getDataModel(), schemaHolder);
 
         Assert.assertTrue(entities.indexOf(entity3) < entities.indexOf(entity2));
         Assert.assertTrue(entities.indexOf(entity3) < entities.indexOf(entity1));
@@ -67,8 +68,9 @@ public class EntitySorterTest {
 
     @Test
     public void shouldNotSignalErrorOnSelfRelation() {
+        fixDataModel();
         List<EntityDto> initialList = new ArrayList<>();
-        initialList.addAll(getValidDataModel());
+        initialList.addAll(getDataModel());
         initialList.add(binaryTree);
 
         List<EntityDto> sortingResult = EntitySorter.sortByHasARelation(initialList, schemaHolder);
@@ -79,28 +81,24 @@ public class EntitySorterTest {
 
     @Test(expected = InvalidRelationshipException.class)
     public void shouldSignalInvalidBidirectionalRelationship() {
-        EntitySorter.sortByHasARelation(getInvalidDataModel(), schemaHolder);
+        EntitySorter.sortByHasARelation(getDataModel(), schemaHolder);
     }
 
     @Test(expected = InvalidEntitySettingsException.class)
     public void shouldSignalInvalidHistoryTrackingSettings() {
-        List<EntityDto> entities = getValidDataModel();
+        fixDataModel();
+        List<EntityDto> entities = getDataModel();
         entities.get(0).setRecordHistory(false);
 
         EntitySorter.sortByHasARelation(entities, schemaHolder);
     }
 
-    private List<EntityDto> getInvalidDataModel() {
+    private List<EntityDto> getDataModel() {
         return asList(book, author, entity1, entity2, entity3);
     }
 
-    private List<EntityDto> getValidDataModel() {
-        //Get invalid data model and fix it, by adding necessary metadata to bi-directional relationship
-        List<EntityDto> entities = getInvalidDataModel();
-
+    private void fixDataModel() {
         authorFieldInBook.addMetadata(new MetadataDto(RELATED_FIELD, "book"));
-
-        return entities;
     }
 
     @Before
@@ -111,11 +109,11 @@ public class EntitySorterTest {
         authorFieldInBook = fieldDto("author", ManyToManyRelationship.class);
         authorFieldInBook.addMetadata(new MetadataDto(RELATED_CLASS, "Author"));
 
-        FieldDto authorField = fieldDto("book", ManyToManyRelationship.class);
-        authorField.addMetadata(new MetadataDto(RELATED_CLASS, "Book"));
+        FieldDto bookFieldInAuthor = fieldDto("book", ManyToManyRelationship.class);
+        bookFieldInAuthor.addMetadata(new MetadataDto(RELATED_CLASS, "Book"));
 
         when(schemaHolder.getFields(book)).thenReturn(singletonList(authorFieldInBook));
-        when(schemaHolder.getFields(author)).thenReturn(singletonList(authorField));
+        when(schemaHolder.getFields(author)).thenReturn(singletonList(bookFieldInAuthor));
 
         entity1 = new EntityDto("Entity1");
         entity2 = new EntityDto("Entity2");

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseInstanceIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseInstanceIT.java
@@ -6,6 +6,7 @@ import org.mockito.MockitoAnnotations;
 import org.motechproject.mds.builder.MDSConstructor;
 import org.motechproject.mds.dto.EntityDto;
 import org.motechproject.mds.dto.FieldDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TrackingDto;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.repository.AllEntities;
@@ -187,7 +188,8 @@ public abstract class BaseInstanceIT extends BaseIT {
         tracking.setAllowDeleteEvent(false);
         entityService.updateTracking(entity.getId(), tracking);
 
-        mdsConstructor.constructEntities();
+        SchemaHolder schemaHolder = entityService.getSchema();
+        mdsConstructor.constructEntities(schemaHolder);
 
         PersistenceManagerFactory factory = getPersistenceManagerFactory();
 

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
@@ -30,6 +30,7 @@ import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.LookupFieldDto;
 import org.motechproject.mds.dto.LookupFieldType;
 import org.motechproject.mds.dto.MetadataDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.osgi.TestClass;
@@ -203,7 +204,8 @@ public class MdsBundleIT extends BasePaxIT {
         //Some additional preparation needed for second run without l2 cache
         if(!withCache) {
             clearEntities();
-            generator.regenerateMdsDataBundle();
+            SchemaHolder schemaHolder = entityService.getSchema();
+            generator.regenerateMdsDataBundle(schemaHolder);
         }
 
         prepareTestEntities();
@@ -243,7 +245,9 @@ public class MdsBundleIT extends BasePaxIT {
         entityService.saveDraftEntityChanges(entityId, draft);
         entityService.commitChanges(entityId);
 
-        generator.regenerateMdsDataBundle(true);
+        SchemaHolder schemaHolder = entityService.getSchema();
+
+        generator.regenerateMdsDataBundle(schemaHolder, true);
         service = (MotechDataService) ServiceRetriever.getService(bundleContext, ClassName.getInterfaceName(FOO_CLASS), true);
 
         assertValuesEqual(getExpectedComboboxValues(), getValues(service.retrieveAll()));
@@ -582,7 +586,8 @@ public class MdsBundleIT extends BasePaxIT {
         entityService.saveDraftEntityChanges(entityId, DraftBuilder.forFieldEdit(fieldToUpdate.getId(), "basic.name", "newFieldName"));
         entityService.commitChanges(entityId);
 
-        generator.regenerateMdsDataBundle();
+        SchemaHolder schemaHolder = entityService.getSchema();
+        generator.regenerateMdsDataBundle(schemaHolder);
 
         FieldDto fieldToUpdateDto = DtoHelper.findByName(entityService.getEntityFields(entityId), "newFieldName");
 
@@ -602,7 +607,9 @@ public class MdsBundleIT extends BasePaxIT {
 
         entityService.saveDraftEntityChanges(entityId, DraftBuilder.forFieldEdit(fieldToUpdate.getId(), "basic.name", "someString"));
         entityService.commitChanges(entityId);
-        generator.regenerateMdsDataBundle();
+
+        schemaHolder = entityService.getSchema();
+        generator.regenerateMdsDataBundle(schemaHolder);
 
         service = (MotechDataService) ServiceRetriever.getService(bundleContext, ClassName.getInterfaceName(FOO_CLASS), true);
     }
@@ -751,7 +758,9 @@ public class MdsBundleIT extends BasePaxIT {
 
         EntityDto entityDto = new EntityDto(9999L, FOO);
         entityDto = entityService.createEntity(entityDto);
-        generator.regenerateMdsDataBundle();
+
+        SchemaHolder schemaHolder = entityService.getSchema();
+        generator.regenerateMdsDataBundle(schemaHolder);
 
         List<FieldDto> fields = new ArrayList<>();
         fields.add(new FieldDto(null, entityDto.getId(),
@@ -880,7 +889,9 @@ public class MdsBundleIT extends BasePaxIT {
 
         entityService.addLookups(entityDto.getId(), lookups);
         entityService.commitChanges(entityDto.getId());
-        generator.regenerateMdsDataBundle();
+
+        schemaHolder = entityService.getSchema();
+        generator.regenerateMdsDataBundle(schemaHolder);
 
         getLogger().info("Entities ready for testing");
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
@@ -20,6 +20,7 @@ import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.LookupFieldDto;
 import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.dto.RestOptionsDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
@@ -126,7 +127,9 @@ public class EntityServiceContextIT extends BaseIT {
         setProperty(monitor, "bundleStarted", true);
         setProperty(monitor, "bundleInstalled", true);
         setProperty(monitor, "contextInitialized", true);
-        jarGeneratorService.regenerateMdsDataBundle();
+
+        SchemaHolder schemaHolder = entityService.getSchema();
+        jarGeneratorService.regenerateMdsDataBundle(schemaHolder);
 
         // then
         // 1. new entry in db should be added

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/JarGeneratorServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/JarGeneratorServiceContextIT.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.motechproject.mds.builder.MDSConstructor;
 import org.motechproject.mds.dto.EntityDto;
+import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.it.BaseIT;
 import org.motechproject.mds.javassist.MotechClassPool;
 import org.motechproject.mds.osgi.EntitiesBundleMonitor;
@@ -95,12 +96,15 @@ public class JarGeneratorServiceContextIT extends BaseIT {
         setProperty(monitor, "bundleInstalled", true);
         setProperty(monitor, "contextInitialized", true);
 
-        constructor.constructEntities();
+        SchemaHolder schemaHolder = entityService.getSchema();
+        constructor.constructEntities(schemaHolder);
     }
 
     @Test
     public void testGenerate() throws Exception {
-        File file = generator.generate();
+        SchemaHolder schemaHolder = entityService.getSchema();
+        File file = generator.generate(schemaHolder);
+
         try (FileInputStream stream = new FileInputStream(file);
              JarInputStream input = new JarInputStream(stream)) {
 

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MdsBundleRegenerationServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MdsBundleRegenerationServiceImplTest.java
@@ -75,7 +75,7 @@ public class MdsBundleRegenerationServiceImplTest {
     @Test
     public void shouldCallRegenerateMdsDataBundleAfterDdeEnhancement() {
         mdsBundleRegenerationService.regenerateMdsDataBundleAfterDdeEnhancement(MODULES);
-        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(schemaHolder,
+        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(eq(schemaHolder),
                 eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
     }
 
@@ -92,7 +92,7 @@ public class MdsBundleRegenerationServiceImplTest {
         parameters.put(MODULE_NAMES_PARAM, MODULES);
         Event event = new Event(REGENERATE_MDS_DATA_BUNDLE_AFTER_DDE_ENHANCEMENT, parameters);
         mdsBundleRegenerationService.handleEvent(event);
-        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(schemaHolder,
+        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(eq(schemaHolder),
                 eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
     }
 

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MdsBundleRegenerationServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MdsBundleRegenerationServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.service.impl;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -7,6 +8,8 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.mds.dto.SchemaHolder;
+import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.motechproject.server.osgi.event.OsgiEventProxy;
 import org.osgi.service.event.Event;
@@ -19,8 +22,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.motechproject.mds.service.MdsBundleRegenerationService.REGENERATE_MDS_DATA_BUNDLE;
 import static org.motechproject.mds.service.MdsBundleRegenerationService.REGENERATE_MDS_DATA_BUNDLE_AFTER_DDE_ENHANCEMENT;
 
@@ -39,34 +42,41 @@ public class MdsBundleRegenerationServiceImplTest {
     private JarGeneratorService jarGeneratorService;
 
     @Mock
+    private EntityService entityService;
+
+    @Mock
+    private SchemaHolder schemaHolder;
+
+    @Mock
     private MdsBundleRegenerationServiceImpl mdsBundleRegenerationServiceOnOtherInstance;
 
     @InjectMocks
     private MdsBundleRegenerationServiceImpl mdsBundleRegenerationService = new MdsBundleRegenerationServiceImpl();
 
-    @Test
-    public void shouldCallRegenerateMdsDataBundle() {
-        mdsBundleRegenerationService.regenerateMdsDataBundle();
-        verify(jarGeneratorService, times(1)).regenerateMdsDataBundle();
+    @Before
+    public void setUp() {
+        when(entityService.getSchema()).thenReturn(schemaHolder);
     }
 
     @Test
-    public void shouldBroadcastRegenerateMdsDataBundleEvent() {
+    public void shouldBroadcastRegenerateMdsDataBundleEventAndRegenerateTheBundle() {
         mdsBundleRegenerationService.regenerateMdsDataBundle();
+        verify(jarGeneratorService).regenerateMdsDataBundle(schemaHolder);
         verify(osgiEventProxy).broadcastEvent(eq(REGENERATE_MDS_DATA_BUNDLE), argThat(new ParamsMatcher(null)), eq(true));
     }
 
     @Test
     public void shouldHandleRegenerateMdsDataBundle() {
-        Event event = new Event(REGENERATE_MDS_DATA_BUNDLE, new HashMap<String, Object>());
+        Event event = new Event(REGENERATE_MDS_DATA_BUNDLE, new HashMap<>());
         mdsBundleRegenerationService.handleEvent(event);
-        verify(jarGeneratorService).regenerateMdsDataBundle();
+        verify(jarGeneratorService).regenerateMdsDataBundle(schemaHolder);
     }
 
     @Test
     public void shouldCallRegenerateMdsDataBundleAfterDdeEnhancement() {
         mdsBundleRegenerationService.regenerateMdsDataBundleAfterDdeEnhancement(MODULES);
-        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
+        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(schemaHolder,
+                eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
     }
 
     @Test
@@ -82,7 +92,8 @@ public class MdsBundleRegenerationServiceImplTest {
         parameters.put(MODULE_NAMES_PARAM, MODULES);
         Event event = new Event(REGENERATE_MDS_DATA_BUNDLE_AFTER_DDE_ENHANCEMENT, parameters);
         mdsBundleRegenerationService.handleEvent(event);
-        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
+        verify(jarGeneratorService).regenerateMdsDataBundleAfterDdeEnhancement(schemaHolder,
+                eq(PUPPIES_MODULE), eq(KITTIES_MODULE));
     }
 
     @Test
@@ -90,9 +101,9 @@ public class MdsBundleRegenerationServiceImplTest {
         ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
         doNothing().when(osgiEventProxy).broadcastEvent(anyString(), captor.capture(), eq(true));
         mdsBundleRegenerationService.regenerateMdsDataBundle();
-        verify(jarGeneratorService).regenerateMdsDataBundle();
+        verify(jarGeneratorService).regenerateMdsDataBundle(schemaHolder);
         mdsBundleRegenerationService.handleEvent(new Event(REGENERATE_MDS_DATA_BUNDLE, captor.getValue()));
-        verify(jarGeneratorService).regenerateMdsDataBundle();
+        verify(jarGeneratorService).regenerateMdsDataBundle(schemaHolder);
     }
 
     private class ParamsMatcher extends ArgumentMatcher<Map<String, Object>> {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.testutil;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.motechproject.commons.date.model.Time;
 import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.Field;
@@ -17,6 +18,7 @@ import org.motechproject.mds.dto.TypeDto;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.TypeHelper;
 
+import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -143,6 +145,8 @@ public final class FieldTestHelper {
             return LocalDate.now();
         } else if (LocalDateTime.class.equals(clazz)) {
             return LocalDateTime.now();
+        } else if (Byte[].class.equals(clazz)) {
+            return ArrayUtils.toObject("test".getBytes(Charset.forName("UTF-8")));
         } else {
             return clazz.newInstance();
         }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/testutil/FieldTestHelper.java
@@ -160,10 +160,18 @@ public final class FieldTestHelper {
         return fieldDto(id, name, clazz.getName(), null, null);
     }
 
+    public static FieldDto fieldDto(String name, String displayName, Class clazz) {
+        return fieldDto(null, name, clazz.getName(), displayName, null);
+    }
+
     public static FieldDto requiredFieldDto(Long id, String name, Class clazz) {
         FieldDto field = fieldDto(id, name, clazz);
         field.getBasic().setRequired(true);
         return field;
+    }
+
+    public static FieldDto fieldDtoWithDefVal(String name, Class<?> clazz, Object defValue) {
+        return fieldDto(null, name, clazz.getName(), name, defValue);
     }
 
     public static FieldDto fieldDto(Long id, String name, String className,

--- a/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/BundleType.java
+++ b/platform/osgi-platform/src/main/java/org/motechproject/server/osgi/util/BundleType.java
@@ -4,6 +4,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -58,8 +59,8 @@ public enum BundleType {
             "commons-api", "commons-sql", "commons-date", "osgi-web-util", "server-api", "config-core", "event"
     ));
 
-    public static final Set<String> PLATFORM_PRE_WS_BUNDLES = new HashSet<>(Arrays.asList(
-        "server-config"
+    public static final Set<String> PLATFORM_PRE_WS_BUNDLES = new HashSet<>(Collections.singletonList(
+            "server-config"
     ));
 
     public static BundleType forBundle(Bundle bundle) {


### PR DESCRIPTION
I have switched MDS to use dtos instead of domain objects when building classes and
metadata. This limits database queries and minimalizes what has to be done inside a transaction,
which is a good thing. I had to change how textareas are handled a bit, since some of their UI specific
processing was woven into the dto classes, which we now use when processing. 