### PR TITLE
MOTECH-1800: UserPreferences for MDS entities

### DIFF
--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/EntityController.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/controller/EntityController.java
@@ -9,9 +9,11 @@ import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.MdsBundleRegenerationService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.web.SelectData;
 import org.motechproject.mds.web.SelectResult;
 import org.motechproject.mds.web.comparator.EntityNameComparator;
+import org.motechproject.mds.web.domain.GridFieldSelectionUpdate;
 import org.motechproject.mds.web.matcher.EntityMatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -33,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.motechproject.mds.util.Constants.Roles;
+import static org.motechproject.mds.util.SecurityUtil.getUsername;
 
 /**
  * The <code>EntityController</code> is the Spring Framework Controller used by view layer for
@@ -47,6 +50,7 @@ public class EntityController extends MdsController {
 
     private MdsBundleRegenerationService mdsBundleRegenerationService;
     private EntityService entityService;
+    private UserPreferencesService userPreferencesService;
 
     @RequestMapping(value = "/entities/byModule", method = RequestMethod.GET)
     @ResponseBody
@@ -255,6 +259,33 @@ public class EntityController extends MdsController {
         return entityService.getAdvancedSettings(entityId, true);
     }
 
+    @RequestMapping(value = "/entities/{entityId}/preferences/fields", method = RequestMethod.POST)
+    @PreAuthorize(Roles.DATA_ACCESS)
+    @ResponseStatus(HttpStatus.OK)
+    public void updateEntityDispleyableFieldsForUser(@RequestBody GridFieldSelectionUpdate fieldPreferences, @PathVariable Long entityId) {
+        switch (fieldPreferences.getAction()) {
+            case ADD:
+                userPreferencesService.selectField(entityId, getUsername(), fieldPreferences.getField());
+                break;
+            case ADD_ALL:
+                userPreferencesService.selectFields(entityId, getUsername());
+                break;
+            case REMOVE:
+                userPreferencesService.unselectField(entityId, getUsername(), fieldPreferences.getField());
+                break;
+            case REMOVE_ALL:
+                userPreferencesService.unselectFields(entityId, getUsername());
+                break;
+        }
+    }
+
+    @RequestMapping(value = "/entities/{entityId}/preferences/gridSize", method = RequestMethod.POST)
+    @PreAuthorize(Roles.DATA_ACCESS)
+    @ResponseStatus(HttpStatus.OK)
+    public void updateEntityGridRowsNumberForUser(@RequestBody Integer pageSize, @PathVariable Long entityId) {
+        userPreferencesService.updateGridSize(entityId, getUsername(), pageSize);
+    }
+
     @Autowired
     public void setEntityService(EntityService entityService) {
         this.entityService = entityService;
@@ -263,5 +294,10 @@ public class EntityController extends MdsController {
     @Autowired
     public void setMdsBundleRegenerationService(MdsBundleRegenerationService mdsBundleRegenerationService) {
         this.mdsBundleRegenerationService = mdsBundleRegenerationService;
+    }
+
+    @Autowired
+    public void setUserPreferencesService(UserPreferencesService userPreferencesService) {
+        this.userPreferencesService = userPreferencesService;
     }
 }

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridFieldSelectionUpdate.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridFieldSelectionUpdate.java
@@ -1,0 +1,35 @@
+package org.motechproject.mds.web.domain;
+
+/**
+ * The <code>GridFieldSelectionUpdate</code> contains data about a visible fields update.
+ */
+public class GridFieldSelectionUpdate {
+
+    private String field;
+
+    private GridSelectionAction action;
+
+    public GridFieldSelectionUpdate() {}
+
+    public GridFieldSelectionUpdate(String field, GridSelectionAction action) {
+        this.field = field;
+        this.action = action;
+    }
+
+    public GridSelectionAction getAction() {
+        return action;
+    }
+
+    public void setAction(GridSelectionAction action) {
+        this.action = action;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+}

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridSelectionAction.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridSelectionAction.java
@@ -1,0 +1,27 @@
+package org.motechproject.mds.web.domain;
+
+/**
+ * The <code>GridSelectionAction</code> Enum contains the possible actions for a visible fields update.
+ */
+public enum GridSelectionAction {
+
+    /**
+     * Add field to visible fields.
+     */
+    ADD,
+
+    /**
+     * Add all fields to visible fields.
+     */
+    ADD_ALL,
+
+    /**
+     * Remove field from visible fields.
+     */
+    REMOVE,
+
+    /**
+     * Removes all field from visible fields.
+     */
+    REMOVE_ALL
+}

--- a/platform/mds/mds-web/src/main/resources/META-INF/spring/blueprint.xml
+++ b/platform/mds/mds-web/src/main/resources/META-INF/spring/blueprint.xml
@@ -20,6 +20,8 @@
 
     <osgi:reference id="entityServiceOSGi" interface="org.motechproject.mds.service.EntityService"/>
 
+    <osgi:reference id="userPreferencesServiceOSGi" interface="org.motechproject.mds.service.UserPreferencesService"/>
+
     <osgi:reference id="historyServiceOSGi" interface="org.motechproject.mds.service.HistoryService" availability="optional"/>
 
     <osgi:reference id="trashServiceOSGi" interface="org.motechproject.mds.service.TrashService" availability="optional"/>

--- a/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
@@ -152,18 +152,29 @@
     * whether is selected for display in the jqGrid
     */
     function isSelectedField(name, selectedFields) {
-        var result = true;
-        if (selectedFields !== undefined && $.isArray(selectedFields)) {
-            $.each(selectedFields, function (i, sField) {
-                if(name === sField.basic.name) {
-                    result = true;
-                } else {
-                    result = false;
+        var i;
+        if (selectedFields) {
+            for (i = 0; i < selectedFields.length; i += 1) {
+                if (name === selectedFields[i].basic.name) {
+                    return true;
                 }
-                return (!result);
-            });
+            }
         }
-        return result;
+        return false;
+    }
+
+    function handleGridPagination(pgButton, pager, scope) {
+        var newPage = 1, last, newSize;
+        if ("user" === pgButton) { //Handle changing page by the page input
+            newPage = parseInt(pager.find('input:text').val(), 10); // get new page number
+            last = parseInt($(this).getGridParam("lastpage"), 10); // get last page number
+            if (newPage > last || newPage === 0) { // check range - if we cross range then stop
+                return 'stop';
+            }
+        } else if ("records" === pgButton) { //Page size change, we must update scope value to avoid wrong page size in the trash screen
+            newSize = parseInt(pager.find('select')[0].value, 10);
+            scope.entityAdvanced.userPreferences.gridRowsNumber = newSize;
+        }
     }
 
     function buildGridColModel(colModel, fields, scope, ignoreHideFields) {
@@ -1291,6 +1302,10 @@
                             postData: {
                                 fields: JSON.stringify(scope.lookupBy)
                             },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
+                            },
                             jsonReader: {
                                 repeatitems: false
                             },
@@ -1547,11 +1562,10 @@
                                 var name = scope.getFieldName(optionElement.text());
                                 // don't act for fields show automatically in trash and history
                                 if (scope.autoDisplayFields.indexOf(name) === -1) {
-                                    // set the cookie, users have their own browsing settings
-                                    scope.markFieldForDataBrowser(name, checked);
+                                    scope.addFieldForDataBrowser(name, checked);
                                 }
                             } else {
-                                scope.markAllFieldsForDataBrowser(checked);
+                                scope.addFieldsForDataBrowser(checked);
                             }
 
                             noSelectedFields = true;
@@ -1640,6 +1654,10 @@
                                 } else {
                                     scope.historyInstance(id);
                                 }
+                            },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
                             },
                             resizeStop: function (width, index) {
                                 var widthNew, widthOrg, colModel = $('#' + gridId).jqGrid('getGridParam','colModel');
@@ -1761,6 +1779,10 @@
                             },
                             jsonReader: {
                                 repeatitems: false
+                            },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
                             },
                             onSelectRow: function (id) {
                                 firstLoad = true;

--- a/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
+++ b/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
@@ -390,7 +390,7 @@ mds.dataBrowsing.editRelatedInstance=Edit related instance
 mds.dataBrowsing.removeRelatedInstance=Remove related instance
 
 #Settings
-mds.tab.dataRetention=Data retention
+mds.tab.mdsSettings=Mds settings
 mds.tab.import=Import
 mds.tab.export=Export
 
@@ -402,6 +402,10 @@ mds.dataRetention.emptyTrash=Empty the trash
 mds.dataRetention.save=Save settings
 mds.dataRetention.success=Settings has been saved
 mds.dataRetention.error=Error while saving settings
+
+# User preferences
+mds.userPreferences.info=Default Data Browser preferences
+mds.userPreferences.gridSize=Default grid size
 
 #Date-Time units
 mds.dateTimeUnits.seconds=Seconds
@@ -490,3 +494,5 @@ mds.operator.matches = Matches
 mds.operator.matches.ci = Matches (Case Insensitive)
 mds.operator.starts = Starts with
 mds.operator.ends = Ends with
+
+mds.preferences.error.fields=Cannot update visible fields preferences.

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/settings.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/settings.html
@@ -2,7 +2,7 @@
     <div id="settings-tab">
         <ul class="nav nav-tabs mds-settings" id="myTab">
             <li class="active">
-                <a target="_self" href="#data-retention" data-toggle="tab">{{msg('mds.tab.dataRetention')}}</a>
+                <a target="_self" href="#mds-settings" data-toggle="tab">{{msg('mds.tab.mdsSettings')}}</a>
             </li>
             <li>
                 <a target="_self" href="#import" data-toggle="tab">{{msg('mds.tab.import')}}</a>
@@ -13,8 +13,8 @@
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane active inside" id="data-retention">
-                <div ng-include="'../mds/resources/partials/widgets/data-retention.html'"></div>
+            <div class="tab-pane active inside" id="mds-settings">
+                <div ng-include="'../mds/resources/partials/widgets/mds-settings.html'"></div>
             </div>
             <div class="tab-pane" id="import">
                 <div ng-include="'../mds/resources/partials/widgets/import.html'"></div>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
@@ -89,7 +89,7 @@
         </div>
     </div>
 
-    <div id="entityInstancesTable" class="overrideJqgridTable">
+    <div ng-if="entityAdvanced" id="entityInstancesTable" class="overrideJqgridTable">
         <table id="instancesTable" entity-instances-grid="pageInstancesTable"></table>
         <div id="pageInstancesTable"></div>
     </div>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/mds-settings.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/mds-settings.html
@@ -24,6 +24,17 @@
             <select class="form-control input-auto" ng-disabled="checkTimeSelectDisable()" ng-model="settings.timeUnit" ng-options="t.value as t.label for t in timeUnits"></select>
         </div>
     </div>
+    <div class="form-group">
+        {{msg('mds.userPreferences.info')}}
+    </div>
+    <div class="form-group form-inline">
+        <label class="label-radio">
+            {{msg('mds.userPreferences.gridSize')}}
+        </label>
+        <div class="settings-input-group">
+            <select class="form-control input-auto" ng-model="settings.gridSize" ng-options="size for size in gridSizes"></select>
+        </div>
+    </div>
     <span class="btn btn-default" ng-click="saveSettings()">{{msg('mds.dataRetention.save')}}</span>
 
 </form>

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/ExampleData.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/ExampleData.java
@@ -154,6 +154,35 @@ public class ExampleData {
         instanceFields.add(new FieldInstanceDto(2L, 1L, new FieldBasicDto("User", "user")));
         instanceFields.add(new FieldInstanceDto(3L, 1L, new FieldBasicDto("Action", "action")));
         instanceFields.add(new FieldInstanceDto(4L, 1L, new FieldBasicDto("Changes", "changes")));
+
+        draftFields.add(
+                new FieldDto(
+                        12L, 9007L, STRING,
+                        new FieldBasicDto("ID", "ID", false, "pass", null, null),
+                        false, null,
+                        FieldValidationDto.STRING, null, null
+                )
+        );
+
+        draftFields.add(
+                new FieldDto(
+                        13L, 9007L, STRING,
+                        new FieldBasicDto("Sample", "Sample", false, "pass", null, null),
+                        false, null,
+                        FieldValidationDto.STRING, null, null
+                )
+        );
+
+        List<MetadataDto> exampleMetadata = new LinkedList<>();
+        exampleMetadata.add(new MetadataDto("key1", "value1"));
+        exampleMetadata.add(new MetadataDto("key2", "value2"));
+        draftFields.add(
+                new FieldDto(
+                        14L, 9005L, STRING,
+                        new FieldBasicDto("Other", "Other", false, "test", null, null),
+                        false, exampleMetadata, FieldValidationDto.STRING, null, null
+                )
+        );
     }
 
     public List<FieldDto> getFields(Long entityId) {

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/controller/EntityControllerTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/controller/EntityControllerTest.java
@@ -1,11 +1,15 @@
 package org.motechproject.mds.web.controller;
 
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.motechproject.mds.dto.AdvancedSettingsDto;
 import org.motechproject.mds.dto.DraftData;
@@ -20,18 +24,33 @@ import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.ex.entity.EntityReadOnlyException;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.MdsBundleRegenerationService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.util.SecurityMode;
 import org.motechproject.mds.web.ExampleData;
 import org.motechproject.mds.web.SelectData;
 import org.motechproject.mds.web.SelectResult;
 import org.motechproject.mds.web.TestData;
+import org.motechproject.mds.web.domain.GridFieldSelectionUpdate;
+import org.motechproject.mds.web.domain.GridSelectionAction;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.test.web.server.MockMvc;
+import org.springframework.test.web.server.ResultActions;
+import org.springframework.test.web.server.setup.MockMvcBuilders;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,10 +64,19 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.motechproject.mds.dto.TypeDto.STRING;
+import static org.springframework.test.web.server.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.server.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.server.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.server.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.server.result.MockMvcResultMatchers.status;
 
+@RunWith(MockitoJUnitRunner.class)
 public class EntityControllerTest {
+
+    private static final String ENTITY_NOT_FOUND = "key:mds.error.entityNotFound";
+    private static final String ENTITY_READ_ONLY = "key:mds.error.entityIsReadOnly";
+    private static final String ENTITY_ALREADY_EXSIST = "key:mds.error.entityAlreadyExist";
 
     @Mock
     private EntityService entityService;
@@ -56,17 +84,21 @@ public class EntityControllerTest {
     @Mock
     private MdsBundleRegenerationService mdsBundleRegenerationService;
 
-    private EntityController controller;
+    @Mock
+    private UserPreferencesService userPreferencesService;
+
+    @InjectMocks
+    private EntityController entityController = new EntityController();
+
+    private MockMvc controller;
 
     private final ExampleData exampleData = new ExampleData();
 
+    ArgumentCaptor<DraftData> draftDataCaptor = ArgumentCaptor.forClass(DraftData.class);
+
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
-
-        controller = new EntityController();
-        controller.setEntityService(entityService);
-        controller.setMdsBundleRegenerationService(mdsBundleRegenerationService);
+        controller = MockMvcBuilders.standaloneSetup(entityController).build();
 
         when(entityService.listEntities()).thenReturn(TestData.getEntities());
 
@@ -108,27 +140,36 @@ public class EntityControllerTest {
         expected.add(new EntityDto(9002L, "org.motechproject.openmrs.ws.resource.model.Person", "MOTECH OpenMRS Web Services", "navio", SecurityMode.EVERYONE, null));
         expected.add(new EntityDto(9004L, "org.motechproject.openmrs.ws.resource.model.Person", "MOTECH OpenMRS Web Services", "accra", SecurityMode.EVERYONE, null));
         expected.add(new EntityDto(9007L, "org.motechproject.mds.entity.Voucher", SecurityMode.EVERYONE, null));
+        SelectResult expectedResult = new SelectResult(new SelectData(null, 1, 10), expected);
 
-        SelectResult<EntityDto> result = controller.getEntities(new SelectData(null, 1, 10));
-
-        assertEquals(expected, result.getResults());
-        assertFalse(result.isMore());
+        controller.perform(get("/selectEntities")
+                .param("term", "")
+                .param("page", String.valueOf(1))
+                .param("pageLimit", String.valueOf(10)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(new ObjectMapper().writeValueAsString(expectedResult)));
     }
 
     @Test
     public void shouldReturnEntityById() throws Exception {
-        assertEquals(new EntityDto(9007L, "org.motechproject.mds.entity.Voucher", SecurityMode.EVERYONE, null), controller.getEntity(9007L));
+        controller.perform(get("/entities/9007"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(new ObjectMapper().writeValueAsString(new EntityDto(9007L, "org.motechproject.mds.entity.Voucher",
+                        SecurityMode.EVERYONE, null))));
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldThrowExceptionIfNotFoundEntity() throws Exception {
         doThrow(new EntityNotFoundException(10L)).when(entityService).getEntityForEdit(10L);
-        controller.getEntity(10L);
+        controller.perform(get("/entities/10"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
     @Test
     public void shouldDeleteEntity() throws Exception {
-        controller.deleteEntity(9007L);
+        controller.perform(delete("/entities/9007"))
+                .andExpect(status().isOk());
 
         ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
         verify(entityService).deleteEntity(captor.capture());
@@ -136,16 +177,20 @@ public class EntityControllerTest {
         assertEquals(Long.valueOf(9007), captor.getValue());
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldThrowExceptionIfEntityToDeleteNotExists() throws Exception {
         doThrow(new EntityNotFoundException(1000L)).when(entityService).deleteEntity(1000L);
-        controller.deleteEntity(1000L);
+        controller.perform(delete("/entities/1000"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
-    @Test(expected = EntityReadOnlyException.class)
+    @Test
     public void shouldThrowExceptionIfEntityToDeleteisReadonly() throws Exception {
         doThrow(new EntityReadOnlyException("EntityName")).when(entityService).deleteEntity(9001L);
-        controller.deleteEntity(9001L);
+        controller.perform(delete("/entities/9001"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_READ_ONLY));
     }
 
     @Test
@@ -156,18 +201,25 @@ public class EntityControllerTest {
         doReturn(expected).when(entityService).createEntity(given);
         doReturn(expected).when(entityService).getEntityForEdit(9L);
 
-        assertEquals(expected, controller.saveEntity(given));
+        controller.perform(post("/entities")
+                .body(new ObjectMapper().writeValueAsBytes(given))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(new ObjectMapper().writeValueAsString(expected)));
+
         verify(entityService).createEntity(given);
     }
 
-    @Test(expected = EntityAlreadyExistException.class)
+    @Test
     public void shouldThrowExceptionIfEntityWithGivenNameExists() throws Exception {
         doThrow(new EntityAlreadyExistException("Voucher")).when(entityService).createEntity(any(EntityDto.class));
-
-        controller.saveEntity(new EntityDto(7L, "Voucher", SecurityMode.EVERYONE, null));
+        controller.perform(post("/entities")
+                .body(new ObjectMapper().writeValueAsBytes(new EntityDto(7L, "Voucher", SecurityMode.EVERYONE, null)))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_ALREADY_EXSIST));
     }
 
-    @Ignore("Ignored until we get fields from database")
     @Test
     public void shouldSaveTemporaryChange() throws Exception {
         DraftData data = new DraftData();
@@ -177,9 +229,15 @@ public class EntityControllerTest {
         data.getValues().put(DraftData.FIELD_ID, "2");
         data.getValues().put(DraftData.VALUE, singletonList("test"));
 
-        EntityDto entity = controller.getEntity(9007L);
-        List<FieldDto> fields = controller.getFields(9007L);
-        FieldDto fieldDto = findFieldById(fields, 2L);
+        ResultActions actions = controller.perform(get("/entities/9007"))
+                .andExpect(status().isOk());
+        EntityDto entity = new ObjectMapper().readValue(actions.andReturn().getResponse().getContentAsByteArray(), EntityDto.class);
+
+        actions = controller.perform(get("/entities/9007/fields"))
+                .andExpect(status().isOk());
+        List<FieldDto> fields = new ObjectMapper().readValue(actions.andReturn().getResponse().getContentAsByteArray(),
+                new TypeReference<List<FieldDto>>() {});
+        FieldDto fieldDto = findFieldById(fields, 12L);
 
         // before change
         assertFalse(entity.isModified());
@@ -187,21 +245,35 @@ public class EntityControllerTest {
         assertEquals("ID", fieldDto.getBasic().getDisplayName());
 
         // change
-        controller.draft(9007L, data);
+        controller.perform(post("/entities/9007/draft")
+                .body(new ObjectMapper().writeValueAsBytes(data))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
-        verify(entityService).saveDraftEntityChanges(9007L, data);
+        verify(entityService).saveDraftEntityChanges(eq(9007L), draftDataCaptor.capture());
+        DraftData captured = draftDataCaptor.getValue();
+        assertTrue(captured.isEdit());
+        assertEquals("basic.displayName", captured.getPath());
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldNotSaveTemporaryChangeIfEntityNotExists() throws Exception {
         doThrow(new EntityNotFoundException(100L)).when(entityService).saveDraftEntityChanges(eq(100L), any(DraftData.class));
-        controller.draft(100L, new DraftData());
+        controller.perform(post("/entities/100/draft")
+                .body(new ObjectMapper().writeValueAsString(new DraftData()).getBytes())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
-    @Test(expected = EntityReadOnlyException.class)
+    @Test
     public void shouldNotSaveTemporaryChangeIfEntityIsReadonly() throws Exception {
         doThrow(new EntityReadOnlyException("EntityName")).when(entityService).saveDraftEntityChanges(eq(9001L), any(DraftData.class));
-        controller.draft(9001L, new DraftData());
+        controller.perform(post("/entities/9001/draft")
+                .body(new ObjectMapper().writeValueAsString(new DraftData()).getBytes())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_READ_ONLY));
     }
 
     @Test
@@ -213,43 +285,53 @@ public class EntityControllerTest {
         data.getValues().put(DraftData.FIELD_ID, "2");
         data.getValues().put(DraftData.VALUE, singletonList("test"));
 
-        controller.draft(9007L, data);
-        verify(entityService).saveDraftEntityChanges(9007L, data);
+        controller.perform(post("/entities/9007/draft")
+                .body(new ObjectMapper().writeValueAsBytes(data))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        verify(entityService).saveDraftEntityChanges(eq(9007l), draftDataCaptor.capture());
 
-        controller.abandonChanges(9007L);
+        DraftData capuredData = draftDataCaptor.getValue();
+        assertNotNull(capuredData);
+        assertTrue(capuredData.isEdit());
+        assertEquals("basic.displayName", capuredData.getPath());
+
+        controller.perform(post("/entities/9007/abandon")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
         verify(entityService).abandonChanges(9007L);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldNotAbandonChangesIfEntityNotExists() throws Exception {
         doThrow(new EntityNotFoundException(10000L)).when(entityService).abandonChanges(10000L);
-        controller.abandonChanges(10000L);
+        controller.perform(post("/entities/10000/abandon")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
+        verify(entityService).abandonChanges(10000L);
     }
 
-    @Ignore("Ignored until we get drafts working with db")
     @Test
     public void shouldCommitChanges() throws Exception {
-        DraftData data = new DraftData();
-        data.setEdit(true);
-        data.setValues(new HashMap<String, Object>());
-        data.getValues().put(DraftData.PATH, "basic.displayName");
-        data.getValues().put(DraftData.FIELD_ID, "2");
-        data.getValues().put(DraftData.VALUE, Arrays.asList("test"));
+        when(entityService.commitChanges(9007L)).thenReturn(new ArrayList<String>());
 
-        controller.draft(9007L, data);
-        assertTrue(controller.getEntity(9007L).isModified());
-
-        controller.commitChanges(9007L);
-        assertFalse(controller.getEntity(9007L).isModified());
+        controller.perform(post("/entities/9007/commit")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        verify(entityService).commitChanges(9007l);
+        verify(mdsBundleRegenerationService).regenerateMdsDataBundle();
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldNotComitChangesIfEntityNotExists() throws Exception {
         doThrow(new EntityNotFoundException(10000L)).when(entityService).commitChanges(10000L);
-        controller.commitChanges(10000L);
+        controller.perform(post("/entities/10000/commit")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
-    @Ignore("Ignored until we get fields from database")
     @Test
     public void shouldGetEntityFields() throws Exception {
         List<MetadataDto> exampleMetadata = new LinkedList<>();
@@ -259,23 +341,27 @@ public class EntityControllerTest {
         List<FieldDto> expected = new LinkedList<>();
         expected.add(
                 new FieldDto(
-                        1L, 9005L, STRING,
-                        new FieldBasicDto("ID", "ID", false, "pass", null, null),
+                        14L, 9005L, STRING,
+                        new FieldBasicDto("Other", "Other", false, "test", null, null),
                         false, exampleMetadata, FieldValidationDto.STRING, null, null
                 )
         );
 
-        assertEquals(expected, controller.getFields(9005L));
-
+        ResultActions actions = controller.perform(get("/entities/9005/fields"))
+                .andExpect(status().isOk());
+        List<FieldDto> fields = new ObjectMapper().readValue(actions.andReturn().getResponse().getContentAsByteArray(),
+                new TypeReference<List<FieldDto>>() {});
+        assertEquals(expected, fields);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldNotGetEntityFieldsIfEntityNotExists() throws Exception {
         doThrow(new EntityNotFoundException(10000L)).when(entityService).getFields(10000L);
-        controller.getFields(10000L);
+        controller.perform(get("/entities/10000/fields"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
-    @Ignore("Ignored until we get fields from database")
     @Test
     public void shouldFindFieldByName() throws Exception {
         List<MetadataDto> exampleMetadata = new LinkedList<>();
@@ -283,19 +369,24 @@ public class EntityControllerTest {
         exampleMetadata.add(new MetadataDto("key2", "value2"));
 
         FieldDto expected = new FieldDto(
-                1L, 9005L, STRING,
-                new FieldBasicDto("ID", "ID", false, "pass", null, null),
+                14L, 9005L, STRING,
+                new FieldBasicDto("Other", "Other", false, "test", null, null),
                 false, exampleMetadata, FieldValidationDto.STRING, null, null
         );
 
-        assertEquals(expected, controller.getFieldByName(9005L, "ID"));
-
+        ResultActions actions = controller.perform(get("/entities/9005/fields/Other"))
+                .andExpect(status().isOk());
+        FieldDto field = new ObjectMapper().readValue(actions.andReturn().getResponse().getContentAsByteArray(),
+                FieldDto.class);
+        assertEquals(expected, field);
     }
 
-    @Test(expected = EntityNotFoundException.class)
+    @Test
     public void shouldNotFindFieldByNameIfEntityNotExists() throws Exception {
         doThrow(new EntityNotFoundException(500L)).when(entityService).findFieldByName(500L, "ID");
-        controller.getFieldByName(500L, "ID");
+        controller.perform(get("/entities/500/fields/ID"))
+                .andExpect(status().isConflict())
+                .andExpect(content().string(ENTITY_NOT_FOUND));
     }
 
     @Test
@@ -311,7 +402,85 @@ public class EntityControllerTest {
         expected.setEntityId(7L);
         expected.setRestOptions(restOptions);
 
-        assertEquals(expected, controller.getAdvanced(7L));
+        controller.perform(get("/entities/7/advanced"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(new ObjectMapper().writeValueAsString(expected)));
+    }
+
+    @Test
+    public void shouldUpdateGridSize() throws Exception {
+        setUpSecurityContext();
+        controller.perform(post("/entities/2/preferences/gridSize")
+                .body(new ObjectMapper().writeValueAsBytes(20))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(userPreferencesService).updateGridSize(2l, "motech", 20);
+    }
+
+    @Test
+    public void shouldSelectField() throws Exception {
+        setUpSecurityContext();
+        controller.perform(post("/entities/2/preferences/fields")
+                .body(new ObjectMapper().writeValueAsString(new GridFieldSelectionUpdate("fieldName",
+                        GridSelectionAction.ADD)).getBytes(Charset.forName("UTF-8")))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(userPreferencesService).selectField(2l, "motech", "fieldName");
+    }
+
+
+    @Test
+    public void shouldUnselectField() throws Exception {
+        setUpSecurityContext();
+        controller.perform(post("/entities/2/preferences/fields")
+                .body(new ObjectMapper().writeValueAsString(new GridFieldSelectionUpdate("fieldName",
+                        GridSelectionAction.REMOVE)).getBytes(Charset.forName("UTF-8")))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(userPreferencesService).unselectField(2l, "motech", "fieldName");
+    }
+
+
+    @Test
+    public void shouldSelectFields() throws Exception {
+        setUpSecurityContext();
+        controller.perform(post("/entities/2/preferences/fields")
+                .body(new ObjectMapper().writeValueAsString(new GridFieldSelectionUpdate("fieldName",
+                        GridSelectionAction.ADD_ALL)).getBytes(Charset.forName("UTF-8")))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(userPreferencesService).selectFields(2l, "motech");
+    }
+
+
+    @Test
+    public void shouldUnselectFields() throws Exception {
+        setUpSecurityContext();
+        controller.perform(post("/entities/2/preferences/fields")
+                .body(new ObjectMapper().writeValueAsString(new GridFieldSelectionUpdate("fieldName",
+                        GridSelectionAction.REMOVE_ALL)).getBytes(Charset.forName("UTF-8")))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(userPreferencesService).unselectFields(2l, "motech");
+    }
+
+    private void setUpSecurityContext() {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("mdsSchemaAccess");
+        List<SimpleGrantedAuthority> authorities = asList(authority);
+
+        User principal = new User("motech", "motech", authorities);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "motech", authorities);
+
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
     }
 
     private FieldDto findFieldById(List<FieldDto> fields, Long id) {

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.web.service.impl;
 
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,11 +19,13 @@ import org.motechproject.mds.ex.entity.EntityInstancesNonEditableException;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.ex.object.ObjectNotFoundException;
 import org.motechproject.mds.ex.object.ObjectUpdateException;
+import org.motechproject.mds.ex.object.SecurityException;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.service.DefaultMotechDataService;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.mds.service.TrashService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.MDSClassLoader;
@@ -35,7 +38,13 @@ import org.motechproject.mds.web.service.InstanceService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
-import org.motechproject.mds.ex.object.SecurityException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,9 +67,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -92,11 +104,22 @@ public class InstanceServiceTest {
     @Mock
     private TrashService trashService;
 
+    @Mock
+    private UserPreferencesService userPreferencesService;
+
     @Before
     public void setUp() {
         when(entity.getClassName()).thenReturn(TestSample.class.getName());
         when(entity.getId()).thenReturn(ENTITY_ID);
         when(bundleContext.getBundles()).thenReturn(new Bundle[0]);
+    }
+
+    @After
+    public void resetSecurity() {
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(null);
+
+        SecurityContextHolder.setContext(securityContext);
     }
 
     @Test
@@ -151,6 +174,9 @@ public class InstanceServiceTest {
 
         //Make sure all fields that were in the instance are still available
         assertEquals(records.get(0).getFields().size(), 5);
+
+        // should not perform update when username is null or blank
+        verify(userPreferencesService, never()).updateGridSize(anyLong(), anyString(), anyInt());
     }
 
     @Test(expected = ObjectNotFoundException.class)
@@ -606,6 +632,58 @@ public class InstanceServiceTest {
         EntityRecord record = new EntityRecord(INSTANCE_ID, ENTITY_ID, fieldRecords);
 
         instanceService.saveInstance(record);
+    }
+
+    @Test
+    public void shouldNotUpdateGridSizeWhenUsernameIsBlank() {
+        EntityDto entityDto = new EntityDto();
+        entityDto.setReadOnlySecurityMode(null);
+        entityDto.setSecurityMode(null);
+        entityDto.setClassName(TestSample.class.getName());
+
+        EntityRecord entityRecord = new EntityRecord(ENTITY_ID + 1, null, new ArrayList<FieldRecord>());
+
+        when(entityService.getEntity(ENTITY_ID + 1)).thenReturn(entityDto);
+
+        mockDataService();
+        instanceService.getEntityRecords(entityRecord.getId(), new QueryParams(1, 100));
+
+        verify(entityService).getEntityFields(ENTITY_ID + 1);
+        verify(userPreferencesService, never()).updateGridSize(anyLong(), anyString(), anyInt());
+    }
+
+    @Test
+    public void shouldUpdateGridSize() {
+        setUpSecurityContext();
+
+        EntityDto entityDto = new EntityDto();
+        entityDto.setReadOnlySecurityMode(null);
+        entityDto.setSecurityMode(null);
+        entityDto.setClassName(TestSample.class.getName());
+
+        EntityRecord entityRecord = new EntityRecord(ENTITY_ID + 1, null, new ArrayList<FieldRecord>());
+
+        when(entityService.getEntity(ENTITY_ID + 1)).thenReturn(entityDto);
+
+        mockDataService();
+        instanceService.getEntityRecords(entityRecord.getId(), new QueryParams(1, 100));
+
+        verify(entityService).getEntityFields(ENTITY_ID + 1);
+        verify(userPreferencesService).updateGridSize(ENTITY_ID + 1, "motech", 100);
+    }
+
+    private void setUpSecurityContext() {
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority("mdsSchemaAccess");
+        List<SimpleGrantedAuthority> authorities = asList(authority);
+
+        User principal = new User("motech", "motech", authorities);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "motech", authorities);
+
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(securityContext);
     }
 
     private List buildRelatedRecord() {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/ModuleSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/ModuleSettings.java
@@ -1,25 +1,6 @@
 package org.motechproject.mds.config;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
-import java.io.IOException;
 import java.util.Objects;
-import java.util.Properties;
-
-import static org.apache.commons.lang.StringUtils.isNotBlank;
-import static org.apache.commons.lang.StringUtils.isNumeric;
-import static org.motechproject.mds.util.Constants.Config.MDS_DELETE_MODE;
-import static org.motechproject.mds.util.Constants.Config.MDS_EMPTY_TRASH;
-import static org.motechproject.mds.util.Constants.Config.MDS_TIME_UNIT;
-import static org.motechproject.mds.util.Constants.Config.MDS_TIME_VALUE;
 
 /**
  * The <code>ModuleSettings</code> contains the base module settings which are inside the
@@ -27,148 +8,84 @@ import static org.motechproject.mds.util.Constants.Config.MDS_TIME_VALUE;
  * inside this class always checks the given property and if it is incorrect then the default
  * value of the given property will be returned.
  */
-@JsonSerialize(using = ModuleSettings.Serializer.class)
-@JsonDeserialize(using = ModuleSettings.Deserializer.class)
-public class ModuleSettings extends Properties {
-    private static final long serialVersionUID = -3738155444078581700L;
-
+public class ModuleSettings {
     public static final DeleteMode DEFAULT_DELETE_MODE = DeleteMode.TRASH;
     public static final Boolean DEFAULT_EMPTY_TRASH = false;
     public static final Integer DEFAULT_TIME_VALUE = 1;
     public static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.HOURS;
+    public static final Integer DEFAULT_GRID_SIZE = 50;
 
-    public DeleteMode getDeleteMode() {
-        Object objectValue = getValueForKey(MDS_DELETE_MODE);
-        String valueAsString = null;
+    private DeleteMode deleteMode;
+    private Boolean emptyTrash;
+    private Integer timeValue;
+    private TimeUnit timeUnit;
+    private Integer gridSize;
 
-        if (objectValue != null) {
-            valueAsString = objectValue.toString();
-        }
-
-        DeleteMode value = DEFAULT_DELETE_MODE;
-
-        if (isNotBlank(valueAsString)) {
-            value = DeleteMode.fromString(valueAsString);
-        }
-
-        return value;
+    public ModuleSettings() {
     }
 
-    public void setDeleteMode(String deleteMode) {
-        DeleteMode fromString = DeleteMode.fromString(deleteMode);
-
-        if (DeleteMode.UNKNOWN == fromString) {
-            setDeleteMode(DEFAULT_DELETE_MODE);
-        } else {
-            setDeleteMode(fromString);
+    public DeleteMode getDeleteMode() {
+        if (deleteMode == null) {
+            return DEFAULT_DELETE_MODE;
         }
+        return deleteMode;
     }
 
     public void setDeleteMode(DeleteMode deleteMode) {
-        DeleteMode mode = DeleteMode.UNKNOWN == deleteMode ? DEFAULT_DELETE_MODE : deleteMode;
-        set(MDS_DELETE_MODE, mode, DEFAULT_DELETE_MODE);
+        this.deleteMode = deleteMode == null ? DEFAULT_DELETE_MODE : deleteMode;
     }
 
     public Boolean isEmptyTrash() {
-        Object objectValue = getValueForKey(MDS_EMPTY_TRASH);
-
-        String valueAsString = null;
-
-        if (objectValue != null) {
-            valueAsString = objectValue.toString();
+        if (emptyTrash == null) {
+            return DEFAULT_EMPTY_TRASH;
         }
-
-        Boolean value = DEFAULT_EMPTY_TRASH;
-
-        if (isNotBlank(valueAsString)) {
-            value = Boolean.parseBoolean(valueAsString);
-        }
-
-        return value;
-    }
-
-    public void setEmptyTrash(String emptyTrash) {
-        if (isNotBlank(emptyTrash)) {
-            setEmptyTrash(Boolean.parseBoolean(emptyTrash));
-        } else {
-            setEmptyTrash(DEFAULT_EMPTY_TRASH);
-        }
+        return emptyTrash;
     }
 
     public void setEmptyTrash(Boolean emptyTrash) {
-        set(MDS_EMPTY_TRASH, emptyTrash, DEFAULT_EMPTY_TRASH);
+        this.emptyTrash = emptyTrash == null ? DEFAULT_EMPTY_TRASH : emptyTrash;
     }
 
     public Integer getTimeValue() {
-        Object value = getValueForKey(MDS_TIME_VALUE);
-
-        Integer intValue = 0;
-        String valueAsString = null;
-        if (value != null) {
-            valueAsString = value.toString();
+        if (timeValue == null) {
+            return DEFAULT_TIME_VALUE;
         }
-
-        if (isNotBlank(valueAsString) && isNumeric(valueAsString)) {
-            intValue = Integer.parseInt(valueAsString);
-        }
-
-        if (intValue < 1) {
-            intValue = DEFAULT_TIME_VALUE;
-        }
-
-        return intValue;
-
-    }
-
-    public void setTimeValue(String timeValue) {
-        if (isNotBlank(timeValue) && isNumeric(timeValue)) {
-            setTimeValue(Integer.parseInt(timeValue));
-        } else {
-            setTimeValue(DEFAULT_TIME_VALUE);
-        }
+        return timeValue;
     }
 
     public void setTimeValue(Integer timeValue) {
-        Integer value = timeValue < 1 ? DEFAULT_TIME_VALUE : timeValue;
-        set(MDS_TIME_VALUE, value, DEFAULT_TIME_VALUE);
+        if (timeValue == null) {
+            this.timeValue = DEFAULT_TIME_VALUE;
+        } else {
+            this.timeValue = timeValue < 1 ? DEFAULT_TIME_VALUE : timeValue;
+        }
     }
 
     public TimeUnit getTimeUnit() {
-        String valueAsString = getProperty(MDS_TIME_UNIT);
-        TimeUnit value = DEFAULT_TIME_UNIT;
-
-        if (isNotBlank(valueAsString)) {
-            value = TimeUnit.fromString(valueAsString);
+        if (timeUnit == null) {
+            return DEFAULT_TIME_UNIT;
         }
-
-        return value;
-    }
-
-    public void setTimeUnit(String timeUnit) {
-        TimeUnit fromString = TimeUnit.fromString(timeUnit);
-
-        if (TimeUnit.UNKNOWN == fromString) {
-            setTimeUnit(DEFAULT_TIME_UNIT);
-        } else {
-            setTimeUnit(fromString);
-        }
+        return timeUnit;
     }
 
     public void setTimeUnit(TimeUnit timeUnit) {
-        TimeUnit unit = TimeUnit.UNKNOWN == timeUnit ? DEFAULT_TIME_UNIT : timeUnit;
-        set(MDS_TIME_UNIT, unit, DEFAULT_TIME_UNIT);
+        this.timeUnit = timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit;
     }
 
-    private void set(String key, Object given, Object defaultValue) {
-        Object value = null == given ? defaultValue : given;
-        String valueAsString = value.toString();
+    public void setGridSize(Integer gridSize) {
+        this.gridSize = gridSize == null ? DEFAULT_GRID_SIZE : gridSize;
+    }
 
-        setProperty(key, valueAsString);
+    public Integer getGridSize() {
+        if (gridSize == null) {
+            return DEFAULT_GRID_SIZE;
+        }
+        return gridSize;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit());
+        return Objects.hash(getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit(), getGridSize());
     }
 
     @Override
@@ -186,68 +103,7 @@ public class ModuleSettings extends Properties {
         return Objects.equals(this.getDeleteMode(), other.getDeleteMode())
                 && Objects.equals(this.isEmptyTrash(), other.isEmptyTrash())
                 && Objects.equals(this.getTimeValue(), other.getTimeValue())
-                && Objects.equals(this.getTimeUnit(), other.getTimeUnit());
-    }
-
-    @Override
-    public String toString() {
-        return String.format(
-                "ModuleSettings{deleteMode=%s, emptyTrash=%s, timeValue=%d, timeUnit=%s}",
-                getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit()
-        );
-    }
-
-    private Object getValueForKey(String key) {
-        for (Object keyFromSet : keySet()) {
-            if (key.compareTo(keyFromSet.toString()) == 0) {
-                return get(key);
-            }
-        }
-        return null;
-    }
-
-    public static final class Serializer extends JsonSerializer<ModuleSettings> {
-
-        @Override
-        public void serialize(ModuleSettings value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeStartObject();
-            jgen.writeObjectField("deleteMode", value.getDeleteMode());
-            jgen.writeObjectField("emptyTrash", value.isEmptyTrash());
-            jgen.writeObjectField("timeValue", value.getTimeValue());
-            jgen.writeObjectField("timeUnit", value.getTimeUnit());
-            jgen.writeEndObject();
-        }
-    }
-
-    public static final class Deserializer extends JsonDeserializer<ModuleSettings> {
-
-        @Override
-        public ModuleSettings deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-            JsonNode jsonNode = jp.readValueAsTree();
-
-            String deleteMode = getValue(jsonNode, "deleteMode");
-            String emptyTrash = getValue(jsonNode, "emptyTrash");
-            String timeValue = getValue(jsonNode, "timeValue");
-            String timeUnit = getValue(jsonNode, "timeUnit");
-
-            ModuleSettings settings = new ModuleSettings();
-            settings.setDeleteMode(deleteMode);
-            settings.setEmptyTrash(emptyTrash);
-            settings.setTimeValue(timeValue);
-            settings.setTimeUnit(timeUnit);
-
-            return settings;
-        }
-
-        private String getValue(JsonNode jsonNode, String key) {
-            String value = null;
-
-            if (jsonNode.has(key)) {
-                value = jsonNode.get(key).asText();
-            }
-
-            return value;
-        }
-
+                && Objects.equals(this.getTimeUnit(), other.getTimeUnit())
+                && Objects.equals(this.getGridSize(), other.getGridSize());
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/SettingsService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/SettingsService.java
@@ -1,7 +1,5 @@
 package org.motechproject.mds.config;
 
-import java.util.Properties;
-
 /**
  * The <code>SettingsService</code> is a generic class, allowing access to all
  * MDS settings, as well as providing an ability to easily change these settings.
@@ -38,6 +36,13 @@ public interface SettingsService {
     TimeUnit getTimeUnit();
 
     /**
+     * Returns current setting of the grid size.
+     *
+     * @return the size of the grid
+     */
+    Integer getGridSize();
+
+    /**
      * Updates all MDS settings and performs necessary actions if required (eg. scheduling jobs, that remove
      * instances from trash).
      *
@@ -51,11 +56,4 @@ public interface SettingsService {
      * @return MDS settings
      */
     ModuleSettings getModuleSettings();
-
-    /**
-     * Retrieves all MDS settings as {@link java.util.Properties}.
-     *
-     * @return MDS settings
-     */
-    Properties getProperties();
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/impl/SettingsServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/impl/SettingsServiceImpl.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.config.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.mds.config.DeleteMode;
 import org.motechproject.mds.config.MdsConfig;
 import org.motechproject.mds.config.ModuleSettings;
@@ -12,8 +13,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Properties;
 
+import static org.motechproject.mds.util.Constants.Config.MDS_DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.util.Constants.Config.MDS_DELETE_MODE;
 import static org.motechproject.mds.util.Constants.Config.MDS_EMPTY_TRASH;
 import static org.motechproject.mds.util.Constants.Config.MDS_TIME_UNIT;
@@ -51,16 +54,19 @@ public class SettingsServiceImpl implements SettingsService {
     }
 
     @Override
+    public Integer getGridSize() {
+        return getModuleSettings().getGridSize();
+    }
+
+    @Override
     @Transactional
     public void saveModuleSettings(ModuleSettings settings) {
         ConfigSettings configSetting = new ConfigSettings();
-        configSetting.setEmptyTrash(Boolean.parseBoolean(settings.getProperty(MDS_EMPTY_TRASH)));
-        configSetting.setAfterTimeUnit(TimeUnit.fromString(settings.getProperty(MDS_TIME_UNIT)));
-        configSetting.setDeleteMode(DeleteMode.fromString(settings.getProperty(MDS_DELETE_MODE)));
-
-        if (settings.getProperty(MDS_TIME_VALUE) != null) {
-            configSetting.setAfterTimeValue(Integer.parseInt(settings.getProperty(MDS_TIME_VALUE)));
-        }
+        configSetting.setEmptyTrash(settings.isEmptyTrash());
+        configSetting.setAfterTimeUnit(settings.getTimeUnit());
+        configSetting.setDeleteMode(settings.getDeleteMode());
+        configSetting.setDefaultGridSize(settings.getGridSize());
+        configSetting.setAfterTimeValue(settings.getTimeValue());
 
         allConfigSettings.addOrUpdate(configSetting);
 
@@ -72,27 +78,42 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     @Transactional
     public ModuleSettings getModuleSettings() {
+        ConfigSettings configSettings = getConfigFromDb();
+        ModuleSettings moduleSettings;
 
-        ModuleSettings moduleSettings = new ModuleSettings();
-        moduleSettings.putAll(getProperties());
+        if (configSettings != null) {
+            moduleSettings = new ModuleSettings();
+            moduleSettings.setDeleteMode(configSettings.getDeleteMode());
+            moduleSettings.setEmptyTrash(configSettings.getEmptyTrash());
+            moduleSettings.setTimeValue(configSettings.getAfterTimeValue());
+            moduleSettings.setTimeUnit(configSettings.getAfterTimeUnit());
+            moduleSettings.setGridSize(configSettings.getDefaultGridSize());
+        } else {
+            moduleSettings = getSettingsFromFile();
+        }
 
         return moduleSettings;
     }
 
-    @Override
-    @Transactional
-    public Properties getProperties() {
-        ConfigSettings configSettings = allConfigSettings.retrieve("id", 1);
-        Properties props = new Properties();
-        if (configSettings != null) {
-            props.put(MDS_TIME_VALUE, configSettings.getAfterTimeValue());
-            props.put(MDS_EMPTY_TRASH, configSettings.getEmptyTrash());
-            props.put(MDS_TIME_UNIT, configSettings.getAfterTimeUnit());
-            props.put(MDS_DELETE_MODE, configSettings.getDeleteMode());
-        } else {
-            props = mdsConfig.getProperties(MODULE_FILE);
+    private ConfigSettings getConfigFromDb() {
+        List<ConfigSettings> configs = allConfigSettings.retrieveAll();
+        if (configs != null && configs.size() > 0) {
+            return configs.get(0);
         }
-        return props;
+        return null;
+    }
+
+    private ModuleSettings getSettingsFromFile() {
+        Properties props = mdsConfig.getProperties(MODULE_FILE);
+
+        ModuleSettings moduleSettings = new ModuleSettings();
+        moduleSettings.setDeleteMode(StringUtils.isNotBlank(props.getProperty(MDS_DELETE_MODE)) ? DeleteMode.fromString(props.getProperty(MDS_DELETE_MODE)) : null);
+        moduleSettings.setEmptyTrash(StringUtils.isNotBlank(props.getProperty(MDS_EMPTY_TRASH)) ? Boolean.parseBoolean(props.getProperty(MDS_EMPTY_TRASH)) : null);
+        moduleSettings.setTimeValue(StringUtils.isNotBlank(props.getProperty(MDS_TIME_VALUE)) ? Integer.parseInt(props.getProperty(MDS_TIME_VALUE)) : null);
+        moduleSettings.setTimeUnit(StringUtils.isNotBlank(props.getProperty(MDS_TIME_UNIT)) ? TimeUnit.fromString(props.getProperty(MDS_TIME_UNIT)) : null);
+        moduleSettings.setGridSize(StringUtils.isNotBlank(props.getProperty(MDS_DEFAULT_GRID_SIZE)) ? Integer.parseInt(props.getProperty(MDS_DEFAULT_GRID_SIZE)) : null);
+
+        return moduleSettings;
     }
 
     @Autowired

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ConfigSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ConfigSettings.java
@@ -33,15 +33,19 @@ public class ConfigSettings {
     @Persistent
     private TimeUnit afterTimeUnit;
 
+    @Persistent
+    private int defaultGridSize;
+
     public ConfigSettings() {
-        this(DeleteMode.TRASH, false, 1, TimeUnit.HOURS);
+        this(DeleteMode.TRASH, false, 1, TimeUnit.HOURS, 10);
     }
 
-    public ConfigSettings(DeleteMode deleteMode, boolean emptyTrash, int afterTimeValue, TimeUnit afterTimeUnit) {
+    public ConfigSettings(DeleteMode deleteMode, boolean emptyTrash, int afterTimeValue, TimeUnit afterTimeUnit, int defaultGridSize) {
         this.deleteMode = deleteMode;
         this.emptyTrash = emptyTrash;
         this.afterTimeValue = afterTimeValue;
         this.afterTimeUnit = afterTimeUnit;
+        this.defaultGridSize = defaultGridSize;
     }
 
     public Long getId() {
@@ -82,6 +86,14 @@ public class ConfigSettings {
 
     public void setAfterTimeUnit(TimeUnit afterTimeUnit) {
         this.afterTimeUnit = afterTimeUnit;
+    }
+
+    public int getDefaultGridSize() {
+        return defaultGridSize;
+    }
+
+    public void setDefaultGridSize(int defaultGridSize) {
+        this.defaultGridSize = defaultGridSize;
     }
 
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
@@ -1,0 +1,146 @@
+package org.motechproject.mds.domain;
+
+import org.motechproject.mds.dto.UserPreferencesDto;
+
+import javax.jdo.annotations.Element;
+import javax.jdo.annotations.ForeignKeyAction;
+import javax.jdo.annotations.IdentityType;
+import javax.jdo.annotations.Join;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The <code>UserPreferences</code> class contains information about an entity user preferences. For example grid size
+ * on the UI.
+ */
+@PersistenceCapable(identityType = IdentityType.DATASTORE, detachable = "true")
+public class UserPreferences {
+
+    @PrimaryKey
+    @Persistent
+    private String username;
+
+    @PrimaryKey
+    @Persistent
+    private String className;
+
+    @Persistent
+    private Integer gridRowsNumber;
+
+    @Persistent(defaultFetchGroup = "true")
+    @Join
+    @Element(column = "selectedField",  deleteAction = ForeignKeyAction.CASCADE)
+    private List<Field> selectedFields;
+
+    @Persistent(defaultFetchGroup = "true")
+    @Join
+    @Element(column = "unselectedField",  deleteAction = ForeignKeyAction.CASCADE)
+    private List<Field> unselectedFields;
+
+    public UserPreferences() {
+    }
+
+    public UserPreferences(String username, String className, Integer gridRowsNumber, List<Field> selectedFields, List<Field> unselectedFields) {
+        this.username = username;
+        this.className = className;
+        this.gridRowsNumber = gridRowsNumber;
+        this.selectedFields = selectedFields;
+        this.unselectedFields = unselectedFields;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Integer getGridRowsNumber() {
+        return gridRowsNumber;
+    }
+
+    public void setGridRowsNumber(Integer gridRowsNumber) {
+        this.gridRowsNumber = gridRowsNumber;
+    }
+
+    public List<Field> getSelectedFields() {
+        if (selectedFields == null) {
+            return new ArrayList<>();
+        }
+        return selectedFields;
+    }
+
+    public void setSelectedFields(List<Field> selectedFields) {
+        this.selectedFields = selectedFields;
+    }
+
+
+    public List<Field> getUnselectedFields() {
+        if (unselectedFields == null) {
+            return new ArrayList<>();
+        }
+        return unselectedFields;
+    }
+
+    public void setUnselectedFields(List<Field> unselectedFields) {
+        this.unselectedFields = unselectedFields;
+    }
+
+    public UserPreferencesDto toDto(List<String> displayableFields) {
+        List<String> mergedFields = new ArrayList<>(displayableFields);
+        List<String> selected = new ArrayList<>();
+        List<String> unselected = new ArrayList<>();
+
+        for (Field field : getUnselectedFields()) {
+            if (mergedFields.contains(field.getName())) {
+                mergedFields.remove(field.getName());
+            }
+            unselected.add(field.getName());
+        }
+
+        for (Field field : getSelectedFields()) {
+            if (!mergedFields.contains(field.getName())) {
+                mergedFields.add(field.getName());
+            }
+            selected.add(field.getName());
+        }
+
+        return new UserPreferencesDto(className, username, gridRowsNumber, mergedFields, selected, unselected);
+    }
+
+    public void selectField(Field field) {
+        if (selectedFields == null) {
+            selectedFields = new ArrayList<>();
+        }
+        selectedFields.add(field);
+
+        // if field is selected then we must remove it from unselected list
+        if (unselectedFields != null && unselectedFields.contains(field)) {
+            unselectedFields.remove(field);
+        }
+    }
+
+    public void unselectField(Field field) {
+        if (unselectedFields == null) {
+            unselectedFields = new ArrayList<>();
+        }
+        unselectedFields.add(field);
+
+        // if field is unselected then we must remove it from selected list
+        if (selectedFields != null && selectedFields.contains(field)) {
+            selectedFields.remove(field);
+        }
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
@@ -18,6 +18,7 @@ public class AdvancedSettingsDto {
     private List<LookupDto> indexes = new ArrayList<>();
     private RestOptionsDto restOptions = new RestOptionsDto();
     private BrowsingSettingsDto browsing = new BrowsingSettingsDto();
+    private UserPreferencesDto userPreferences;
 
     public Long getId() {
         return id;
@@ -75,6 +76,14 @@ public class AdvancedSettingsDto {
 
     public void setBrowsing(BrowsingSettingsDto browsing) {
         this.browsing = browsing;
+    }
+
+    public UserPreferencesDto getUserPreferences() {
+        return userPreferences;
+    }
+
+    public void setUserPreferences(UserPreferencesDto userPreferences) {
+        this.userPreferences = userPreferences;
     }
 
     /**

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/DraftData.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/DraftData.java
@@ -1,5 +1,8 @@
 package org.motechproject.mds.dto;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -23,7 +26,7 @@ public class DraftData {
     private boolean create;
     private boolean edit;
     private boolean remove;
-    private Map<String, Object> values;
+    private Map<String, Object> values = new HashMap<>();
 
     public boolean isCreate() {
         return create;
@@ -61,18 +64,22 @@ public class DraftData {
         this.values = values;
     }
 
+    @JsonIgnore
     public boolean isForField() {
         return getValue(FIELD_ID) != null;
     }
 
+    @JsonIgnore
     public boolean isForAdvanced() {
         return getValue(ADVANCED) != null;
     }
 
+    @JsonIgnore
     public boolean isForSecurity() {
         return getValue(SECURITY) != null;
     }
 
+    @JsonIgnore
     public String getPath() {
         Object path = getValue(PATH);
         return (path == null) ? null : path.toString();

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
@@ -1,0 +1,97 @@
+package org.motechproject.mds.dto;
+
+import java.util.List;
+
+/**
+ * The <code>UserPreferencesDto</code> contains information about user preferences of an entity.
+ */
+public class UserPreferencesDto {
+
+    /**
+     * The entity class name.
+     */
+    private String className;
+
+    /**
+     * Username of the preferences owner.
+     */
+    private String username;
+
+    /**
+     * The size of the grid.
+     */
+    private Integer gridRowsNumber;
+
+    /**
+     * The list of the fields which will be displayed on the UI. It is constructed from selected fields, unselected fields
+     * and advance settings of the entity.
+     */
+    private List<String> visibleFields;
+
+    /**
+     * The list of the selected fields.
+     */
+    private List<String> selectedFields;
+
+    /**
+     * The list of the unselected fields.
+     */
+    private List<String> unselectedFields;
+
+    public UserPreferencesDto(String className, String username, Integer gridRowsNumber, List<String> visibleFields, List<String> selectedFields, List<String> unselectedFields) {
+        this.className = className;
+        this.username = username;
+        this.gridRowsNumber = gridRowsNumber;
+        this.visibleFields = visibleFields;
+        this.selectedFields = selectedFields;
+        this.unselectedFields = unselectedFields;
+    }
+
+    public Integer getGridRowsNumber() {
+        return gridRowsNumber;
+    }
+
+    public void setGridRowsNumber(Integer gridRowsNumber) {
+        this.gridRowsNumber = gridRowsNumber;
+    }
+
+    public List<String> getVisibleFields() {
+        return visibleFields;
+    }
+
+    public void setVisibleFields(List<String> visibleFields) {
+        this.visibleFields = visibleFields;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public List<String> getSelectedFields() {
+        return selectedFields;
+    }
+
+    public void setSelectedFields(List<String> selectedFields) {
+        this.selectedFields = selectedFields;
+    }
+
+    public List<String> getUnselectedFields() {
+        return unselectedFields;
+    }
+
+    public void setUnselectedFields(List<String> unselectedFields) {
+        this.unselectedFields = unselectedFields;
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllConfigSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllConfigSettings.java
@@ -25,6 +25,7 @@ public class AllConfigSettings extends MotechDataRepository<ConfigSettings> {
             rec.setAfterTimeUnit(record.getAfterTimeUnit());
             rec.setDeleteMode(record.getDeleteMode());
             rec.setEmptyTrash(record.getEmptyTrash());
+            rec.setDefaultGridSize(record.getDefaultGridSize());
             update(rec);
         }
     }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllUserPreferences.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllUserPreferences.java
@@ -1,0 +1,22 @@
+package org.motechproject.mds.repository;
+
+import org.motechproject.mds.domain.UserPreferences;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class AllUserPreferences extends MotechDataRepository<UserPreferences> {
+
+    protected AllUserPreferences() {
+        super(UserPreferences.class);
+    }
+
+    public UserPreferences retrieveByClassNameAndUsername(String entityClassName, String username) {
+        return retrieve(new String[] {"className", "username"}, new Object[] {entityClassName, username});
+    }
+
+    public List<UserPreferences> retrieveByClassName(String entityClassName) {
+        return retrieveAll("className", entityClassName);
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/UserPreferencesService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/UserPreferencesService.java
@@ -1,0 +1,84 @@
+package org.motechproject.mds.service;
+
+import org.motechproject.mds.dto.UserPreferencesDto;
+
+import java.util.List;
+
+
+/**
+ * The <code>UserPreferencesService</code> provides API for managing the entity user preferences (grid size, visible fields).
+ *
+ * @see org.motechproject.mds.domain.UserPreferences
+ */
+public interface UserPreferencesService {
+
+    /**
+     * Returns preferences for entity with the given id.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @return list of user preferences for the entity
+     */
+    List<UserPreferencesDto> getEntityPreferences(Long entityId);
+
+    /**
+     * Returns preferences for given user and entity. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @return user preferences for the entity and username
+     */
+    UserPreferencesDto getUserPreferences(Long entityId, String username);
+
+    /**
+     * Updates grid size preferences for given user and entity. If preferences don't exist then default ones will be created.
+
+     * @param entityId the id of the entity for the preferences
+     * @param username the owner of the preferences
+     * @param newSize the new size og the grid
+     */
+    void updateGridSize(Long entityId, String username, Integer newSize);
+
+    /**
+     * Adds field with the given name to the user visible fields. If preferences don't exist then default ones will be
+     * created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @param fieldName the name of the field to add
+     */
+    void selectField(Long entityId, String username, String fieldName);
+
+    /**
+     * Removes field with the given name from the user visible fields. If preferences don't exist then default ones will be
+     * created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @param fieldName the name of the field to remove
+     */
+    void unselectField(Long entityId, String username, String fieldName);
+
+    /**
+     * Adds all entity fields to the user visible fields. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     */
+    void selectFields(Long entityId, String username);
+
+    /**
+     * Removes all entity fields from the user visible fields. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     */
+    void unselectFields(Long entityId, String username);
+
+    /**
+     * Removes user preferences for entity with the given id.
+     *
+     * @param entityId he id of entity
+     * @param username the owner of the preferences
+     */
+    void removeUserPreferences(Long entityId, String username);
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
@@ -15,6 +15,7 @@ import org.motechproject.mds.domain.MdsEntity;
 import org.motechproject.mds.domain.Type;
 import org.motechproject.mds.domain.TypeSetting;
 import org.motechproject.mds.domain.TypeValidation;
+import org.motechproject.mds.domain.UserPreferences;
 import org.motechproject.mds.dto.AdvancedSettingsDto;
 import org.motechproject.mds.dto.DraftData;
 import org.motechproject.mds.dto.DraftResult;
@@ -29,6 +30,7 @@ import org.motechproject.mds.dto.RestOptionsDto;
 import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.dto.TrackingDto;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
 import org.motechproject.mds.dto.ValidationCriterionDto;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.entity.EntityChangedException;
@@ -48,8 +50,10 @@ import org.motechproject.mds.repository.AllEntities;
 import org.motechproject.mds.repository.AllEntityAudits;
 import org.motechproject.mds.repository.AllEntityDrafts;
 import org.motechproject.mds.repository.AllTypes;
+import org.motechproject.mds.repository.AllUserPreferences;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
 import org.motechproject.mds.util.LookupName;
@@ -62,6 +66,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,7 +108,9 @@ public class EntityServiceImpl implements EntityService {
     private AllTypes allTypes;
     private AllEntityDrafts allEntityDrafts;
     private AllEntityAudits allEntityAudits;
+    private AllUserPreferences allUserPreferences;
     private MDSConstructor mdsConstructor;
+    private UserPreferencesService userPreferencesService;
 
     private BundleContext bundleContext;
     private EntityValidator entityValidator;
@@ -429,9 +437,10 @@ public class EntityServiceImpl implements EntityService {
         mdsConstructor.updateFields(parent.getId(), draft.getFieldNameChanges());
         comboboxDataMigrationHelper.migrateComboboxDataIfNecessary(parent, draft);
 
+        List<UserPreferencesDto> oldEntityPreferences = userPreferencesService.getEntityPreferences(parent.getId());
         configureRelatedFields(parent, draft, modulesToRefresh);
-
         parent.updateFromDraft(draft);
+        updateUserPreferences(parent, draft, oldEntityPreferences);
 
         if (username != null) {
             allEntityAudits.createAudit(parent, username);
@@ -441,6 +450,37 @@ public class EntityServiceImpl implements EntityService {
         addModuleToRefresh(parent, modulesToRefresh);
 
         return modulesToRefresh;
+    }
+
+    private void updateUserPreferences(Entity parent, EntityDraft draft, List<UserPreferencesDto> userPreferencesDtos) {
+        for (UserPreferencesDto preferencesDto : userPreferencesDtos) {
+            UserPreferences preferences = allUserPreferences.retrieveByClassNameAndUsername(preferencesDto.getClassName(),
+                    preferencesDto.getUsername());
+
+            preferences.setSelectedFields(getFieldsForPreferences(parent, draft, preferencesDto.getSelectedFields()));
+            preferences.setUnselectedFields(getFieldsForPreferences(parent, draft, preferencesDto.getUnselectedFields()));
+
+            allUserPreferences.update(preferences);
+        }
+    }
+
+    private List<Field> getFieldsForPreferences(Entity parent, EntityDraft draft, List<String> oldList) {
+        List<Field> newFields = new ArrayList<>();
+
+        for (String field : oldList) {
+
+            String name = field;
+            if (draft.getFieldNameChanges().containsKey(name)) {
+                name = draft.getFieldNameChanges().get(name);
+            }
+
+            Field newfield = parent.getField(name);
+            if (newfield != null) {
+                newFields.add(newfield);
+            }
+        }
+
+        return newFields;
     }
 
     private void addModuleToRefresh(Entity entity, List<String> modulesToRefresh) {
@@ -1339,12 +1379,20 @@ public class EntityServiceImpl implements EntityService {
         //For dataBrowser we need to add information about the lookup fields(type, settings, displayName)
         if (committed) {
             addNonPersistentDataForLookupFields(advancedSettingsDto.getIndexes(), entity);
+            addEntityUserPreferences(advancedSettingsDto, entity);
         }
         addLookupsReferences(advancedSettingsDto.getIndexes(), entity.getClassName());
         return advancedSettingsDto;
     }
 
-
+    private void addEntityUserPreferences(AdvancedSettingsDto advancedSettingsDto, Entity entity) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(entity.getId(),
+                    SecurityContextHolder.getContext().getAuthentication().getName());
+            advancedSettingsDto.setUserPreferences(userPreferencesDto);
+        }
+    }
 
     private void addNonPersistentDataForLookupFields(Collection<LookupDto> lookupDtos, Entity entity) {
         for (LookupDto lookup : lookupDtos) {
@@ -1403,6 +1451,11 @@ public class EntityServiceImpl implements EntityService {
     }
 
     @Autowired
+    public void setAllUserPreferences(AllUserPreferences allUserPreferences) {
+        this.allUserPreferences = allUserPreferences;
+    }
+
+    @Autowired
     public void setMDSConstructor(MDSConstructor mdsConstructor) {
         this.mdsConstructor = mdsConstructor;
     }
@@ -1420,5 +1473,10 @@ public class EntityServiceImpl implements EntityService {
     @Autowired
     public void setComboboxDataMigrationHelper(ComboboxDataMigrationHelper comboboxDataMigrationHelper) {
         this.comboboxDataMigrationHelper = comboboxDataMigrationHelper;
+    }
+
+    @Autowired
+    public void setUserPreferencesService(UserPreferencesService userPreferencesService) {
+        this.userPreferencesService = userPreferencesService;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
@@ -1,0 +1,199 @@
+package org.motechproject.mds.service.impl;
+
+import org.motechproject.mds.config.SettingsService;
+import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.domain.Field;
+import org.motechproject.mds.domain.UserPreferences;
+import org.motechproject.mds.dto.UserPreferencesDto;
+import org.motechproject.mds.ex.entity.EntityNotFoundException;
+import org.motechproject.mds.ex.field.FieldNotFoundException;
+import org.motechproject.mds.repository.AllEntities;
+import org.motechproject.mds.repository.AllUserPreferences;
+import org.motechproject.mds.service.UserPreferencesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of the {@link org.motechproject.mds.service.UserPreferencesService}.
+ */
+@Service
+public class UserPreferencesServiceImpl implements UserPreferencesService {
+
+    private AllUserPreferences allUserPreferences;
+
+    private AllEntities allEntities;
+
+    private SettingsService settingsService;
+
+    @Override
+    public List<UserPreferencesDto> getEntityPreferences(Long id) {
+        Entity entity = getEntity(id);
+        List<UserPreferences> userPreferences =  allUserPreferences.retrieveByClassName(entity.getClassName());
+        List<UserPreferencesDto> dtos = new ArrayList<>();
+        List<String> displayableFields = getDisplayableFields(entity);
+
+        if (userPreferences != null) {
+            Integer defaultGridSize = settingsService.getGridSize();
+            for (UserPreferences preferences : userPreferences) {
+                UserPreferencesDto dto = preferences.toDto(displayableFields);
+                if (dto.getGridRowsNumber() == null) {
+                    dto.setGridRowsNumber(defaultGridSize);
+                }
+                dtos.add(dto);
+            }
+        }
+
+        return dtos;
+    }
+
+    @Override
+    @Transactional
+    public UserPreferencesDto getUserPreferences(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        if (userPreferences != null) {
+            UserPreferencesDto dto = userPreferences.toDto(getDisplayableFields(entity));
+            if (dto.getGridRowsNumber() == null) {
+                dto.setGridRowsNumber(settingsService.getGridSize());
+            }
+            return dto;
+        }
+
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public void updateGridSize(Long id, String username, Integer newSize) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        if (userPreferences.getGridRowsNumber() != newSize) {
+            userPreferences.setGridRowsNumber(newSize == null ? settingsService.getGridSize() : newSize);
+            allUserPreferences.update(userPreferences);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void selectField(Long id, String username, String fieldName) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        Field field = entity.getField(fieldName);
+        assertField(field, entity.getClassName(), fieldName);
+        userPreferences.selectField(field);
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void unselectField(Long id, String username, String fieldName) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        Field field = entity.getField(fieldName);
+        assertField(field, entity.getClassName(), fieldName);
+        userPreferences.unselectField(field);
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void selectFields(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(entity.getFields());
+        userPreferences.setSelectedFields(fields);
+        userPreferences.setUnselectedFields(new ArrayList<Field>());
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void unselectFields(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(entity.getFields());
+        userPreferences.setUnselectedFields(fields);
+        userPreferences.setSelectedFields(new ArrayList<Field>());
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void removeUserPreferences(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        if (userPreferences != null) {
+            allUserPreferences.delete(userPreferences);
+        }
+    }
+
+    public void assertField(Field field, String className, String fieldName) {
+        if (field == null) {
+            throw new FieldNotFoundException(className, fieldName);
+        }
+    }
+
+    private Entity getEntity(Long id) {
+        Entity entity = allEntities.retrieveById(id);
+
+        if (entity == null) {
+            throw new EntityNotFoundException(id);
+        }
+        return entity;
+    }
+
+    private List<String> getDisplayableFields(Entity entity) {
+        List<String> displayFields = new ArrayList<>();
+        for (Field field : entity.getFields()) {
+            if (field.isUIDisplayable() && !field.isNonDisplayable()) {
+                displayFields.add(field.getName());
+            }
+        }
+
+        return displayFields;
+    }
+
+    private UserPreferences checkPreferences(UserPreferences userPreferences, Entity entity, String username) {
+        if (userPreferences == null) {
+            return allUserPreferences.create(new UserPreferences(username, entity.getClassName(), null, new ArrayList<Field>(), new ArrayList<Field>()));
+        }
+        return userPreferences;
+    }
+    @Autowired
+    public void setAllUserPreferences(AllUserPreferences allUserPreferences) {
+        this.allUserPreferences = allUserPreferences;
+    }
+
+    @Autowired
+    public void setSettingsService(SettingsService settingsService) {
+        this.settingsService = settingsService;
+    }
+
+    @Autowired
+    public void setAllEntities(AllEntities allEntities) {
+        this.allEntities = allEntities;
+    }
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
@@ -224,6 +224,11 @@ public final class Constants {
         public static final String MDS_TIME_UNIT = "mds.emptyTrash.afterTimeUnit";
 
         /**
+         * The property that specifies default number of records in each data browser grid.
+         */
+        public static final String MDS_DEFAULT_GRID_SIZE = "mds.default.gridSize";
+
+        /**
          * Constant <code>EMPTY_TRASH_JOB</code> presents a name of job scheduled by scheduler
          * module.
          */

--- a/platform/mds/mds/src/main/resources/META-INF/spring/blueprint.xml
+++ b/platform/mds/mds/src/main/resources/META-INF/spring/blueprint.xml
@@ -23,6 +23,8 @@
 
     <osgi:service ref="entityServiceImpl" interface="org.motechproject.mds.service.EntityService"/>
 
+    <osgi:service ref="userPreferencesServiceImpl" interface="org.motechproject.mds.service.UserPreferencesService"/>
+
     <osgi:service ref="actionHandlerServiceImpl" interface="org.motechproject.mds.service.ActionHandlerService"/>
 
     <osgi:service ref="jdoListenerRegistryService" interface="org.motechproject.mds.service.JdoListenerRegistryService" auto-export="interfaces" />

--- a/platform/mds/mds/src/main/resources/db/migration/default/V43__MOTECH-1800.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V43__MOTECH-1800.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS "UserPreferences" (
+  "username" varchar(255) NOT NULL,
+  "className" varchar(255) NOT NULL,
+  "gridRowsNumber" int,
+  PRIMARY KEY ("username", "className")
+);
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_selectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "selectedField" bigint,
+  "IDX" int,
+  PRIMARY KEY ("className_OID", "username_OID", "IDX"),
+  CONSTRAINT "UserPreferences_selectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_selectedFields_FK2" FOREIGN KEY ("selectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_unselectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "unselectedField" bigint,
+  "IDX" int,
+  PRIMARY KEY ("className_OID", "username_OID", "IDX"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK2" FOREIGN KEY ("unselectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "ConfigSettings" (
+  "id" bigint,
+  "afterTimeUnit" varchar(255) NOT NULL,
+  "afterTimeValue" int,
+  "deleteMode" varchar(255) NOT NULL,
+  "emptyTrash" bit(1),
+  PRIMARY KEY ("id")
+);
+
+ALTER TABLE "ConfigSettings" ADD "defaultGridSize" int DEFAULT 50;

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V43__MOTECH-1800.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V43__MOTECH-1800.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS UserPreferences (
+  className varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  gridRowsNumber int,
+  PRIMARY KEY (className, username)
+);
+
+CREATE TABLE IF NOT EXISTS UserPreferences_selectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  selectedField bigint(20),
+  IDX int(11),
+  PRIMARY KEY (className_OID, username_OID, IDX),
+  KEY UserPreferences_selectedFields_N49 (selectedField),
+  KEY UserPreferences_selectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_visibleFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_visibleFields_FK2 FOREIGN KEY (selectedField) REFERENCES Field (id) ON DELETE CASCADE
+);
+
+
+CREATE TABLE IF NOT EXISTS UserPreferences_unselectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  unselectedField bigint(20),
+  IDX int(11),
+  PRIMARY KEY (className_OID, username_OID, IDX),
+  KEY UserPreferences_unselectedFields_N49 (unselectedField),
+  KEY UserPreferences_unselectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_unselectedFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_unselectedFields_FK2 FOREIGN KEY (unselectedField) REFERENCES Field (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS ConfigSettings (
+  id bigint(20),
+  afterTimeUnit varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  afterTimeValue int(11),
+  deleteMode varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  emptyTrash bit(1),
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE ConfigSettings add defaultGridSize int DEFAULT 50;

--- a/platform/mds/mds/src/main/resources/motech-mds.properties
+++ b/platform/mds/mds/src/main/resources/motech-mds.properties
@@ -3,3 +3,5 @@ mds.deleteMode = trash
 mds.emptyTrash = false
 mds.emptyTrash.afterTimeValue = 1
 mds.emptyTrash.afterTimeUnit = Hours
+
+mds.default.gridSize = 50

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/config/ModuleSettingsTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/config/ModuleSettingsTest.java
@@ -1,12 +1,11 @@
 package org.motechproject.mds.config;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_DELETE_MODE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_EMPTY_TRASH;
+import static org.motechproject.mds.config.ModuleSettings.DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_UNIT;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_VALUE;
 
@@ -24,30 +23,18 @@ public class ModuleSettingsTest {
         settings.setEmptyTrash(true);
         settings.setTimeValue(10);
         settings.setTimeUnit(TimeUnit.WEEKS);
+        settings.setGridSize(100);
 
-        assertValues(DeleteMode.DELETE, true, 10, TimeUnit.WEEKS);
+        assertValues(DeleteMode.DELETE, true, 10, TimeUnit.WEEKS, 100);
     }
 
     @Test
     public void shouldSetDefaultValuesIfStringParameterIsIncorrect() throws Exception {
-        settings.setDeleteMode((String) null);
-        settings.setEmptyTrash((String) null);
-        settings.setTimeValue((String) null);
-        settings.setTimeUnit((String) null);
-
-        assertDefaultValues();
-
-        settings.setDeleteMode("  ");
-        settings.setEmptyTrash("   ");
-        settings.setTimeValue("   ");
-        settings.setTimeUnit("   ");
-
-        assertDefaultValues();
-
-        settings.setDeleteMode("del");
-        settings.setEmptyTrash("t");
-        settings.setTimeValue("alb");
-        settings.setTimeUnit("w");
+        settings.setDeleteMode(null);
+        settings.setEmptyTrash(null);
+        settings.setTimeValue(null);
+        settings.setTimeUnit(null);
+        settings.setGridSize(null);
 
         assertDefaultValues();
 
@@ -55,42 +42,18 @@ public class ModuleSettingsTest {
         assertEquals(DEFAULT_TIME_VALUE, settings.getTimeValue());
     }
 
-    @Test
-    public void shouldCreateAppropriateJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
-        JsonNode json = mapper.valueToTree(settings);
-        assertValues(
-                json.get("deleteMode").asText(), json.get("emptyTrash").asText(),
-                json.get("timeValue").asText(), json.get("timeUnit").asText()
-        );
-
-        ModuleSettings fromJSON = mapper.readValue(json, ModuleSettings.class);
-        assertValues(
-                fromJSON.getDeleteMode(), fromJSON.isEmptyTrash(),
-                fromJSON.getTimeValue(), fromJSON.getTimeUnit()
-        );
-    }
-
     private void assertDefaultValues() {
         assertValues(
-                DEFAULT_DELETE_MODE, DEFAULT_EMPTY_TRASH, DEFAULT_TIME_VALUE, DEFAULT_TIME_UNIT
-        );
-    }
-
-    private void assertValues(String deleteMode, String emptyTrash, String timeValue,
-                              String timeUnit) {
-        assertValues(
-                DeleteMode.fromString(deleteMode), Boolean.parseBoolean(emptyTrash),
-                Integer.parseInt(timeValue), TimeUnit.fromString(timeUnit)
+                DEFAULT_DELETE_MODE, DEFAULT_EMPTY_TRASH, DEFAULT_TIME_VALUE, DEFAULT_TIME_UNIT, DEFAULT_GRID_SIZE
         );
     }
 
     private void assertValues(DeleteMode deleteMode, boolean emptyTrash, Integer timeValue,
-                              TimeUnit timeUnit) {
+                              TimeUnit timeUnit, Integer gridSize) {
         assertEquals(deleteMode, settings.getDeleteMode());
         assertEquals(emptyTrash, settings.isEmptyTrash());
         assertEquals(timeValue, settings.getTimeValue());
         assertEquals(timeUnit, settings.getTimeUnit());
+        assertEquals(gridSize, settings.getGridSize());
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/config/SettingsServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/config/SettingsServiceImplTest.java
@@ -17,6 +17,7 @@ import static org.motechproject.mds.config.ModuleSettings.DEFAULT_DELETE_MODE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_EMPTY_TRASH;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_UNIT;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_VALUE;
+import static org.motechproject.mds.config.ModuleSettings.DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.util.Constants.Config.MODULE_FILE;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,6 +53,7 @@ public class SettingsServiceImplTest {
         assertEquals(DEFAULT_EMPTY_TRASH, settingsServiceImpl.isEmptyTrash());
         assertEquals(DEFAULT_TIME_VALUE, settingsServiceImpl.getTimeValue());
         assertEquals(DEFAULT_TIME_UNIT, settingsServiceImpl.getTimeUnit());
+        assertEquals(DEFAULT_GRID_SIZE, settingsServiceImpl.getGridSize());
 
         // settings should contains the same values
         ModuleSettings settings = settingsServiceImpl.getModuleSettings();
@@ -60,5 +62,6 @@ public class SettingsServiceImplTest {
         assertEquals(DEFAULT_EMPTY_TRASH, settings.isEmptyTrash());
         assertEquals(DEFAULT_TIME_VALUE, settings.getTimeValue());
         assertEquals(DEFAULT_TIME_UNIT, settings.getTimeUnit());
+        assertEquals(DEFAULT_GRID_SIZE, settings.getGridSize());
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseIT.java
@@ -8,6 +8,7 @@ import org.motechproject.mds.domain.EntityAudit;
 import org.motechproject.mds.domain.EntityDraft;
 import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.Lookup;
+import org.motechproject.mds.domain.UserPreferences;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.orm.jdo.JdoTransactionManager;
@@ -99,6 +100,10 @@ public abstract class BaseIT {
         return getAll(EntityDraft.class);
     }
 
+    protected List<UserPreferences> getUserPreferences() {
+        return getAll(UserPreferences.class);
+    }
+
     protected List<EntityDraft> getEntityDrafts() {
         return getAll(EntityDraft.class);
     }
@@ -118,6 +123,7 @@ public abstract class BaseIT {
         getPersistenceManager().deletePersistentAll(getEntities());
         getPersistenceManager().deletePersistentAll(getEntitiesAudits());
         getPersistenceManager().deletePersistentAll(getEntitiesDrafts());
+        getPersistenceManager().deletePersistentAll(getUserPreferences());
     }
 
     protected <T> List<T> cast(Class<T> clazz, Collection collection) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/osgi/MdsBundleIT.java
@@ -17,6 +17,7 @@ import org.motechproject.commons.api.Range;
 import org.motechproject.commons.date.model.Time;
 import org.motechproject.commons.date.util.DateUtil;
 import org.motechproject.commons.sql.service.SqlDBManager;
+import org.motechproject.mds.domain.Entity;
 import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.dto.CsvImportResults;
 import org.motechproject.mds.dto.DraftData;
@@ -30,17 +31,21 @@ import org.motechproject.mds.dto.LookupFieldType;
 import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.dto.SettingDto;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
+import org.motechproject.mds.jdo.MdsTransactionManager;
 import org.motechproject.mds.osgi.TestClass;
 import org.motechproject.mds.query.QueryExecution;
 import org.motechproject.mds.query.QueryExecutor;
 import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.query.SqlQueryExecution;
+import org.motechproject.mds.repository.AllEntities;
 import org.motechproject.mds.service.CsvImportExportService;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.motechproject.mds.service.MDSLookupService;
 import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.mds.service.RestDocumentationService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.testutil.DraftBuilder;
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.util.Constants;
@@ -57,6 +62,9 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.inject.Inject;
@@ -85,6 +93,7 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -105,6 +114,8 @@ public class MdsBundleIT extends BasePaxIT {
     private static final String FOO = "Foo";
     private static final String FOO_CLASS = String.format("%s.%s", Constants.PackagesGenerated.ENTITY, FOO);
 
+    private static final String CLASS_NAME = "org.motechproject.sampleModule.SampleEntity";
+    private static final String USERNAME = "motech";
     private static final int INSTANCE_COUNT = 5;
     private static final Byte[] BYTE_ARRAY_VALUE = new Byte[]{110, 111, 112};
     private static final Period TEST_PERIOD = new Period().withDays(3).withHours(7).withMinutes(50);
@@ -133,6 +144,8 @@ public class MdsBundleIT extends BasePaxIT {
     private JarGeneratorService generator;
     private EntityService entityService;
     private MotechDataService service;
+    private AllEntities allEntities;
+    private MdsTransactionManager mdsTransactionManager;
 
     @Inject
     private SqlDBManager sqlDBManager;
@@ -146,12 +159,17 @@ public class MdsBundleIT extends BasePaxIT {
     @Inject
     private RestDocumentationService restDocService;
 
+    @Inject
+    private UserPreferencesService userPreferencesService;
+
     @Before
     public void setUp() throws Exception {
         WebApplicationContext context = ServiceRetriever.getWebAppContext(bundleContext, MDS_BUNDLE_SYMBOLIC_NAME, 10000, 12);
 
         entityService = context.getBean(EntityService.class);
         generator = context.getBean(JarGeneratorService.class);
+        allEntities = context.getBean(AllEntities.class);
+        mdsTransactionManager = context.getBean(MdsTransactionManager.class);
 
         clearEntities();
         setUpSecurityContextForDefaultUser("mdsSchemaAccess");
@@ -190,6 +208,144 @@ public class MdsBundleIT extends BasePaxIT {
         verifyComboboxDataMigration();
         verifyInstanceDeleting();
         verifyRestDocumentation();
+    }
+
+    @Test
+    public void testUserPreferences() {
+        EntityDto entityDto = createEntityForPreferencesTest();
+
+        // first retrieve - should create default user preferences for entity
+        UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+
+        assertEquals(new Integer(50), userPreferencesDto.getGridRowsNumber());
+        assertEquals(3, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someBoolean"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someString"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someInteger"));
+
+        assertEquals(0, userPreferencesDto.getSelectedFields().size());
+        assertEquals(0, userPreferencesDto.getUnselectedFields().size());
+
+        userPreferencesService.updateGridSize(entityDto.getId(), USERNAME, 100);
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+        assertEquals(new Integer(100), userPreferencesDto.getGridRowsNumber());
+
+        // if null then default value from settings will be used
+        userPreferencesService.updateGridSize(entityDto.getId(), USERNAME, null);
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+        assertEquals(new Integer(50), userPreferencesDto.getGridRowsNumber());
+
+        userPreferencesService.unselectField(entityDto.getId(), USERNAME, "someString");
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+
+        assertEquals(2, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someBoolean"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someInteger"));
+
+        assertEquals(0, userPreferencesDto.getSelectedFields().size());
+        assertEquals(1, userPreferencesDto.getUnselectedFields().size());
+        assertTrue(userPreferencesDto.getUnselectedFields().contains("someString"));
+
+        userPreferencesService.selectField(entityDto.getId(), USERNAME, "otherInteger");
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+
+        assertEquals(3, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someBoolean"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someInteger"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("otherInteger"));
+
+        assertEquals(1, userPreferencesDto.getSelectedFields().size());
+        assertTrue(userPreferencesDto.getSelectedFields().contains("otherInteger"));
+        assertEquals(1, userPreferencesDto.getUnselectedFields().size());
+        assertTrue(userPreferencesDto.getUnselectedFields().contains("someString"));
+
+        userPreferencesService.selectField(entityDto.getId(), USERNAME, "someString");
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+
+        assertEquals(4, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someBoolean"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("otherInteger"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("otherInteger"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("someString"));
+
+        assertEquals(2, userPreferencesDto.getSelectedFields().size());
+        assertTrue(userPreferencesDto.getSelectedFields().contains("otherInteger"));
+        assertTrue(userPreferencesDto.getSelectedFields().contains("someString"));
+        assertEquals(0, userPreferencesDto.getUnselectedFields().size());
+
+        userPreferencesService.unselectFields(entityDto.getId(), USERNAME);
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+        assertEquals(0, userPreferencesDto.getVisibleFields().size());
+        assertEquals(0, userPreferencesDto.getSelectedFields().size());
+        assertEquals(10, userPreferencesDto.getUnselectedFields().size());
+
+        userPreferencesService.selectFields(entityDto.getId(), USERNAME);
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+        assertEquals(10, userPreferencesDto.getVisibleFields().size());
+        assertEquals(10, userPreferencesDto.getSelectedFields().size());
+        assertEquals(0, userPreferencesDto.getUnselectedFields().size());
+
+        // if field will be removed from entity then it should be removed also from preferences (CASCADE)
+        TransactionTemplate transactionTemplate = new TransactionTemplate(mdsTransactionManager);
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus transactionStatus) {
+                Entity entity = allEntities.retrieveByClassName(CLASS_NAME);
+                List<Field> fields = entity.getFields();
+                fields.remove(entity.getField("someInteger"));
+                entity.setFields(fields);
+                allEntities.update(entity);
+            }
+        });
+
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityDto.getId(), USERNAME);
+        assertEquals(9, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getSelectedFields().contains("someBoolean"));
+        assertTrue(userPreferencesDto.getSelectedFields().contains("someString"));
+        assertFalse(userPreferencesDto.getSelectedFields().contains("someInteger"));
+    }
+
+    private EntityDto createEntityForPreferencesTest() {
+        EntityDto entityDto = new EntityDto(null, CLASS_NAME);
+        entityDto = entityService.createEntity(entityDto);
+
+        List<FieldDto> fields = new ArrayList<>();
+        fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.BOOLEAN,
+                new FieldBasicDto("Some Boolean", "someBoolean"),
+                false, false, false, false, false, null, null, null, null));
+
+        fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.STRING,
+                new FieldBasicDto("Some String", "someString"),
+                false, false, false, false, false, null, null,
+                asList(
+                        new SettingDto("mds.form.label.textarea", false, BOOLEAN)
+                ), null));
+        fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.INTEGER,
+                new FieldBasicDto("Some Integer", "someInteger"),
+                false, false, false, false, false, null, null, null, null));
+        fields.add(new FieldDto(null, entityDto.getId(),
+                TypeDto.INTEGER,
+                new FieldBasicDto("Other Integer", "otherInteger"),
+                false, false, false, false, false, null, null, null, null));
+
+        entityService.addFields(entityDto, fields);
+
+        TransactionTemplate transactionTemplate = new TransactionTemplate(mdsTransactionManager);
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus transactionStatus) {
+                Entity entity = allEntities.retrieveByClassName(CLASS_NAME);
+                entity.getField("someInteger").setUIDisplayable(true);
+                entity.getField("someString").setUIDisplayable(true);
+                entity.getField("someBoolean").setUIDisplayable(true);
+                allEntities.update(entity);
+            }
+        });
+
+        return entityDto;
     }
 
     private void verifyComboboxDataMigration() throws NoSuchFieldException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
@@ -814,7 +970,7 @@ public class MdsBundleIT extends BasePaxIT {
         lookupFields = new ArrayList<>();
         lookupFields.add(new LookupFieldDto(null, "someString", LookupFieldType.VALUE,
                 Constants.Operators.MATCHES_CASE_INSENSITIVE));
-;       lookups.add(new LookupDto("With matches case insensitive", false, false, lookupFields, true, "matchesOperatorCI",
+       lookups.add(new LookupDto("With matches case insensitive", false, false, lookupFields, true, "matchesOperatorCI",
                 singletonList("someString")));
 
         entityService.addLookups(entityDto.getId(), lookups);
@@ -829,6 +985,7 @@ public class MdsBundleIT extends BasePaxIT {
 
         for (EntityDto entity : entityService.listEntities()) {
             if (!entity.isDDE()) {
+                userPreferencesService.removeUserPreferences(entity.getId(), USERNAME);
                 entityService.deleteEntity(entity.getId());
             }
         }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
@@ -21,6 +21,7 @@ import org.motechproject.mds.dto.LookupFieldDto;
 import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.dto.RestOptionsDto;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.it.BaseIT;
@@ -31,6 +32,7 @@ import org.motechproject.mds.repository.MetadataHolder;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.motechproject.mds.service.TypeService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.testutil.DraftBuilder;
 import org.motechproject.mds.testutil.FieldTestHelper;
 import org.motechproject.mds.util.Constants;
@@ -73,10 +75,10 @@ import static org.motechproject.mds.dto.LookupFieldType.RANGE;
 import static org.motechproject.mds.dto.LookupFieldType.SET;
 import static org.motechproject.mds.dto.LookupFieldType.VALUE;
 import static org.motechproject.mds.testutil.LookupTestHelper.lookupFieldsFromNames;
+import static org.motechproject.mds.util.Constants.MetadataKeys.OWNING_SIDE;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_CLASS;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_FIELD;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATIONSHIP_COLLECTION_TYPE;
-import static org.motechproject.mds.util.Constants.MetadataKeys.OWNING_SIDE;
 
 public class EntityServiceContextIT extends BaseIT {
     private static final String SIMPLE_NAME = "Test";
@@ -103,6 +105,9 @@ public class EntityServiceContextIT extends BaseIT {
 
     @Autowired
     private AllEntityDrafts allEntityDrafts;
+
+    @Autowired
+    private UserPreferencesService userPreferencesService;
 
     @Before
     public void setUp() throws Exception {
@@ -551,6 +556,45 @@ public class EntityServiceContextIT extends BaseIT {
         entityService.updateMaxFetchDepth(entityDto.getId(), 3);
         entityDto = entityService.getEntity(entityDto.getId());
         assertEquals(Integer.valueOf(3), entityDto.getMaxFetchDepth());
+    }
+
+    @Test
+    public void shouldUpdateUserPreferencesAfterCommit() {
+        EntityDto entityDto = new EntityDto();
+        entityDto.setName("UserPrefTest");
+        entityDto = entityService.createEntity(entityDto);
+
+        final Long entityId = entityDto.getId();
+
+        entityService.saveDraftEntityChanges(entityId,
+                DraftBuilder.forNewField("disp", "f1name", Long.class.getName()));
+        List<FieldDto> fields = entityService.getFields(entityId);
+        assertNotNull(fields);
+        assertEquals(asList("id", "creator", "owner", "modifiedBy", "creationDate", "modificationDate", "f1name"),
+                extract(fields, on(FieldDto.class).getBasic().getName()));
+        entityService.commitChanges(entityId);
+
+        List<Field> draftFields = entityService.getEntityDraft(entityId).getFields();
+        Field field = selectFirst(draftFields, having(on(Field.class).getName(), equalTo("f1name")));
+        entityService.saveDraftEntityChanges(entityDto.getId(),
+                DraftBuilder.forFieldEdit(field.getId(), "basic.name", "newName"));
+
+        userPreferencesService.selectFields(entityId, "motech");
+        userPreferencesService.unselectField(entityId, "motech", "id");
+        userPreferencesService.unselectField(entityId, "motech", "owner");
+
+        UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
+        assertEquals(asList( "f1name", "creator", "modifiedBy", "creationDate", "modificationDate"),
+                userPreferencesDto.getVisibleFields());
+
+        entityService.commitChanges(entityId);
+
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
+        assertEquals(asList("newName", "creator", "modifiedBy", "creationDate", "modificationDate"),
+                userPreferencesDto.getVisibleFields());
+
+        assertEquals(asList("id", "owner"),
+                userPreferencesDto.getUnselectedFields());
     }
 
     private void assertRelatedField(EntityDto relatedEntity, FieldDto relatedField, String collection) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/EntityServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/EntityServiceImplTest.java
@@ -20,6 +20,7 @@ import org.motechproject.mds.dto.FieldBasicDto;
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
 import org.motechproject.mds.enhancer.MdsJDOEnhancer;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.field.FieldUsedInLookupException;
@@ -30,6 +31,7 @@ import org.motechproject.mds.repository.AllEntityAudits;
 import org.motechproject.mds.repository.AllEntityDrafts;
 import org.motechproject.mds.repository.AllTypes;
 import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.testutil.DraftBuilder;
 import org.motechproject.mds.validation.EntityValidator;
 import org.osgi.framework.BundleContext;
@@ -103,6 +105,8 @@ public class EntityServiceImplTest {
     @Mock
     private Lookup draftLookup;
 
+    @Mock
+    private UserPreferencesService userPreferencesService;
 
     @Mock
     private BundleContext bundleContext;
@@ -534,6 +538,8 @@ public class EntityServiceImplTest {
 
         when(allEntities.retrieveById(8L)).thenReturn(entity);
         when(allEntityDrafts.retrieve(eq(entity), anyString())).thenReturn(draft);
+
+        when(userPreferencesService.getEntityPreferences(8l)).thenReturn(new ArrayList<UserPreferencesDto>());
 
         entityService.commitChanges(8L);
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
@@ -1,0 +1,267 @@
+package org.motechproject.mds.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.mds.config.SettingsService;
+import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.domain.Field;
+import org.motechproject.mds.domain.Lookup;
+import org.motechproject.mds.domain.UserPreferences;
+import org.motechproject.mds.dto.UserPreferencesDto;
+import org.motechproject.mds.ex.field.FieldNotFoundException;
+import org.motechproject.mds.repository.AllEntities;
+import org.motechproject.mds.repository.AllUserPreferences;
+import org.motechproject.mds.service.UserPreferencesService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserPreferencesServiceTest {
+
+    private static final String USERNAME = "username";
+    private static final String CLASS_NAME = "org.motechproject.sample.ClassName";
+
+    @Mock
+    private AllUserPreferences allUserPreferences;
+
+    @Mock
+    private AllEntities allEntities;
+
+    @Mock
+    private SettingsService settingsService;
+
+    @Mock
+    private UserPreferences userPreferences;
+
+    @Mock
+    Entity entity;
+
+    @Captor
+    ArgumentCaptor<UserPreferences> userPreferencesCaptor;
+
+    @Captor
+    ArgumentCaptor<List<Field>> selectedFieldsCaptor;
+
+    @Captor
+    ArgumentCaptor<List<Field>> unselectedFieldsCaptor;
+
+    @Captor
+    ArgumentCaptor<Field> fieldCaptor;
+
+    @InjectMocks
+    private UserPreferencesService userPreferencesService = new UserPreferencesServiceImpl();
+
+    @Before
+    public void setUp() {
+        when(settingsService.getGridSize()).thenReturn(20);
+        when(entity.getFields()).thenReturn(createFields());
+        when(entity.getClassName()).thenReturn(CLASS_NAME);
+        when(allEntities.retrieveById(15l)).thenReturn(entity);
+    }
+
+    @Test
+    public void shouldCreateDefaultPreferences() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(null);
+
+        userPreferencesService.getUserPreferences(15l, USERNAME);
+
+        verify(allUserPreferences).create(userPreferencesCaptor.capture());
+        UserPreferences capturedPreferences = userPreferencesCaptor.getValue();
+
+        assertEquals(USERNAME, capturedPreferences.getUsername());
+        assertEquals(CLASS_NAME, capturedPreferences.getClassName());
+        assertNotNull(capturedPreferences.getSelectedFields().size());
+        assertEquals(0, capturedPreferences.getSelectedFields().size());
+        assertEquals(0, capturedPreferences.getUnselectedFields().size());
+    }
+
+    @Test
+    public void shouldMergeFieldsInformation() {
+        List<Field> selectedFields = new ArrayList<>();
+        selectedFields.add(getField3());
+        List<Field> unselectedFields = new ArrayList<>();
+        unselectedFields.add(getField2());
+
+        UserPreferences preferences = new UserPreferences(USERNAME, CLASS_NAME, 20, selectedFields, unselectedFields);
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(preferences);
+
+        UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(15l, USERNAME);
+
+        assertNotNull(userPreferencesDto);
+        assertEquals(1, userPreferencesDto.getSelectedFields().size());
+        assertEquals(1, userPreferencesDto.getUnselectedFields().size());
+        assertEquals(2, userPreferencesDto.getVisibleFields().size());
+
+        assertEquals("sampleField3", userPreferencesDto.getSelectedFields().get(0));
+        assertEquals("sampleField2", userPreferencesDto.getUnselectedFields().get(0));
+        assertEquals("sampleField1", userPreferencesDto.getVisibleFields().get(0));
+        assertEquals("sampleField3", userPreferencesDto.getVisibleFields().get(1));
+
+    }
+
+    @Test
+    public void shouldUpdateGridSize() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.updateGridSize(15l, USERNAME, 50);
+
+        verify(userPreferences).setGridRowsNumber(50);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+
+    @Test
+    public void shouldTakeGridSizeFromSettingsService() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.updateGridSize(15l, USERNAME, null);
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+
+    @Test(expected = FieldNotFoundException.class)
+    public void shouldCheckFieldSelectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.selectField(15l, USERNAME, "oldField");
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+    @Test
+    public void shouldSelectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+
+        userPreferencesService.selectField(15l, USERNAME, "sampleField1");
+
+        verify(userPreferences).selectField(fieldCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        Field field = fieldCaptor.getValue();
+        assertNotNull(field);
+        assertEquals("sampleField1", field.getName());
+    }
+
+    @Test(expected = FieldNotFoundException.class)
+    public void shouldCheckFieldWhenUnselectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.unselectField(15l, USERNAME, "oldField");
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+    @Test
+    public void shouldUnselectField() {
+        Field field1 = getField1();
+
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(field1);
+
+        userPreferencesService.unselectField(15l, USERNAME, "sampleField1");
+
+        verify(userPreferences).unselectField(fieldCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        Field field = fieldCaptor.getValue();
+        assertNotNull(field);
+        assertEquals("sampleField1", field.getName());
+    }
+
+    @Test
+    public void shouldSelectFields() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+        when(userPreferences.getSelectedFields()).thenReturn(new ArrayList<Field>());
+
+        userPreferencesService.selectFields(15l, USERNAME);
+
+        verify(userPreferences).setSelectedFields(selectedFieldsCaptor.capture());
+        verify(userPreferences).setUnselectedFields(unselectedFieldsCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        List<Field> fields = selectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(4, fields.size());
+        assertEquals("sampleField1", fields.get(0).getName());
+        assertEquals("sampleField2", fields.get(1).getName());
+        assertEquals("sampleField3", fields.get(2).getName());
+        assertEquals("sampleField4", fields.get(3).getName());
+
+        fields = unselectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(0, fields.size());
+    }
+
+    @Test
+    public void shouldUnselectFields() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+        when(userPreferences.getSelectedFields()).thenReturn(createFields());
+
+        userPreferencesService.unselectFields(15l, USERNAME);
+
+        verify(userPreferences).setUnselectedFields(unselectedFieldsCaptor.capture());
+        verify(userPreferences).setSelectedFields(selectedFieldsCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        List<Field> fields = unselectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(4, fields.size());
+        assertEquals("sampleField1", fields.get(0).getName());
+        assertEquals("sampleField2", fields.get(1).getName());
+        assertEquals("sampleField3", fields.get(2).getName());
+        assertEquals("sampleField4", fields.get(3).getName());
+
+        fields = selectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(0, fields.size());
+    }
+
+    private List<Field> createFields() {
+        List<Field> fields = new ArrayList<>();
+        fields.add(getField1());
+        fields.add(getField2());
+        fields.add(getField3());
+        fields.add(getField4());
+        return fields;
+    }
+
+    private Field getField1() {
+        Field field =  new Field(null, "sampleField1", "Display Name 1", true, false, false, false, false, false, "default 1", "tooltip 1", "placeholder 1", new HashSet<Lookup>());
+        field.setUIDisplayable(true);
+        return field;
+    }
+
+    private Field getField2() {
+        Field field = new Field(null, "sampleField2", "Display Name 2", true, false, false, false, false, false, "default 2", "tooltip 2", "placeholder 2", new HashSet<Lookup>());
+        field.setUIDisplayable(true);
+        return field;
+    }
+
+    private Field getField3() {
+        return new Field(null, "sampleField3", "Display Name 3", true, false, false, false, false, false, "default 3", "tooltip 3", "placeholder 3", new HashSet<Lookup>());
+    }
+
+    private Field getField4() {
+        return new Field(null, "sampleField4", "Display Name 4", true, false, false, true, false, false, "default 4", "tooltip 4", "placeholder 4", new HashSet<Lookup>());
+    }
+}

--- a/platform/server-bundle/src/main/resources/webapp/js/common.js
+++ b/platform/server-bundle/src/main/resources/webapp/js/common.js
@@ -139,7 +139,7 @@ var jFormErrorHandler = function(response) {
             autowidth: true,
             rownumbers: false,
             rowNum: 10,
-            rowList: [10, 20, 50],
+            rowList: [10, 20, 50, 100],
             width: '100%',
             height: 'auto',
             sortorder: 'asc',


### PR DESCRIPTION
- Added global settings for grid size
- Added possibility to store data about visible fields in the database
- User can have other preferences for each entity
- Cherry-pick: Refactor of the EntityControllerTest
- ModuleSettings refactor