### PR TITLE
MOTECH-1999: Remove motech-osgi-platform from admin module management

### DIFF
--- a/modules/admin/src/main/java/org/motechproject/admin/bundles/DefaultBundleFilter.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/bundles/DefaultBundleFilter.java
@@ -19,6 +19,7 @@ public class DefaultBundleFilter extends MotechBundleFilter {
 
     private static final String MOTECH_PACKAGE = "org.motechproject";
     private static final String PLATFORM_PREFIX = MOTECH_PACKAGE + ".motech-platform";
+    private static final String OSGI_PLATFORM_NAME = MOTECH_PACKAGE + ".motech-osgi-platform";
     private static final String FRAMEWORK_NAME = "org.apache.felix.framework";
 
     @Autowired
@@ -39,7 +40,8 @@ public class DefaultBundleFilter extends MotechBundleFilter {
     private boolean isPlatformBundle(Bundle bundle) {
         String symbolicName = bundle.getSymbolicName();
         return StringUtils.startsWith(symbolicName, PLATFORM_PREFIX) || StringUtils.equals(symbolicName, FRAMEWORK_NAME)
-                || StringUtils.equals(symbolicName, bundleContext.getBundle().getSymbolicName());
+                || StringUtils.equals(symbolicName, bundleContext.getBundle().getSymbolicName())
+                || StringUtils.equals(symbolicName, OSGI_PLATFORM_NAME);
 
     }
 }

--- a/modules/admin/src/test/java/org/motechproject/admin/bundles/DefaultBundleFilterTest.java
+++ b/modules/admin/src/test/java/org/motechproject/admin/bundles/DefaultBundleFilterTest.java
@@ -97,4 +97,12 @@ public class DefaultBundleFilterTest {
 
         assertFalse(bundleFilter.passesCriteria(bundle));
     }
+
+    @Test
+    public void testOSGiPlatformBundle() {
+        when(bundle.getSymbolicName()).thenReturn("org.motechproject.motech-osgi-platform");
+        when(headers.get(ExtendedBundleInformation.EXPORT_PACKAGE)).thenReturn(MOTECH_IMPORT_EXPORT);
+
+        assertFalse(bundleFilter.passesCriteria(bundle));
+    }
 }


### PR DESCRIPTION
This bundle should not be managed by users, stopping it can break
the system.