### PR TITLE
MOTECH-1800: UserPreferences for MDS entities

### DIFF
--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridFieldSelectionUpdate.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridFieldSelectionUpdate.java
@@ -1,0 +1,35 @@
+package org.motechproject.mds.web.domain;
+
+/**
+ * The <code>GridFieldSelectionUpdate</code> contains data about a visible fields update.
+ */
+public class GridFieldSelectionUpdate {
+
+    private String field;
+
+    private GridSelectionAction action;
+
+    public GridFieldSelectionUpdate() {}
+
+    public GridFieldSelectionUpdate(String field, GridSelectionAction action) {
+        this.field = field;
+        this.action = action;
+    }
+
+    public GridSelectionAction getAction() {
+        return action;
+    }
+
+    public void setAction(GridSelectionAction action) {
+        this.action = action;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+}

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridSelectionAction.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/domain/GridSelectionAction.java
@@ -1,0 +1,27 @@
+package org.motechproject.mds.web.domain;
+
+/**
+ * The <code>GridSelectionAction</code> Enum contains the possible actions for a visible fields update.
+ */
+public enum GridSelectionAction {
+
+    /**
+     * Add field to visible fields.
+     */
+    ADD,
+
+    /**
+     * Add all fields to visible fields.
+     */
+    ADD_ALL,
+
+    /**
+     * Remove field from visible fields.
+     */
+    REMOVE,
+
+    /**
+     * Removes all field from visible fields.
+     */
+    REMOVE_ALL
+}

--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
@@ -39,6 +39,8 @@ import org.motechproject.mds.service.HistoryService;
 import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.mds.service.TrashService;
 import org.motechproject.mds.service.TypeService;
+import org.motechproject.mds.service.UserPreferencesService;
+
 import org.motechproject.mds.util.ClassName;
 import org.motechproject.mds.service.HistoryTrashClassHelper;
 import org.motechproject.mds.util.Constants;
@@ -88,6 +90,7 @@ import static org.motechproject.mds.util.Constants.MetadataKeys.MAP_KEY_TYPE;
 import static org.motechproject.mds.util.Constants.MetadataKeys.MAP_VALUE_TYPE;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_CLASS;
 import static org.motechproject.mds.util.Constants.Util.ID_FIELD_NAME;
+import static org.motechproject.mds.util.SecurityUtil.getUsername;
 
 /**
  * Default implementation of the {@link org.motechproject.mds.web.service.InstanceService} interface.
@@ -104,6 +107,7 @@ public class InstanceServiceImpl implements InstanceService {
     private TrashService trashService;
     private TypeService typeService;
     private RelationshipDisplayUtil relationshipDisplayUtil;
+    private UserPreferencesService userPreferencesService;
 
     @Override
     @Transactional
@@ -190,6 +194,7 @@ public class InstanceServiceImpl implements InstanceService {
 
         MotechDataService service = getServiceForEntity(entity);
         List instances = service.retrieveAll(queryParams);
+        updateGridSize(entityId, queryParams);
 
         return instancesToRecords(instances, entity, fields, service, EntityType.STANDARD);
     }
@@ -208,6 +213,7 @@ public class InstanceServiceImpl implements InstanceService {
         MotechDataService service = getServiceForEntity(entity);
         List<FieldDto> fields = entityService.getEntityFieldsForUI(entityId);
         Collection collection = trashService.getInstancesFromTrash(entity.getClassName(), queryParams);
+        updateGridSize(entityId, queryParams);
 
         return instancesToRecords(collection, entity, fields, service, EntityType.TRASH);
     }
@@ -354,6 +360,8 @@ public class InstanceServiceImpl implements InstanceService {
         Object instance = service.retrieve(ID_FIELD_NAME, instanceId);
 
         List history = historyService.getHistoryForInstance(instance, queryParams);
+        updateGridSize(entityId, queryParams);
+
         List<HistoryRecord> result = new ArrayList<>();
         for (Object o : history) {
             result.add(convertToHistoryRecord(o, entity, instanceId, service));
@@ -467,6 +475,13 @@ public class InstanceServiceImpl implements InstanceService {
     @Override
     public void validateNonEditableProperty(Long entityId) {
         validateNonEditableProperty(getEntity(entityId));
+    }
+
+    private void updateGridSize(Long entityId, QueryParams queryParams) {
+        String username = getUsername();
+        if (queryParams != null && StringUtils.isNotBlank(username)) {
+            userPreferencesService.updateGridSize(entityId, username, queryParams.getPageSize());
+        }
     }
 
     private void validateNonEditableProperty(EntityDto entity) {
@@ -1027,5 +1042,10 @@ public class InstanceServiceImpl implements InstanceService {
     @Autowired
     public void setRelationshipDisplayUtil(RelationshipDisplayUtil relationshipDisplayUtil) {
         this.relationshipDisplayUtil = relationshipDisplayUtil;
+    }
+
+    @Autowired
+    public void setUserPreferencesService(UserPreferencesService userPreferencesService) {
+        this.userPreferencesService = userPreferencesService;
     }
 }

--- a/platform/mds/mds-web/src/main/resources/META-INF/spring/blueprint.xml
+++ b/platform/mds/mds-web/src/main/resources/META-INF/spring/blueprint.xml
@@ -20,6 +20,8 @@
 
     <osgi:reference id="entityServiceOSGi" interface="org.motechproject.mds.service.EntityService"/>
 
+    <osgi:reference id="userPreferencesServiceOSGi" interface="org.motechproject.mds.service.UserPreferencesService"/>
+
     <osgi:reference id="historyServiceOSGi" interface="org.motechproject.mds.service.HistoryService" availability="optional"/>
 
     <osgi:reference id="trashServiceOSGi" interface="org.motechproject.mds.service.TrashService" availability="optional"/>

--- a/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/controllers.js
@@ -3321,7 +3321,7 @@
 
         $scope.allEntityFields = [];
 
-        $scope.availableFieldsForDisplay= [];
+        $scope.availableFieldsForDisplay = [];
 
         $scope.validatePattern = '';
 
@@ -3343,7 +3343,7 @@
 
         $scope.availableUsers = MDSUsers.query();
 
-        // fields which won't be persisted in the user cookie
+        // fields which won't be persisted in the user preferences
         $scope.autoDisplayFields = [];
 
         /**
@@ -3747,6 +3747,7 @@
                     $scope.previouslyEdited = prev.previouslyEdited;
                 });
             } else {
+                $scope.entityAdvanced = undefined;
                 if ($scope.entityClassName) {
                     $scope.selectEntityByClassName($scope.entityClassName);
                 } else {
@@ -3945,38 +3946,22 @@
                               });
                           }
                       }
+
+                      $scope.selectedFields = [];
+                      for (i = 0; i < $scope.allEntityFields.length; i += 1) {
+                          field = $scope.allEntityFields[i];
+                          if ($.inArray(field.basic.name, $scope.entityAdvanced.userPreferences.visibleFields) !== -1) {
+                              $scope.selectedFields.push(field);
+                          }
+                      }
+                      $scope.updateInstanceGridFields();
+
+                      if (callback) {
+                          callback();
+                      }
+
                       unblockUI();
                    });
-
-                   Entities.getDisplayFields({id: $scope.selectedEntity.id}, function(data) {
-                        var i, field, selectedName,
-                            dbUserPreferences = $scope.getDataBrowserUserPreferencesCookie($scope.selectedEntity);
-
-                        $scope.selectedFields = [];
-
-                        // filter data from db
-                        for (i = 0; i < data.length; i += 1) {
-                            field = data[i];
-                            if ($.inArray(field.basic.name, dbUserPreferences.unselected) === -1) {
-                                $scope.selectedFields.push(field);
-                            }
-                        }
-
-                        // additional selections
-                        for (i = 0; i < dbUserPreferences.selected.length; i += 1) {
-                            selectedName = dbUserPreferences.selected[i];
-                            // check if already selected
-                            if (!$scope.isFieldSelected(selectedName)) {
-                                $scope.selectFieldByName(selectedName);
-                            }
-                        }
-
-                        $scope.updateInstanceGridFields();
-                    });
-
-                    if (callback) {
-                        callback();
-                    }
                 });
             });
         };
@@ -4034,31 +4019,6 @@
             return username + '_org.motechproject.mds.databrowser.fields.' + entity.className + '#' + entity.id;
         };
 
-        $scope.getDataBrowserUserPreferencesCookie = function(entity) {
-            var cookieName = $scope.dataBrowserPreferencesCookieName($scope.selectedEntity),
-                cookie;
-            // get or create
-            if ($.cookie(cookieName)) {
-                cookie = JSON.parse($.cookie(cookieName));
-            } else {
-                cookie = {
-                    selected: [],
-                    unselected: []
-                };
-                $.cookie(cookieName, JSON.stringify(cookie));
-            }
-
-            // check fields
-            if (cookie.unselected === undefined) {
-                cookie.unselected = [];
-            }
-            if (cookie.selected === undefined) {
-                cookie.selected = [];
-            }
-
-            return cookie;
-        };
-
         $scope.isFieldSelected = function(name) {
             var i;
             for (i = 0; i < $scope.selectedFields.length; i += 1) {
@@ -4080,49 +4040,61 @@
             }
         };
 
-        $scope.markAllFieldsForDataBrowser = function (selected) {
-            var i, field;
-            for (i = 0; i < $scope.allEntityFields.length; i += 1) {
-                field = $scope.allEntityFields[i];
-                $scope.markFieldForDataBrowser(field.basic.name, selected);
+        $scope.addFieldsForDataBrowser = function(checked) {
+            var field, i, fieldsData = {
+                field: '',
+                action: 'ADD_ALL'
+            };
+
+            if (!checked) {
+                fieldsData.action = 'REMOVE_ALL';
+                $scope.selectedFields = [];
+            } else {
+                $scope.selectedFields = [];
+                for (i = 0; i < $scope.availableFieldsForDisplay.length; i += 1) {
+                    $scope.selectedFields.push(field);
+                }
             }
+
+            $http.post('../mds/entities/' + $scope.selectedEntity.id + "/preferences/fields", fieldsData)
+            .error(function () {
+                handleResponse('mds.error', 'mds.preferences.error.fields', '');
+                unblockUI();
+            });
         };
 
-        $scope.markFieldForDataBrowser = function(name, selected) {
-            if (name) {
-                var i, field, dbUserPreferences = $scope.getDataBrowserUserPreferencesCookie($scope.selectedEntity),
-                    cookieName = $scope.dataBrowserPreferencesCookieName($scope.selectedEntity);
+        $scope.addFieldForDataBrowser = function(selected, checked) {
+            var field, i, fieldsData = {
+                field: selected,
+                action: 'ADD'
+            };
 
-                if (selected) {
-                    dbUserPreferences.unselected.removeObject(name);
-                    dbUserPreferences.selected.uniquePush(name);
-
-                    // update selectedFields for grid switch
-                    if (!$scope.isFieldSelected(name)) {
-                        for (i = 0; i < $scope.allEntityFields.length; i += 1) {
-                            field = $scope.allEntityFields[i];
-                            if (field.basic.name === name) {
-                                $scope.selectedFields.push(field);
-                            }
-                        }
-                    }
-                } else {
-                    dbUserPreferences.selected.removeObject(name);
-                    dbUserPreferences.unselected.uniquePush(name);
-
-                    // update selectedFields for grid switch
-                    if ($scope.isFieldSelected(name)) {
-                        for (i = 0; i < $scope.selectedFields.length; i += 1) {
-                            field = $scope.selectedFields[i];
-                            if (field.basic.name === name) {
-                                $scope.selectedFields.remove(i, i);
-                            }
+            if (!checked) {
+                fieldsData.action = 'REMOVE';
+                if ($scope.isFieldSelected(selected)) {
+                    for (i = 0; i < $scope.selectedFields.length; i += 1) {
+                        field = $scope.selectedFields[i];
+                        if (field.basic.name === selected) {
+                            $scope.selectedFields.remove(i, i);
                         }
                     }
                 }
-
-                $.cookie(cookieName, JSON.stringify(dbUserPreferences));
+            } else {
+                if (!$scope.isFieldSelected(selected)) {
+                    for (i = 0; i < $scope.availableFieldsForDisplay.length; i += 1) {
+                        field = $scope.allEntityFields[i];
+                        if (field.basic.name === selected) {
+                            $scope.selectedFields.push(field);
+                        }
+                    }
+                }
             }
+
+            $http.post('../mds/entities/' + $scope.selectedEntity.id + "/preferences/fields", fieldsData)
+            .error(function () {
+                handleResponse('mds.error', 'mds.preferences.error.fields', '');
+                unblockUI();
+            });
         };
 
         $scope.filtersForField = function(field) {
@@ -4263,6 +4235,7 @@
         * Unselects entity to allow user to return to entities list by modules
         */
         $scope.unselectEntity = function () {
+            $scope.entityAdvanced = undefined;
             $scope.dataRetrievalError = false;
             innerLayout({
                 spacing_closed: 30,
@@ -4661,7 +4634,7 @@
             angular.forEach($("select.multiselect")[0], function(field) {
                 var name = $scope.getFieldName(field.label), selected = false;
 
-                // this fields won't be used for cookie data
+                // this fields won't be used for user preferences
                 $scope.autoDisplayFields = fieldsToSelect || [];
 
                 if (name) {
@@ -4878,6 +4851,8 @@
         };
 
         $scope.settings = MdsSettings.getSettings();
+
+        $scope.gridSizes = [10, 20, 50, 100];
 
         $scope.timeUnits = [
             { value: 'HOURS', label: $scope.msg('mds.dateTimeUnits.hours') },

--- a/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
@@ -152,18 +152,29 @@
     * whether is selected for display in the jqGrid
     */
     function isSelectedField(name, selectedFields) {
-        var result = true;
-        if (selectedFields !== undefined && $.isArray(selectedFields)) {
-            $.each(selectedFields, function (i, sField) {
-                if(name === sField.basic.name) {
-                    result = true;
-                } else {
-                    result = false;
+        var i;
+        if (selectedFields) {
+            for (i = 0; i < selectedFields.length; i += 1) {
+                if (name === selectedFields[i].basic.name) {
+                    return true;
                 }
-                return (!result);
-            });
+            }
         }
-        return result;
+        return false;
+    }
+
+    function handleGridPagination(pgButton, pager, scope) {
+        var newPage = 1, last, newSize;
+        if ("user" === pgButton) { //Handle changing page by the page input
+            newPage = parseInt(pager.find('input:text').val(), 10); // get new page number
+            last = parseInt($(this).getGridParam("lastpage"), 10); // get last page number
+            if (newPage > last || newPage === 0) { // check range - if we cross range then stop
+                return 'stop';
+            }
+        } else if ("records" === pgButton) { //Page size change, we must update scope value to avoid wrong page size in the trash screen
+            newSize = parseInt(pager.find('select')[0].value, 10);
+            scope.entityAdvanced.userPreferences.gridRowsNumber = newSize;
+        }
     }
 
     function buildGridColModel(colModel, fields, scope, removeVersionField, ignoreHideFields) {
@@ -1307,6 +1318,10 @@
                             postData: {
                                 fields: JSON.stringify(scope.lookupBy)
                             },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
+                            },
                             jsonReader: {
                                 repeatitems: false
                             },
@@ -1563,11 +1578,10 @@
                                 var name = scope.getFieldName(optionElement.text());
                                 // don't act for fields show automatically in trash and history
                                 if (scope.autoDisplayFields.indexOf(name) === -1) {
-                                    // set the cookie, users have their own browsing settings
-                                    scope.markFieldForDataBrowser(name, checked);
+                                    scope.addFieldForDataBrowser(name, checked);
                                 }
                             } else {
-                                scope.markAllFieldsForDataBrowser(checked);
+                                scope.addFieldsForDataBrowser(checked);
                             }
 
                             noSelectedFields = true;
@@ -1656,6 +1670,10 @@
                                 } else {
                                     scope.historyInstance(id);
                                 }
+                            },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
                             },
                             resizeStop: function (width, index) {
                                 var widthNew, widthOrg, colModel = $('#' + gridId).jqGrid('getGridParam','colModel');
@@ -1777,6 +1795,10 @@
                             },
                             jsonReader: {
                                 repeatitems: false
+                            },
+                            rowNum: scope.entityAdvanced.userPreferences.gridRowsNumber,
+                            onPaging: function (pgButton) {
+                                handleGridPagination(pgButton, $(this.p.pager), scope);
                             },
                             onSelectRow: function (id) {
                                 firstLoad = true;

--- a/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
+++ b/platform/mds/mds-web/src/main/resources/webapp/messages/messages.properties
@@ -395,7 +395,7 @@ mds.dataBrowsing.editRelatedInstance=Edit related instance
 mds.dataBrowsing.removeRelatedInstance=Remove related instance
 
 #Settings
-mds.tab.dataRetention=Data retention
+mds.tab.mdsSettings=Mds settings
 mds.tab.import=Import
 mds.tab.export=Export
 
@@ -407,6 +407,10 @@ mds.dataRetention.emptyTrash=Empty the trash
 mds.dataRetention.save=Save settings
 mds.dataRetention.success=Settings has been saved
 mds.dataRetention.error=Error while saving settings
+
+# User preferences
+mds.userPreferences.info=Default Data Browser preferences
+mds.userPreferences.gridSize=Default grid size
 
 #Date-Time units
 mds.dateTimeUnits.seconds=Seconds
@@ -500,3 +504,5 @@ mds.operator.matches = Matches
 mds.operator.matches.ci = Matches (Case Insensitive)
 mds.operator.starts = Starts with
 mds.operator.ends = Ends with
+
+mds.preferences.error.fields=Cannot update visible fields preferences.

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/settings.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/settings.html
@@ -2,7 +2,7 @@
     <div id="settings-tab">
         <ul class="nav nav-tabs mds-settings" id="myTab">
             <li class="active">
-                <a target="_self" href="#data-retention" data-toggle="tab">{{msg('mds.tab.dataRetention')}}</a>
+                <a target="_self" href="#mds-settings" data-toggle="tab">{{msg('mds.tab.mdsSettings')}}</a>
             </li>
             <li>
                 <a target="_self" href="#import" data-toggle="tab">{{msg('mds.tab.import')}}</a>
@@ -13,8 +13,8 @@
         </ul>
 
         <div class="tab-content">
-            <div class="tab-pane active inside" id="data-retention">
-                <div ng-include="'../mds/resources/partials/widgets/data-retention.html'"></div>
+            <div class="tab-pane active inside" id="mds-settings">
+                <div ng-include="'../mds/resources/partials/widgets/mds-settings.html'"></div>
             </div>
             <div class="tab-pane" id="import">
                 <div ng-include="'../mds/resources/partials/widgets/import.html'"></div>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
@@ -89,7 +89,7 @@
         </div>
     </div>
 
-    <div id="entityInstancesTable" class="overrideJqgridTable">
+    <div ng-if="entityAdvanced" id="entityInstancesTable" class="overrideJqgridTable">
         <table id="instancesTable" entity-instances-grid="pageInstancesTable"></table>
         <div id="pageInstancesTable"></div>
     </div>

--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/mds-settings.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/mds-settings.html
@@ -24,6 +24,17 @@
             <select class="form-control input-auto" ng-disabled="checkTimeSelectDisable()" ng-model="settings.timeUnit" ng-options="t.value as t.label for t in timeUnits"></select>
         </div>
     </div>
+    <div class="form-group">
+        {{msg('mds.userPreferences.info')}}
+    </div>
+    <div class="form-group form-inline">
+        <label class="label-radio">
+            {{msg('mds.userPreferences.gridSize')}}
+        </label>
+        <div class="settings-input-group">
+            <select class="form-control input-auto" ng-model="settings.gridSize" ng-options="size for size in gridSizes"></select>
+        </div>
+    </div>
     <span class="btn btn-default" ng-click="saveSettings()">{{msg('mds.dataRetention.save')}}</span>
 
 </form>

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/ModuleSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/ModuleSettings.java
@@ -1,25 +1,6 @@
 package org.motechproject.mds.config;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
-import java.io.IOException;
 import java.util.Objects;
-import java.util.Properties;
-
-import static org.apache.commons.lang.StringUtils.isNotBlank;
-import static org.apache.commons.lang.StringUtils.isNumeric;
-import static org.motechproject.mds.util.Constants.Config.MDS_DELETE_MODE;
-import static org.motechproject.mds.util.Constants.Config.MDS_EMPTY_TRASH;
-import static org.motechproject.mds.util.Constants.Config.MDS_TIME_UNIT;
-import static org.motechproject.mds.util.Constants.Config.MDS_TIME_VALUE;
 
 /**
  * The <code>ModuleSettings</code> contains the base module settings which are inside the
@@ -27,148 +8,84 @@ import static org.motechproject.mds.util.Constants.Config.MDS_TIME_VALUE;
  * inside this class always checks the given property and if it is incorrect then the default
  * value of the given property will be returned.
  */
-@JsonSerialize(using = ModuleSettings.Serializer.class)
-@JsonDeserialize(using = ModuleSettings.Deserializer.class)
-public class ModuleSettings extends Properties {
-    private static final long serialVersionUID = -3738155444078581700L;
-
+public class ModuleSettings {
     public static final DeleteMode DEFAULT_DELETE_MODE = DeleteMode.TRASH;
     public static final Boolean DEFAULT_EMPTY_TRASH = false;
     public static final Integer DEFAULT_TIME_VALUE = 1;
     public static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.HOURS;
+    public static final Integer DEFAULT_GRID_SIZE = 50;
 
-    public DeleteMode getDeleteMode() {
-        Object objectValue = getValueForKey(MDS_DELETE_MODE);
-        String valueAsString = null;
+    private DeleteMode deleteMode;
+    private Boolean emptyTrash;
+    private Integer timeValue;
+    private TimeUnit timeUnit;
+    private Integer gridSize;
 
-        if (objectValue != null) {
-            valueAsString = objectValue.toString();
-        }
-
-        DeleteMode value = DEFAULT_DELETE_MODE;
-
-        if (isNotBlank(valueAsString)) {
-            value = DeleteMode.fromString(valueAsString);
-        }
-
-        return value;
+    public ModuleSettings() {
     }
 
-    public void setDeleteMode(String deleteMode) {
-        DeleteMode fromString = DeleteMode.fromString(deleteMode);
-
-        if (DeleteMode.UNKNOWN == fromString) {
-            setDeleteMode(DEFAULT_DELETE_MODE);
-        } else {
-            setDeleteMode(fromString);
+    public DeleteMode getDeleteMode() {
+        if (deleteMode == null) {
+            return DEFAULT_DELETE_MODE;
         }
+        return deleteMode;
     }
 
     public void setDeleteMode(DeleteMode deleteMode) {
-        DeleteMode mode = DeleteMode.UNKNOWN == deleteMode ? DEFAULT_DELETE_MODE : deleteMode;
-        set(MDS_DELETE_MODE, mode, DEFAULT_DELETE_MODE);
+        this.deleteMode = deleteMode == null ? DEFAULT_DELETE_MODE : deleteMode;
     }
 
     public Boolean isEmptyTrash() {
-        Object objectValue = getValueForKey(MDS_EMPTY_TRASH);
-
-        String valueAsString = null;
-
-        if (objectValue != null) {
-            valueAsString = objectValue.toString();
+        if (emptyTrash == null) {
+            return DEFAULT_EMPTY_TRASH;
         }
-
-        Boolean value = DEFAULT_EMPTY_TRASH;
-
-        if (isNotBlank(valueAsString)) {
-            value = Boolean.parseBoolean(valueAsString);
-        }
-
-        return value;
-    }
-
-    public void setEmptyTrash(String emptyTrash) {
-        if (isNotBlank(emptyTrash)) {
-            setEmptyTrash(Boolean.parseBoolean(emptyTrash));
-        } else {
-            setEmptyTrash(DEFAULT_EMPTY_TRASH);
-        }
+        return emptyTrash;
     }
 
     public void setEmptyTrash(Boolean emptyTrash) {
-        set(MDS_EMPTY_TRASH, emptyTrash, DEFAULT_EMPTY_TRASH);
+        this.emptyTrash = emptyTrash == null ? DEFAULT_EMPTY_TRASH : emptyTrash;
     }
 
     public Integer getTimeValue() {
-        Object value = getValueForKey(MDS_TIME_VALUE);
-
-        Integer intValue = 0;
-        String valueAsString = null;
-        if (value != null) {
-            valueAsString = value.toString();
+        if (timeValue == null) {
+            return DEFAULT_TIME_VALUE;
         }
-
-        if (isNotBlank(valueAsString) && isNumeric(valueAsString)) {
-            intValue = Integer.parseInt(valueAsString);
-        }
-
-        if (intValue < 1) {
-            intValue = DEFAULT_TIME_VALUE;
-        }
-
-        return intValue;
-
-    }
-
-    public void setTimeValue(String timeValue) {
-        if (isNotBlank(timeValue) && isNumeric(timeValue)) {
-            setTimeValue(Integer.parseInt(timeValue));
-        } else {
-            setTimeValue(DEFAULT_TIME_VALUE);
-        }
+        return timeValue;
     }
 
     public void setTimeValue(Integer timeValue) {
-        Integer value = timeValue < 1 ? DEFAULT_TIME_VALUE : timeValue;
-        set(MDS_TIME_VALUE, value, DEFAULT_TIME_VALUE);
+        if (timeValue == null) {
+            this.timeValue = DEFAULT_TIME_VALUE;
+        } else {
+            this.timeValue = timeValue < 1 ? DEFAULT_TIME_VALUE : timeValue;
+        }
     }
 
     public TimeUnit getTimeUnit() {
-        String valueAsString = getProperty(MDS_TIME_UNIT);
-        TimeUnit value = DEFAULT_TIME_UNIT;
-
-        if (isNotBlank(valueAsString)) {
-            value = TimeUnit.fromString(valueAsString);
+        if (timeUnit == null) {
+            return DEFAULT_TIME_UNIT;
         }
-
-        return value;
-    }
-
-    public void setTimeUnit(String timeUnit) {
-        TimeUnit fromString = TimeUnit.fromString(timeUnit);
-
-        if (TimeUnit.UNKNOWN == fromString) {
-            setTimeUnit(DEFAULT_TIME_UNIT);
-        } else {
-            setTimeUnit(fromString);
-        }
+        return timeUnit;
     }
 
     public void setTimeUnit(TimeUnit timeUnit) {
-        TimeUnit unit = TimeUnit.UNKNOWN == timeUnit ? DEFAULT_TIME_UNIT : timeUnit;
-        set(MDS_TIME_UNIT, unit, DEFAULT_TIME_UNIT);
+        this.timeUnit = timeUnit == null ? DEFAULT_TIME_UNIT : timeUnit;
     }
 
-    private void set(String key, Object given, Object defaultValue) {
-        Object value = null == given ? defaultValue : given;
-        String valueAsString = value.toString();
+    public void setGridSize(Integer gridSize) {
+        this.gridSize = gridSize == null ? DEFAULT_GRID_SIZE : gridSize;
+    }
 
-        setProperty(key, valueAsString);
+    public Integer getGridSize() {
+        if (gridSize == null) {
+            return DEFAULT_GRID_SIZE;
+        }
+        return gridSize;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit());
+        return Objects.hash(getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit(), getGridSize());
     }
 
     @Override
@@ -186,68 +103,7 @@ public class ModuleSettings extends Properties {
         return Objects.equals(this.getDeleteMode(), other.getDeleteMode())
                 && Objects.equals(this.isEmptyTrash(), other.isEmptyTrash())
                 && Objects.equals(this.getTimeValue(), other.getTimeValue())
-                && Objects.equals(this.getTimeUnit(), other.getTimeUnit());
-    }
-
-    @Override
-    public String toString() {
-        return String.format(
-                "ModuleSettings{deleteMode=%s, emptyTrash=%s, timeValue=%d, timeUnit=%s}",
-                getDeleteMode(), isEmptyTrash(), getTimeValue(), getTimeUnit()
-        );
-    }
-
-    private Object getValueForKey(String key) {
-        for (Object keyFromSet : keySet()) {
-            if (key.compareTo(keyFromSet.toString()) == 0) {
-                return get(key);
-            }
-        }
-        return null;
-    }
-
-    public static final class Serializer extends JsonSerializer<ModuleSettings> {
-
-        @Override
-        public void serialize(ModuleSettings value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeStartObject();
-            jgen.writeObjectField("deleteMode", value.getDeleteMode());
-            jgen.writeObjectField("emptyTrash", value.isEmptyTrash());
-            jgen.writeObjectField("timeValue", value.getTimeValue());
-            jgen.writeObjectField("timeUnit", value.getTimeUnit());
-            jgen.writeEndObject();
-        }
-    }
-
-    public static final class Deserializer extends JsonDeserializer<ModuleSettings> {
-
-        @Override
-        public ModuleSettings deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-            JsonNode jsonNode = jp.readValueAsTree();
-
-            String deleteMode = getValue(jsonNode, "deleteMode");
-            String emptyTrash = getValue(jsonNode, "emptyTrash");
-            String timeValue = getValue(jsonNode, "timeValue");
-            String timeUnit = getValue(jsonNode, "timeUnit");
-
-            ModuleSettings settings = new ModuleSettings();
-            settings.setDeleteMode(deleteMode);
-            settings.setEmptyTrash(emptyTrash);
-            settings.setTimeValue(timeValue);
-            settings.setTimeUnit(timeUnit);
-
-            return settings;
-        }
-
-        private String getValue(JsonNode jsonNode, String key) {
-            String value = null;
-
-            if (jsonNode.has(key)) {
-                value = jsonNode.get(key).asText();
-            }
-
-            return value;
-        }
-
+                && Objects.equals(this.getTimeUnit(), other.getTimeUnit())
+                && Objects.equals(this.getGridSize(), other.getGridSize());
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/SettingsService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/SettingsService.java
@@ -1,7 +1,5 @@
 package org.motechproject.mds.config;
 
-import java.util.Properties;
-
 /**
  * The <code>SettingsService</code> is a generic class, allowing access to all
  * MDS settings, as well as providing an ability to easily change these settings.
@@ -38,6 +36,13 @@ public interface SettingsService {
     TimeUnit getTimeUnit();
 
     /**
+     * Returns current setting of the grid size.
+     *
+     * @return the size of the grid
+     */
+    Integer getGridSize();
+
+    /**
      * Updates all MDS settings and performs necessary actions if required (eg. scheduling jobs, that remove
      * instances from trash).
      *
@@ -51,11 +56,4 @@ public interface SettingsService {
      * @return MDS settings
      */
     ModuleSettings getModuleSettings();
-
-    /**
-     * Retrieves all MDS settings as {@link java.util.Properties}.
-     *
-     * @return MDS settings
-     */
-    Properties getProperties();
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/impl/SettingsServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/impl/SettingsServiceImpl.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.config.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.mds.config.DeleteMode;
 import org.motechproject.mds.config.MdsConfig;
 import org.motechproject.mds.config.ModuleSettings;
@@ -12,8 +13,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Properties;
 
+import static org.motechproject.mds.util.Constants.Config.MDS_DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.util.Constants.Config.MDS_DELETE_MODE;
 import static org.motechproject.mds.util.Constants.Config.MDS_EMPTY_TRASH;
 import static org.motechproject.mds.util.Constants.Config.MDS_TIME_UNIT;
@@ -51,16 +54,19 @@ public class SettingsServiceImpl implements SettingsService {
     }
 
     @Override
+    public Integer getGridSize() {
+        return getModuleSettings().getGridSize();
+    }
+
+    @Override
     @Transactional
     public void saveModuleSettings(ModuleSettings settings) {
         ConfigSettings configSetting = new ConfigSettings();
-        configSetting.setEmptyTrash(Boolean.parseBoolean(settings.getProperty(MDS_EMPTY_TRASH)));
-        configSetting.setAfterTimeUnit(TimeUnit.fromString(settings.getProperty(MDS_TIME_UNIT)));
-        configSetting.setDeleteMode(DeleteMode.fromString(settings.getProperty(MDS_DELETE_MODE)));
-
-        if (settings.getProperty(MDS_TIME_VALUE) != null) {
-            configSetting.setAfterTimeValue(Integer.parseInt(settings.getProperty(MDS_TIME_VALUE)));
-        }
+        configSetting.setEmptyTrash(settings.isEmptyTrash());
+        configSetting.setAfterTimeUnit(settings.getTimeUnit());
+        configSetting.setDeleteMode(settings.getDeleteMode());
+        configSetting.setDefaultGridSize(settings.getGridSize());
+        configSetting.setAfterTimeValue(settings.getTimeValue());
 
         allConfigSettings.addOrUpdate(configSetting);
 
@@ -72,27 +78,42 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     @Transactional
     public ModuleSettings getModuleSettings() {
+        ConfigSettings configSettings = getConfigFromDb();
+        ModuleSettings moduleSettings;
 
-        ModuleSettings moduleSettings = new ModuleSettings();
-        moduleSettings.putAll(getProperties());
+        if (configSettings != null) {
+            moduleSettings = new ModuleSettings();
+            moduleSettings.setDeleteMode(configSettings.getDeleteMode());
+            moduleSettings.setEmptyTrash(configSettings.getEmptyTrash());
+            moduleSettings.setTimeValue(configSettings.getAfterTimeValue());
+            moduleSettings.setTimeUnit(configSettings.getAfterTimeUnit());
+            moduleSettings.setGridSize(configSettings.getDefaultGridSize());
+        } else {
+            moduleSettings = getSettingsFromFile();
+        }
 
         return moduleSettings;
     }
 
-    @Override
-    @Transactional
-    public Properties getProperties() {
-        ConfigSettings configSettings = allConfigSettings.retrieve("id", 1);
-        Properties props = new Properties();
-        if (configSettings != null) {
-            props.put(MDS_TIME_VALUE, configSettings.getAfterTimeValue());
-            props.put(MDS_EMPTY_TRASH, configSettings.getEmptyTrash());
-            props.put(MDS_TIME_UNIT, configSettings.getAfterTimeUnit());
-            props.put(MDS_DELETE_MODE, configSettings.getDeleteMode());
-        } else {
-            props = mdsConfig.getProperties(MODULE_FILE);
+    private ConfigSettings getConfigFromDb() {
+        List<ConfigSettings> configs = allConfigSettings.retrieveAll();
+        if (configs != null && configs.size() > 0) {
+            return configs.get(0);
         }
-        return props;
+        return null;
+    }
+
+    private ModuleSettings getSettingsFromFile() {
+        Properties props = mdsConfig.getProperties(MODULE_FILE);
+
+        ModuleSettings moduleSettings = new ModuleSettings();
+        moduleSettings.setDeleteMode(StringUtils.isNotBlank(props.getProperty(MDS_DELETE_MODE)) ? DeleteMode.fromString(props.getProperty(MDS_DELETE_MODE)) : null);
+        moduleSettings.setEmptyTrash(StringUtils.isNotBlank(props.getProperty(MDS_EMPTY_TRASH)) ? Boolean.parseBoolean(props.getProperty(MDS_EMPTY_TRASH)) : null);
+        moduleSettings.setTimeValue(StringUtils.isNotBlank(props.getProperty(MDS_TIME_VALUE)) ? Integer.parseInt(props.getProperty(MDS_TIME_VALUE)) : null);
+        moduleSettings.setTimeUnit(StringUtils.isNotBlank(props.getProperty(MDS_TIME_UNIT)) ? TimeUnit.fromString(props.getProperty(MDS_TIME_UNIT)) : null);
+        moduleSettings.setGridSize(StringUtils.isNotBlank(props.getProperty(MDS_DEFAULT_GRID_SIZE)) ? Integer.parseInt(props.getProperty(MDS_DEFAULT_GRID_SIZE)) : null);
+
+        return moduleSettings;
     }
 
     @Autowired

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ConfigSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/ConfigSettings.java
@@ -33,15 +33,19 @@ public class ConfigSettings {
     @Persistent
     private TimeUnit afterTimeUnit;
 
+    @Persistent
+    private int defaultGridSize;
+
     public ConfigSettings() {
-        this(DeleteMode.TRASH, false, 1, TimeUnit.HOURS);
+        this(DeleteMode.TRASH, false, 1, TimeUnit.HOURS, 10);
     }
 
-    public ConfigSettings(DeleteMode deleteMode, boolean emptyTrash, int afterTimeValue, TimeUnit afterTimeUnit) {
+    public ConfigSettings(DeleteMode deleteMode, boolean emptyTrash, int afterTimeValue, TimeUnit afterTimeUnit, int defaultGridSize) {
         this.deleteMode = deleteMode;
         this.emptyTrash = emptyTrash;
         this.afterTimeValue = afterTimeValue;
         this.afterTimeUnit = afterTimeUnit;
+        this.defaultGridSize = defaultGridSize;
     }
 
     public Long getId() {
@@ -82,6 +86,14 @@ public class ConfigSettings {
 
     public void setAfterTimeUnit(TimeUnit afterTimeUnit) {
         this.afterTimeUnit = afterTimeUnit;
+    }
+
+    public int getDefaultGridSize() {
+        return defaultGridSize;
+    }
+
+    public void setDefaultGridSize(int defaultGridSize) {
+        this.defaultGridSize = defaultGridSize;
     }
 
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
@@ -1,0 +1,146 @@
+package org.motechproject.mds.domain;
+
+import org.motechproject.mds.dto.UserPreferencesDto;
+
+import javax.jdo.annotations.Element;
+import javax.jdo.annotations.ForeignKeyAction;
+import javax.jdo.annotations.IdentityType;
+import javax.jdo.annotations.Join;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The <code>UserPreferences</code> class contains information about an entity user preferences. For example grid size
+ * on the UI.
+ */
+@PersistenceCapable(identityType = IdentityType.DATASTORE, detachable = "true")
+public class UserPreferences {
+
+    @PrimaryKey
+    @Persistent
+    private String username;
+
+    @PrimaryKey
+    @Persistent
+    private String className;
+
+    @Persistent
+    private Integer gridRowsNumber;
+
+    @Persistent(defaultFetchGroup = "true")
+    @Join
+    @Element(column = "selectedField",  deleteAction = ForeignKeyAction.CASCADE)
+    private List<Field> selectedFields;
+
+    @Persistent(defaultFetchGroup = "true")
+    @Join
+    @Element(column = "unselectedField",  deleteAction = ForeignKeyAction.CASCADE)
+    private List<Field> unselectedFields;
+
+    public UserPreferences() {
+    }
+
+    public UserPreferences(String username, String className, Integer gridRowsNumber, List<Field> selectedFields, List<Field> unselectedFields) {
+        this.username = username;
+        this.className = className;
+        this.gridRowsNumber = gridRowsNumber;
+        this.selectedFields = selectedFields;
+        this.unselectedFields = unselectedFields;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public Integer getGridRowsNumber() {
+        return gridRowsNumber;
+    }
+
+    public void setGridRowsNumber(Integer gridRowsNumber) {
+        this.gridRowsNumber = gridRowsNumber;
+    }
+
+    public List<Field> getSelectedFields() {
+        if (selectedFields == null) {
+            return new ArrayList<>();
+        }
+        return selectedFields;
+    }
+
+    public void setSelectedFields(List<Field> selectedFields) {
+        this.selectedFields = selectedFields;
+    }
+
+
+    public List<Field> getUnselectedFields() {
+        if (unselectedFields == null) {
+            return new ArrayList<>();
+        }
+        return unselectedFields;
+    }
+
+    public void setUnselectedFields(List<Field> unselectedFields) {
+        this.unselectedFields = unselectedFields;
+    }
+
+    public UserPreferencesDto toDto(List<String> displayableFields) {
+        List<String> mergedFields = new ArrayList<>(displayableFields);
+        List<String> selected = new ArrayList<>();
+        List<String> unselected = new ArrayList<>();
+
+        for (Field field : getUnselectedFields()) {
+            if (mergedFields.contains(field.getName())) {
+                mergedFields.remove(field.getName());
+            }
+            unselected.add(field.getName());
+        }
+
+        for (Field field : getSelectedFields()) {
+            if (!mergedFields.contains(field.getName())) {
+                mergedFields.add(field.getName());
+            }
+            selected.add(field.getName());
+        }
+
+        return new UserPreferencesDto(className, username, gridRowsNumber, mergedFields, selected, unselected);
+    }
+
+    public void selectField(Field field) {
+        if (selectedFields == null) {
+            selectedFields = new ArrayList<>();
+        }
+        selectedFields.add(field);
+
+        // if field is selected then we must remove it from unselected list
+        if (unselectedFields != null && unselectedFields.contains(field)) {
+            unselectedFields.remove(field);
+        }
+    }
+
+    public void unselectField(Field field) {
+        if (unselectedFields == null) {
+            unselectedFields = new ArrayList<>();
+        }
+        unselectedFields.add(field);
+
+        // if field is unselected then we must remove it from selected list
+        if (selectedFields != null && selectedFields.contains(field)) {
+            selectedFields.remove(field);
+        }
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/AdvancedSettingsDto.java
@@ -19,6 +19,7 @@ public class AdvancedSettingsDto {
     private List<LookupDto> indexes = new ArrayList<>();
     private RestOptionsDto restOptions = new RestOptionsDto();
     private BrowsingSettingsDto browsing = new BrowsingSettingsDto();
+    private UserPreferencesDto userPreferences;
 
     public Long getId() {
         return id;
@@ -76,6 +77,14 @@ public class AdvancedSettingsDto {
 
     public void setBrowsing(BrowsingSettingsDto browsing) {
         this.browsing = browsing;
+    }
+
+    public UserPreferencesDto getUserPreferences() {
+        return userPreferences;
+    }
+
+    public void setUserPreferences(UserPreferencesDto userPreferences) {
+        this.userPreferences = userPreferences;
     }
 
     @JsonIgnore

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
@@ -1,0 +1,97 @@
+package org.motechproject.mds.dto;
+
+import java.util.List;
+
+/**
+ * The <code>UserPreferencesDto</code> contains information about user preferences of an entity.
+ */
+public class UserPreferencesDto {
+
+    /**
+     * The entity class name.
+     */
+    private String className;
+
+    /**
+     * Username of the preferences owner.
+     */
+    private String username;
+
+    /**
+     * The size of the grid.
+     */
+    private Integer gridRowsNumber;
+
+    /**
+     * The list of the fields which will be displayed on the UI. It is constructed from selected fields, unselected fields
+     * and advance settings of the entity.
+     */
+    private List<String> visibleFields;
+
+    /**
+     * The list of the selected fields.
+     */
+    private List<String> selectedFields;
+
+    /**
+     * The list of the unselected fields.
+     */
+    private List<String> unselectedFields;
+
+    public UserPreferencesDto(String className, String username, Integer gridRowsNumber, List<String> visibleFields, List<String> selectedFields, List<String> unselectedFields) {
+        this.className = className;
+        this.username = username;
+        this.gridRowsNumber = gridRowsNumber;
+        this.visibleFields = visibleFields;
+        this.selectedFields = selectedFields;
+        this.unselectedFields = unselectedFields;
+    }
+
+    public Integer getGridRowsNumber() {
+        return gridRowsNumber;
+    }
+
+    public void setGridRowsNumber(Integer gridRowsNumber) {
+        this.gridRowsNumber = gridRowsNumber;
+    }
+
+    public List<String> getVisibleFields() {
+        return visibleFields;
+    }
+
+    public void setVisibleFields(List<String> visibleFields) {
+        this.visibleFields = visibleFields;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public List<String> getSelectedFields() {
+        return selectedFields;
+    }
+
+    public void setSelectedFields(List<String> selectedFields) {
+        this.selectedFields = selectedFields;
+    }
+
+    public List<String> getUnselectedFields() {
+        return unselectedFields;
+    }
+
+    public void setUnselectedFields(List<String> unselectedFields) {
+        this.unselectedFields = unselectedFields;
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllConfigSettings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllConfigSettings.java
@@ -25,6 +25,7 @@ public class AllConfigSettings extends MotechDataRepository<ConfigSettings> {
             rec.setAfterTimeUnit(record.getAfterTimeUnit());
             rec.setDeleteMode(record.getDeleteMode());
             rec.setEmptyTrash(record.getEmptyTrash());
+            rec.setDefaultGridSize(record.getDefaultGridSize());
             update(rec);
         }
     }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllUserPreferences.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllUserPreferences.java
@@ -1,0 +1,22 @@
+package org.motechproject.mds.repository;
+
+import org.motechproject.mds.domain.UserPreferences;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class AllUserPreferences extends MotechDataRepository<UserPreferences> {
+
+    protected AllUserPreferences() {
+        super(UserPreferences.class);
+    }
+
+    public UserPreferences retrieveByClassNameAndUsername(String entityClassName, String username) {
+        return retrieve(new String[] {"className", "username"}, new Object[] {entityClassName, username});
+    }
+
+    public List<UserPreferences> retrieveByClassName(String entityClassName) {
+        return retrieveAll("className", entityClassName);
+    }
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/UserPreferencesService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/UserPreferencesService.java
@@ -1,0 +1,84 @@
+package org.motechproject.mds.service;
+
+import org.motechproject.mds.dto.UserPreferencesDto;
+
+import java.util.List;
+
+
+/**
+ * The <code>UserPreferencesService</code> provides API for managing the entity user preferences (grid size, visible fields).
+ *
+ * @see org.motechproject.mds.domain.UserPreferences
+ */
+public interface UserPreferencesService {
+
+    /**
+     * Returns preferences for entity with the given id.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @return list of user preferences for the entity
+     */
+    List<UserPreferencesDto> getEntityPreferences(Long entityId);
+
+    /**
+     * Returns preferences for given user and entity. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @return user preferences for the entity and username
+     */
+    UserPreferencesDto getUserPreferences(Long entityId, String username);
+
+    /**
+     * Updates grid size preferences for given user and entity. If preferences don't exist then default ones will be created.
+
+     * @param entityId the id of the entity for the preferences
+     * @param username the owner of the preferences
+     * @param newSize the new size og the grid
+     */
+    void updateGridSize(Long entityId, String username, Integer newSize);
+
+    /**
+     * Adds field with the given name to the user visible fields. If preferences don't exist then default ones will be
+     * created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @param fieldName the name of the field to add
+     */
+    void selectField(Long entityId, String username, String fieldName);
+
+    /**
+     * Removes field with the given name from the user visible fields. If preferences don't exist then default ones will be
+     * created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     * @param fieldName the name of the field to remove
+     */
+    void unselectField(Long entityId, String username, String fieldName);
+
+    /**
+     * Adds all entity fields to the user visible fields. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     */
+    void selectFields(Long entityId, String username);
+
+    /**
+     * Removes all entity fields from the user visible fields. If preferences don't exist then default ones will be created.
+     *
+     * @param entityId the id of  the entity for the preferences
+     * @param username the owner of the preferences
+     */
+    void unselectFields(Long entityId, String username);
+
+    /**
+     * Removes user preferences for entity with the given id.
+     *
+     * @param entityId he id of entity
+     * @param username the owner of the preferences
+     */
+    void removeUserPreferences(Long entityId, String username);
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
@@ -1,0 +1,199 @@
+package org.motechproject.mds.service.impl;
+
+import org.motechproject.mds.config.SettingsService;
+import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.domain.Field;
+import org.motechproject.mds.domain.UserPreferences;
+import org.motechproject.mds.dto.UserPreferencesDto;
+import org.motechproject.mds.ex.entity.EntityNotFoundException;
+import org.motechproject.mds.ex.field.FieldNotFoundException;
+import org.motechproject.mds.repository.AllEntities;
+import org.motechproject.mds.repository.AllUserPreferences;
+import org.motechproject.mds.service.UserPreferencesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of the {@link org.motechproject.mds.service.UserPreferencesService}.
+ */
+@Service
+public class UserPreferencesServiceImpl implements UserPreferencesService {
+
+    private AllUserPreferences allUserPreferences;
+
+    private AllEntities allEntities;
+
+    private SettingsService settingsService;
+
+    @Override
+    public List<UserPreferencesDto> getEntityPreferences(Long id) {
+        Entity entity = getEntity(id);
+        List<UserPreferences> userPreferences =  allUserPreferences.retrieveByClassName(entity.getClassName());
+        List<UserPreferencesDto> dtos = new ArrayList<>();
+        List<String> displayableFields = getDisplayableFields(entity);
+
+        if (userPreferences != null) {
+            Integer defaultGridSize = settingsService.getGridSize();
+            for (UserPreferences preferences : userPreferences) {
+                UserPreferencesDto dto = preferences.toDto(displayableFields);
+                if (dto.getGridRowsNumber() == null) {
+                    dto.setGridRowsNumber(defaultGridSize);
+                }
+                dtos.add(dto);
+            }
+        }
+
+        return dtos;
+    }
+
+    @Override
+    @Transactional
+    public UserPreferencesDto getUserPreferences(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        if (userPreferences != null) {
+            UserPreferencesDto dto = userPreferences.toDto(getDisplayableFields(entity));
+            if (dto.getGridRowsNumber() == null) {
+                dto.setGridRowsNumber(settingsService.getGridSize());
+            }
+            return dto;
+        }
+
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public void updateGridSize(Long id, String username, Integer newSize) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        if (userPreferences.getGridRowsNumber() != newSize) {
+            userPreferences.setGridRowsNumber(newSize == null ? settingsService.getGridSize() : newSize);
+            allUserPreferences.update(userPreferences);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void selectField(Long id, String username, String fieldName) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        Field field = entity.getField(fieldName);
+        assertField(field, entity.getClassName(), fieldName);
+        userPreferences.selectField(field);
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void unselectField(Long id, String username, String fieldName) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        Field field = entity.getField(fieldName);
+        assertField(field, entity.getClassName(), fieldName);
+        userPreferences.unselectField(field);
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void selectFields(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(entity.getFields());
+        userPreferences.setSelectedFields(fields);
+        userPreferences.setUnselectedFields(new ArrayList<Field>());
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void unselectFields(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        userPreferences = checkPreferences(userPreferences, entity, username);
+
+        List<Field> fields = new ArrayList<>();
+        fields.addAll(entity.getFields());
+        userPreferences.setUnselectedFields(fields);
+        userPreferences.setSelectedFields(new ArrayList<Field>());
+
+        allUserPreferences.update(userPreferences);
+    }
+
+    @Override
+    @Transactional
+    public void removeUserPreferences(Long id, String username) {
+        Entity entity = getEntity(id);
+        UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
+        if (userPreferences != null) {
+            allUserPreferences.delete(userPreferences);
+        }
+    }
+
+    public void assertField(Field field, String className, String fieldName) {
+        if (field == null) {
+            throw new FieldNotFoundException(className, fieldName);
+        }
+    }
+
+    private Entity getEntity(Long id) {
+        Entity entity = allEntities.retrieveById(id);
+
+        if (entity == null) {
+            throw new EntityNotFoundException(id);
+        }
+        return entity;
+    }
+
+    private List<String> getDisplayableFields(Entity entity) {
+        List<String> displayFields = new ArrayList<>();
+        for (Field field : entity.getFields()) {
+            if (field.isUIDisplayable() && !field.isNonDisplayable()) {
+                displayFields.add(field.getName());
+            }
+        }
+
+        return displayFields;
+    }
+
+    private UserPreferences checkPreferences(UserPreferences userPreferences, Entity entity, String username) {
+        if (userPreferences == null) {
+            return allUserPreferences.create(new UserPreferences(username, entity.getClassName(), null, new ArrayList<Field>(), new ArrayList<Field>()));
+        }
+        return userPreferences;
+    }
+    @Autowired
+    public void setAllUserPreferences(AllUserPreferences allUserPreferences) {
+        this.allUserPreferences = allUserPreferences;
+    }
+
+    @Autowired
+    public void setSettingsService(SettingsService settingsService) {
+        this.settingsService = settingsService;
+    }
+
+    @Autowired
+    public void setAllEntities(AllEntities allEntities) {
+        this.allEntities = allEntities;
+    }
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
@@ -228,6 +228,11 @@ public final class Constants {
         public static final String MDS_TIME_UNIT = "mds.emptyTrash.afterTimeUnit";
 
         /**
+         * The property that specifies default number of records in each data browser grid.
+         */
+        public static final String MDS_DEFAULT_GRID_SIZE = "mds.default.gridSize";
+
+        /**
          * Constant <code>EMPTY_TRASH_JOB</code> presents a name of job scheduled by scheduler
          * module.
          */

--- a/platform/mds/mds/src/main/resources/META-INF/spring/blueprint.xml
+++ b/platform/mds/mds/src/main/resources/META-INF/spring/blueprint.xml
@@ -23,6 +23,8 @@
 
     <osgi:service ref="entityServiceImpl" interface="org.motechproject.mds.service.EntityService"/>
 
+    <osgi:service ref="userPreferencesServiceImpl" interface="org.motechproject.mds.service.UserPreferencesService"/>
+
     <osgi:service ref="actionHandlerServiceImpl" interface="org.motechproject.mds.service.ActionHandlerService"/>
 
     <osgi:service ref="jdoListenerRegistryService" interface="org.motechproject.mds.service.JdoListenerRegistryService" auto-export="interfaces" />

--- a/platform/mds/mds/src/main/resources/db/migration/default/V43__MOTECH-1800.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V43__MOTECH-1800.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS "UserPreferences" (
+  "username" varchar(255) NOT NULL,
+  "className" varchar(255) NOT NULL,
+  "gridRowsNumber" int,
+  PRIMARY KEY ("username", "className")
+);
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_selectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "selectedField" bigint,
+  "IDX" int,
+  PRIMARY KEY ("className_OID", "username_OID", "IDX"),
+  CONSTRAINT "UserPreferences_selectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_selectedFields_FK2" FOREIGN KEY ("selectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_unselectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "unselectedField" bigint,
+  "IDX" int,
+  PRIMARY KEY ("className_OID", "username_OID", "IDX"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK2" FOREIGN KEY ("unselectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "ConfigSettings" (
+  "id" bigint,
+  "afterTimeUnit" varchar(255) NOT NULL,
+  "afterTimeValue" int,
+  "deleteMode" varchar(255) NOT NULL,
+  "emptyTrash" bit(1),
+  PRIMARY KEY ("id")
+);
+
+ALTER TABLE "ConfigSettings" ADD "defaultGridSize" int DEFAULT 50;

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V43__MOTECH-1800.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V43__MOTECH-1800.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS UserPreferences (
+  className varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  gridRowsNumber int,
+  PRIMARY KEY (className, username)
+);
+
+CREATE TABLE IF NOT EXISTS UserPreferences_selectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  selectedField bigint(20),
+  IDX int(11),
+  PRIMARY KEY (className_OID, username_OID, IDX),
+  KEY UserPreferences_selectedFields_N49 (selectedField),
+  KEY UserPreferences_selectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_visibleFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_visibleFields_FK2 FOREIGN KEY (selectedField) REFERENCES Field (id) ON DELETE CASCADE
+);
+
+
+CREATE TABLE IF NOT EXISTS UserPreferences_unselectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  unselectedField bigint(20),
+  IDX int(11),
+  PRIMARY KEY (className_OID, username_OID, IDX),
+  KEY UserPreferences_unselectedFields_N49 (unselectedField),
+  KEY UserPreferences_unselectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_unselectedFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_unselectedFields_FK2 FOREIGN KEY (unselectedField) REFERENCES Field (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS ConfigSettings (
+  id bigint(20),
+  afterTimeUnit varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  afterTimeValue int(11),
+  deleteMode varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  emptyTrash bit(1),
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE ConfigSettings add defaultGridSize int DEFAULT 50;

--- a/platform/mds/mds/src/main/resources/motech-mds.properties
+++ b/platform/mds/mds/src/main/resources/motech-mds.properties
@@ -3,3 +3,5 @@ mds.deleteMode = trash
 mds.emptyTrash = false
 mds.emptyTrash.afterTimeValue = 1
 mds.emptyTrash.afterTimeUnit = Hours
+
+mds.default.gridSize = 50

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/config/ModuleSettingsTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/config/ModuleSettingsTest.java
@@ -1,12 +1,11 @@
 package org.motechproject.mds.config;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_DELETE_MODE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_EMPTY_TRASH;
+import static org.motechproject.mds.config.ModuleSettings.DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_UNIT;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_VALUE;
 
@@ -24,30 +23,18 @@ public class ModuleSettingsTest {
         settings.setEmptyTrash(true);
         settings.setTimeValue(10);
         settings.setTimeUnit(TimeUnit.WEEKS);
+        settings.setGridSize(100);
 
-        assertValues(DeleteMode.DELETE, true, 10, TimeUnit.WEEKS);
+        assertValues(DeleteMode.DELETE, true, 10, TimeUnit.WEEKS, 100);
     }
 
     @Test
     public void shouldSetDefaultValuesIfStringParameterIsIncorrect() throws Exception {
-        settings.setDeleteMode((String) null);
-        settings.setEmptyTrash((String) null);
-        settings.setTimeValue((String) null);
-        settings.setTimeUnit((String) null);
-
-        assertDefaultValues();
-
-        settings.setDeleteMode("  ");
-        settings.setEmptyTrash("   ");
-        settings.setTimeValue("   ");
-        settings.setTimeUnit("   ");
-
-        assertDefaultValues();
-
-        settings.setDeleteMode("del");
-        settings.setEmptyTrash("t");
-        settings.setTimeValue("alb");
-        settings.setTimeUnit("w");
+        settings.setDeleteMode(null);
+        settings.setEmptyTrash(null);
+        settings.setTimeValue(null);
+        settings.setTimeUnit(null);
+        settings.setGridSize(null);
 
         assertDefaultValues();
 
@@ -55,42 +42,18 @@ public class ModuleSettingsTest {
         assertEquals(DEFAULT_TIME_VALUE, settings.getTimeValue());
     }
 
-    @Test
-    public void shouldCreateAppropriateJSON() throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
-        JsonNode json = mapper.valueToTree(settings);
-        assertValues(
-                json.get("deleteMode").asText(), json.get("emptyTrash").asText(),
-                json.get("timeValue").asText(), json.get("timeUnit").asText()
-        );
-
-        ModuleSettings fromJSON = mapper.readValue(json, ModuleSettings.class);
-        assertValues(
-                fromJSON.getDeleteMode(), fromJSON.isEmptyTrash(),
-                fromJSON.getTimeValue(), fromJSON.getTimeUnit()
-        );
-    }
-
     private void assertDefaultValues() {
         assertValues(
-                DEFAULT_DELETE_MODE, DEFAULT_EMPTY_TRASH, DEFAULT_TIME_VALUE, DEFAULT_TIME_UNIT
-        );
-    }
-
-    private void assertValues(String deleteMode, String emptyTrash, String timeValue,
-                              String timeUnit) {
-        assertValues(
-                DeleteMode.fromString(deleteMode), Boolean.parseBoolean(emptyTrash),
-                Integer.parseInt(timeValue), TimeUnit.fromString(timeUnit)
+                DEFAULT_DELETE_MODE, DEFAULT_EMPTY_TRASH, DEFAULT_TIME_VALUE, DEFAULT_TIME_UNIT, DEFAULT_GRID_SIZE
         );
     }
 
     private void assertValues(DeleteMode deleteMode, boolean emptyTrash, Integer timeValue,
-                              TimeUnit timeUnit) {
+                              TimeUnit timeUnit, Integer gridSize) {
         assertEquals(deleteMode, settings.getDeleteMode());
         assertEquals(emptyTrash, settings.isEmptyTrash());
         assertEquals(timeValue, settings.getTimeValue());
         assertEquals(timeUnit, settings.getTimeUnit());
+        assertEquals(gridSize, settings.getGridSize());
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/config/impl/SettingsServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/config/impl/SettingsServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.motechproject.mds.config.ModuleSettings.DEFAULT_DELETE_MODE;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_EMPTY_TRASH;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_UNIT;
 import static org.motechproject.mds.config.ModuleSettings.DEFAULT_TIME_VALUE;
+import static org.motechproject.mds.config.ModuleSettings.DEFAULT_GRID_SIZE;
 import static org.motechproject.mds.util.Constants.Config.MODULE_FILE;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -54,6 +55,7 @@ public class SettingsServiceImplTest {
         assertEquals(DEFAULT_EMPTY_TRASH, settingsServiceImpl.isEmptyTrash());
         assertEquals(DEFAULT_TIME_VALUE, settingsServiceImpl.getTimeValue());
         assertEquals(DEFAULT_TIME_UNIT, settingsServiceImpl.getTimeUnit());
+        assertEquals(DEFAULT_GRID_SIZE, settingsServiceImpl.getGridSize());
 
         // settings should contains the same values
         ModuleSettings settings = settingsServiceImpl.getModuleSettings();
@@ -62,5 +64,6 @@ public class SettingsServiceImplTest {
         assertEquals(DEFAULT_EMPTY_TRASH, settings.isEmptyTrash());
         assertEquals(DEFAULT_TIME_VALUE, settings.getTimeValue());
         assertEquals(DEFAULT_TIME_UNIT, settings.getTimeUnit());
+        assertEquals(DEFAULT_GRID_SIZE, settings.getGridSize());
     }
 }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/BaseIT.java
@@ -8,6 +8,7 @@ import org.motechproject.mds.domain.EntityAudit;
 import org.motechproject.mds.domain.EntityDraft;
 import org.motechproject.mds.domain.Field;
 import org.motechproject.mds.domain.Lookup;
+import org.motechproject.mds.domain.UserPreferences;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.orm.jdo.JdoTransactionManager;
@@ -99,6 +100,10 @@ public abstract class BaseIT {
         return getAll(EntityDraft.class);
     }
 
+    protected List<UserPreferences> getUserPreferences() {
+        return getAll(UserPreferences.class);
+    }
+
     protected List<EntityDraft> getEntityDrafts() {
         return getAll(EntityDraft.class);
     }
@@ -118,6 +123,7 @@ public abstract class BaseIT {
         getPersistenceManager().deletePersistentAll(getEntities());
         getPersistenceManager().deletePersistentAll(getEntitiesAudits());
         getPersistenceManager().deletePersistentAll(getEntitiesDrafts());
+        getPersistenceManager().deletePersistentAll(getUserPreferences());
     }
 
     protected <T> List<T> cast(Class<T> clazz, Collection collection) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
@@ -22,6 +22,7 @@ import org.motechproject.mds.dto.MetadataDto;
 import org.motechproject.mds.dto.RestOptionsDto;
 import org.motechproject.mds.dto.SchemaHolder;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.entity.EntityNotFoundException;
 import org.motechproject.mds.it.BaseIT;
@@ -32,6 +33,7 @@ import org.motechproject.mds.repository.MetadataHolder;
 import org.motechproject.mds.service.EntityService;
 import org.motechproject.mds.service.JarGeneratorService;
 import org.motechproject.mds.service.TypeService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.testutil.DraftBuilder;
 import org.motechproject.mds.testutil.FieldTestHelper;
 import org.motechproject.mds.util.Constants;
@@ -74,10 +76,10 @@ import static org.motechproject.mds.dto.LookupFieldType.RANGE;
 import static org.motechproject.mds.dto.LookupFieldType.SET;
 import static org.motechproject.mds.dto.LookupFieldType.VALUE;
 import static org.motechproject.mds.testutil.LookupTestHelper.lookupFieldsFromNames;
+import static org.motechproject.mds.util.Constants.MetadataKeys.OWNING_SIDE;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_CLASS;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATED_FIELD;
 import static org.motechproject.mds.util.Constants.MetadataKeys.RELATIONSHIP_COLLECTION_TYPE;
-import static org.motechproject.mds.util.Constants.MetadataKeys.OWNING_SIDE;
 
 public class EntityServiceContextIT extends BaseIT {
     private static final String SIMPLE_NAME = "Test";
@@ -104,6 +106,9 @@ public class EntityServiceContextIT extends BaseIT {
 
     @Autowired
     private AllEntityDrafts allEntityDrafts;
+
+    @Autowired
+    private UserPreferencesService userPreferencesService;
 
     @Before
     public void setUp() throws Exception {
@@ -580,6 +585,45 @@ public class EntityServiceContextIT extends BaseIT {
         entityService.updateMaxFetchDepth(entityDto.getId(), 3);
         entityDto = entityService.getEntity(entityDto.getId());
         assertEquals(Integer.valueOf(3), entityDto.getMaxFetchDepth());
+    }
+
+    @Test
+    public void shouldUpdateUserPreferencesAfterCommit() {
+        EntityDto entityDto = new EntityDto();
+        entityDto.setName("UserPrefTest");
+        entityDto = entityService.createEntity(entityDto);
+
+        final Long entityId = entityDto.getId();
+
+        entityService.saveDraftEntityChanges(entityId,
+                DraftBuilder.forNewField("disp", "f1name", Long.class.getName()));
+        List<FieldDto> fields = entityService.getFields(entityId);
+        assertNotNull(fields);
+        assertEquals(asList("id", "creator", "owner", "modifiedBy", "creationDate", "modificationDate", "f1name"),
+                extract(fields, on(FieldDto.class).getBasic().getName()));
+        entityService.commitChanges(entityId);
+
+        List<Field> draftFields = entityService.getEntityDraft(entityId).getFields();
+        Field field = selectFirst(draftFields, having(on(Field.class).getName(), equalTo("f1name")));
+        entityService.saveDraftEntityChanges(entityDto.getId(),
+                DraftBuilder.forFieldEdit(field.getId(), "basic.name", "newName"));
+
+        userPreferencesService.selectFields(entityId, "motech");
+        userPreferencesService.unselectField(entityId, "motech", "id");
+        userPreferencesService.unselectField(entityId, "motech", "owner");
+
+        UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
+        assertEquals(asList( "f1name", "creator", "modifiedBy", "creationDate", "modificationDate"),
+                userPreferencesDto.getVisibleFields());
+
+        entityService.commitChanges(entityId);
+
+        userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
+        assertEquals(asList("newName", "creator", "modifiedBy", "creationDate", "modificationDate"),
+                userPreferencesDto.getVisibleFields());
+
+        assertEquals(asList("id", "owner"),
+                userPreferencesDto.getUnselectedFields());
     }
 
     private void assertRelatedField(EntityDto relatedEntity, FieldDto relatedField, String collection) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/EntityServiceImplTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/EntityServiceImplTest.java
@@ -20,6 +20,7 @@ import org.motechproject.mds.dto.FieldBasicDto;
 import org.motechproject.mds.dto.FieldDto;
 import org.motechproject.mds.dto.LookupDto;
 import org.motechproject.mds.dto.TypeDto;
+import org.motechproject.mds.dto.UserPreferencesDto;
 import org.motechproject.mds.enhancer.MdsJDOEnhancer;
 import org.motechproject.mds.ex.entity.EntityAlreadyExistException;
 import org.motechproject.mds.ex.field.FieldUsedInLookupException;
@@ -30,6 +31,7 @@ import org.motechproject.mds.repository.AllEntityAudits;
 import org.motechproject.mds.repository.AllEntityDrafts;
 import org.motechproject.mds.repository.AllTypes;
 import org.motechproject.mds.service.MotechDataService;
+import org.motechproject.mds.service.UserPreferencesService;
 import org.motechproject.mds.testutil.DraftBuilder;
 import org.motechproject.mds.validation.EntityValidator;
 import org.osgi.framework.BundleContext;
@@ -103,6 +105,8 @@ public class EntityServiceImplTest {
     @Mock
     private Lookup draftLookup;
 
+    @Mock
+    private UserPreferencesService userPreferencesService;
 
     @Mock
     private BundleContext bundleContext;
@@ -534,6 +538,8 @@ public class EntityServiceImplTest {
 
         when(allEntities.retrieveById(8L)).thenReturn(entity);
         when(allEntityDrafts.retrieve(eq(entity), anyString())).thenReturn(draft);
+
+        when(userPreferencesService.getEntityPreferences(8l)).thenReturn(new ArrayList<UserPreferencesDto>());
 
         entityService.commitChanges(8L);
     }

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
@@ -1,0 +1,267 @@
+package org.motechproject.mds.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.mds.config.SettingsService;
+import org.motechproject.mds.domain.Entity;
+import org.motechproject.mds.domain.Field;
+import org.motechproject.mds.domain.Lookup;
+import org.motechproject.mds.domain.UserPreferences;
+import org.motechproject.mds.dto.UserPreferencesDto;
+import org.motechproject.mds.ex.field.FieldNotFoundException;
+import org.motechproject.mds.repository.AllEntities;
+import org.motechproject.mds.repository.AllUserPreferences;
+import org.motechproject.mds.service.UserPreferencesService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserPreferencesServiceTest {
+
+    private static final String USERNAME = "username";
+    private static final String CLASS_NAME = "org.motechproject.sample.ClassName";
+
+    @Mock
+    private AllUserPreferences allUserPreferences;
+
+    @Mock
+    private AllEntities allEntities;
+
+    @Mock
+    private SettingsService settingsService;
+
+    @Mock
+    private UserPreferences userPreferences;
+
+    @Mock
+    Entity entity;
+
+    @Captor
+    ArgumentCaptor<UserPreferences> userPreferencesCaptor;
+
+    @Captor
+    ArgumentCaptor<List<Field>> selectedFieldsCaptor;
+
+    @Captor
+    ArgumentCaptor<List<Field>> unselectedFieldsCaptor;
+
+    @Captor
+    ArgumentCaptor<Field> fieldCaptor;
+
+    @InjectMocks
+    private UserPreferencesService userPreferencesService = new UserPreferencesServiceImpl();
+
+    @Before
+    public void setUp() {
+        when(settingsService.getGridSize()).thenReturn(20);
+        when(entity.getFields()).thenReturn(createFields());
+        when(entity.getClassName()).thenReturn(CLASS_NAME);
+        when(allEntities.retrieveById(15l)).thenReturn(entity);
+    }
+
+    @Test
+    public void shouldCreateDefaultPreferences() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(null);
+
+        userPreferencesService.getUserPreferences(15l, USERNAME);
+
+        verify(allUserPreferences).create(userPreferencesCaptor.capture());
+        UserPreferences capturedPreferences = userPreferencesCaptor.getValue();
+
+        assertEquals(USERNAME, capturedPreferences.getUsername());
+        assertEquals(CLASS_NAME, capturedPreferences.getClassName());
+        assertNotNull(capturedPreferences.getSelectedFields().size());
+        assertEquals(0, capturedPreferences.getSelectedFields().size());
+        assertEquals(0, capturedPreferences.getUnselectedFields().size());
+    }
+
+    @Test
+    public void shouldMergeFieldsInformation() {
+        List<Field> selectedFields = new ArrayList<>();
+        selectedFields.add(getField3());
+        List<Field> unselectedFields = new ArrayList<>();
+        unselectedFields.add(getField2());
+
+        UserPreferences preferences = new UserPreferences(USERNAME, CLASS_NAME, 20, selectedFields, unselectedFields);
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(preferences);
+
+        UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(15l, USERNAME);
+
+        assertNotNull(userPreferencesDto);
+        assertEquals(1, userPreferencesDto.getSelectedFields().size());
+        assertEquals(1, userPreferencesDto.getUnselectedFields().size());
+        assertEquals(2, userPreferencesDto.getVisibleFields().size());
+
+        assertEquals("sampleField3", userPreferencesDto.getSelectedFields().get(0));
+        assertEquals("sampleField2", userPreferencesDto.getUnselectedFields().get(0));
+        assertEquals("sampleField1", userPreferencesDto.getVisibleFields().get(0));
+        assertEquals("sampleField3", userPreferencesDto.getVisibleFields().get(1));
+
+    }
+
+    @Test
+    public void shouldUpdateGridSize() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.updateGridSize(15l, USERNAME, 50);
+
+        verify(userPreferences).setGridRowsNumber(50);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+
+    @Test
+    public void shouldTakeGridSizeFromSettingsService() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.updateGridSize(15l, USERNAME, null);
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+
+    @Test(expected = FieldNotFoundException.class)
+    public void shouldCheckFieldSelectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.selectField(15l, USERNAME, "oldField");
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+    @Test
+    public void shouldSelectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+
+        userPreferencesService.selectField(15l, USERNAME, "sampleField1");
+
+        verify(userPreferences).selectField(fieldCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        Field field = fieldCaptor.getValue();
+        assertNotNull(field);
+        assertEquals("sampleField1", field.getName());
+    }
+
+    @Test(expected = FieldNotFoundException.class)
+    public void shouldCheckFieldWhenUnselectField() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+
+        userPreferencesService.unselectField(15l, USERNAME, "oldField");
+
+        verify(userPreferences).setGridRowsNumber(20);
+        verify(allUserPreferences).update(userPreferences);
+    }
+
+    @Test
+    public void shouldUnselectField() {
+        Field field1 = getField1();
+
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(field1);
+
+        userPreferencesService.unselectField(15l, USERNAME, "sampleField1");
+
+        verify(userPreferences).unselectField(fieldCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        Field field = fieldCaptor.getValue();
+        assertNotNull(field);
+        assertEquals("sampleField1", field.getName());
+    }
+
+    @Test
+    public void shouldSelectFields() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+        when(userPreferences.getSelectedFields()).thenReturn(new ArrayList<Field>());
+
+        userPreferencesService.selectFields(15l, USERNAME);
+
+        verify(userPreferences).setSelectedFields(selectedFieldsCaptor.capture());
+        verify(userPreferences).setUnselectedFields(unselectedFieldsCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        List<Field> fields = selectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(4, fields.size());
+        assertEquals("sampleField1", fields.get(0).getName());
+        assertEquals("sampleField2", fields.get(1).getName());
+        assertEquals("sampleField3", fields.get(2).getName());
+        assertEquals("sampleField4", fields.get(3).getName());
+
+        fields = unselectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(0, fields.size());
+    }
+
+    @Test
+    public void shouldUnselectFields() {
+        when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
+        when(entity.getField("sampleField1")).thenReturn(getField1());
+        when(userPreferences.getSelectedFields()).thenReturn(createFields());
+
+        userPreferencesService.unselectFields(15l, USERNAME);
+
+        verify(userPreferences).setUnselectedFields(unselectedFieldsCaptor.capture());
+        verify(userPreferences).setSelectedFields(selectedFieldsCaptor.capture());
+        verify(allUserPreferences).update(userPreferences);
+
+        List<Field> fields = unselectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(4, fields.size());
+        assertEquals("sampleField1", fields.get(0).getName());
+        assertEquals("sampleField2", fields.get(1).getName());
+        assertEquals("sampleField3", fields.get(2).getName());
+        assertEquals("sampleField4", fields.get(3).getName());
+
+        fields = selectedFieldsCaptor.getValue();
+        assertNotNull(fields);
+        assertEquals(0, fields.size());
+    }
+
+    private List<Field> createFields() {
+        List<Field> fields = new ArrayList<>();
+        fields.add(getField1());
+        fields.add(getField2());
+        fields.add(getField3());
+        fields.add(getField4());
+        return fields;
+    }
+
+    private Field getField1() {
+        Field field =  new Field(null, "sampleField1", "Display Name 1", true, false, false, false, false, false, "default 1", "tooltip 1", "placeholder 1", new HashSet<Lookup>());
+        field.setUIDisplayable(true);
+        return field;
+    }
+
+    private Field getField2() {
+        Field field = new Field(null, "sampleField2", "Display Name 2", true, false, false, false, false, false, "default 2", "tooltip 2", "placeholder 2", new HashSet<Lookup>());
+        field.setUIDisplayable(true);
+        return field;
+    }
+
+    private Field getField3() {
+        return new Field(null, "sampleField3", "Display Name 3", true, false, false, false, false, false, "default 3", "tooltip 3", "placeholder 3", new HashSet<Lookup>());
+    }
+
+    private Field getField4() {
+        return new Field(null, "sampleField4", "Display Name 4", true, false, false, true, false, false, "default 4", "tooltip 4", "placeholder 4", new HashSet<Lookup>());
+    }
+}

--- a/platform/server-bundle/src/main/resources/webapp/js/common.js
+++ b/platform/server-bundle/src/main/resources/webapp/js/common.js
@@ -148,7 +148,7 @@ var jFormErrorHandler = function(response) {
             autowidth: true,
             rownumbers: false,
             rowNum: 10,
-            rowList: [10, 20, 50],
+            rowList: [10, 20, 50, 100],
             width: '100%',
             height: 'auto',
             sortorder: 'asc',


### PR DESCRIPTION
- Added global settings for grid size
- Added possibility to store data about visible fields in the database
- User can have other preferences for each entity
- Cherry-pick: Refactor of the EntityControllerTest
- ModuleSettings refactor