### PR TITLE
MOTECH-1995: Queues and Topic tabs work with all versions of ActiveMQ

### DIFF
--- a/modules/admin/src/main/java/org/motechproject/admin/jmx/MBeanService.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/jmx/MBeanService.java
@@ -32,7 +32,6 @@ public class MBeanService {
     public static final String JMS_MESSAGE_ID = "JMSMessageID";
     public static final String JMS_REDELIVERED = "JMSRedelivered";
     public static final String JMS_TIMESTAMP = "JMSTimestamp";
-    public static final String DESTINATION = "Destination";
 
     @Autowired
     private MotechMBeanServer mBeanServer;
@@ -47,7 +46,7 @@ public class MBeanService {
         try {
             List<TopicMBean> topics = new ArrayList<>();
             for (ObjectName name : mBeanServer.getTopics()) {
-                String destination = name.getKeyProperty(DESTINATION);
+                String destination = name.getKeyProperty(mBeanServer.getDestinationProperty());
                 TopicViewMBean topicView = mBeanServer.getTopicViewMBean(name);
                 TopicMBean topic = new TopicMBean(destination);
                 topic.setEnqueueCount(topicView.getEnqueueCount());
@@ -72,7 +71,7 @@ public class MBeanService {
         try {
             List<QueueMBean> queues = new ArrayList<>();
             for (ObjectName name : mBeanServer.getQueues()) {
-                String destination = name.getKeyProperty(DESTINATION);
+                String destination = name.getKeyProperty(mBeanServer.getDestinationProperty());
                 QueueViewMBean queueView = mBeanServer.getQueueViewMBean(name);
                 QueueMBean queue = new QueueMBean(destination);
                 queue.setEnqueueCount(queueView.getEnqueueCount());

--- a/modules/admin/src/test/java/org/motechproject/admin/jmx/MBeanServiceTest.java
+++ b/modules/admin/src/test/java/org/motechproject/admin/jmx/MBeanServiceTest.java
@@ -41,7 +41,7 @@ public class MBeanServiceTest {
         given(mBeanServer.getQueueViewMBean(any(ObjectName.class))).willReturn(queueViewMBean);
 
         given(mBeanServer.getQueues()).willReturn(queues);
-        given(fooQueue.getKeyProperty(MotechMBeanServer.DESTINATION)).willReturn("foo_queue");
+        given(fooQueue.getKeyProperty(mBeanServer.getDestinationProperty())).willReturn("foo_queue");
 
         List<QueueMBean> queueStatistics = mBeanService.getQueueStatistics();
         assertThat(queueStatistics.size(), Is.is(1));


### PR DESCRIPTION
Reafctored way in which JMX mBeanName and destination properties are builded, so they will have correct values for newer versions of ActiveMQ, as for 5.8+ naming changed and caused errors in Queues and Topic tabs.