### PR TITLE
MOTECH-1992 Task Action> Long Labels Getting Cut Off

### DIFF
--- a/platform/server-bundle/src/main/resources/webapp/css/index.css
+++ b/platform/server-bundle/src/main/resources/webapp/css/index.css
@@ -51,6 +51,7 @@ h1, h2, h3, h4, h5, h6 {
 
 label {
     font-weight: normal;
+    word-wrap: normal;
 }
 
 a {


### PR DESCRIPTION
Word labels were getting cut off in long label entries. I changed a line of CSS which is a quick fix to a larger problem of unsemantic data getting into the MOTECH UI.