### PR TITLE
MOTECH-2017: CommonsDataProvider for Tasks module

### DIFF
--- a/platform/server-bundle/src/main/java/org/motechproject/server/CommonsDataProvider.java
+++ b/platform/server-bundle/src/main/java/org/motechproject/server/CommonsDataProvider.java
@@ -1,0 +1,58 @@
+package org.motechproject.server;
+
+import org.motechproject.commons.api.AbstractDataProvider;
+import org.motechproject.server.commons.PlatformCommons;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The <code>CommonsDataProvider</code> responsible for providing commons values as current date
+ * or MOTECH version as a data source in Tasks module.
+ */
+public class CommonsDataProvider extends AbstractDataProvider {
+
+    private PlatformCommons platformCommons;
+
+    @Autowired
+    public CommonsDataProvider(ResourceLoader resourceLoader) {
+        Resource resource = resourceLoader.getResource("commons-data-provider.json");
+        if(resource != null) {
+            setBody(resource);
+        }
+    }
+
+    @Autowired
+    public void setPlatformCommons(PlatformCommons platformCommons) {
+        this.platformCommons = platformCommons;
+    }
+
+    @Override
+    public List<Class<?>> getSupportClasses() {
+        List<Class<?>> list = new ArrayList<>();
+        list.add(PlatformCommons.class);
+        return list;
+    }
+
+    @Override
+    public String getPackageRoot() {
+        return "org.motechproject.server.commons";
+    }
+
+    @Override
+    public String getName() {
+        return "MOTECH Commons";
+    }
+
+    @Override
+    public Object lookup(String type, String lookupName, Map<String, String> lookupFields) {
+        if(supports(type)) {
+            return platformCommons;
+        }
+        return null;
+    }
+}

--- a/platform/server-bundle/src/main/java/org/motechproject/server/commons/PlatformCommons.java
+++ b/platform/server-bundle/src/main/java/org/motechproject/server/commons/PlatformCommons.java
@@ -1,0 +1,44 @@
+package org.motechproject.server.commons;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.motechproject.commons.date.util.DateUtil;
+import org.springframework.stereotype.Component;
+
+import java.util.ResourceBundle;
+
+/**
+ * Class used with {@link org.motechproject.server.CommonsDataProvider} to provide common
+ * values as a data source in Tasks module.
+ */
+@Component
+public class PlatformCommons {
+
+    public PlatformCommons() {
+
+    }
+
+    /**
+     * Gets current MOTECH version
+     * @return version of MOTECH
+     */
+    public String getMotechVersion() {
+        return ResourceBundle.getBundle("webapp/messages.messages").getString("server.version");
+    }
+
+    /**
+     * Gets current date as timestamp
+     * @return current date
+     */
+    public DateTime getNow() {
+        return DateUtil.now();
+    }
+
+    /**
+     * Gets date of today
+     * @return date of today
+     */
+    public LocalDate getToday() {
+        return DateUtil.today();
+    }
+}

--- a/platform/server-bundle/src/main/resources/META-INF/motech/applicationPlatformServerBundle.xml
+++ b/platform/server-bundle/src/main/resources/META-INF/motech/applicationPlatformServerBundle.xml
@@ -18,6 +18,7 @@
     <context:component-scan base-package="org.motechproject.server.startup"/>
     <context:component-scan base-package="org.motechproject.server.ui"/>
     <context:component-scan base-package="org.motechproject.server.web"/>
+    <context:component-scan base-package="org.motechproject.server.commons"/>
 
     <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <property name="viewClass" value="org.motechproject.osgi.web.BundledJspView"/>

--- a/platform/server-bundle/src/main/resources/META-INF/spring/blueprint.xml
+++ b/platform/server-bundle/src/main/resources/META-INF/spring/blueprint.xml
@@ -20,11 +20,16 @@
         </constructor-arg>
     </bean>
 
+    <bean id="commonsDataProvider" class="org.motechproject.server.CommonsDataProvider"/>
+
     <osgi:service id="uiFrameworkServiceOsgi" auto-export="interfaces" ref="uiFrameworkService"
                   interface="org.motechproject.osgi.web.UIFrameworkService"/>
 
     <osgi:service id="localeServiceOsgi" auto-export="interfaces" ref="localeService"
                   interface="org.motechproject.osgi.web.LocaleService"/>
+
+    <osgi:service id="commonsDataProviderOsgi" auto-export="interfaces" ref="commonsDataProvider"
+                  interface="org.motechproject.commons.api.DataProvider"/>
 
     <osgi:reference id="userService" interface="org.motechproject.security.service.MotechUserService"/>
 

--- a/platform/server-bundle/src/main/resources/commons-data-provider.json
+++ b/platform/server-bundle/src/main/resources/commons-data-provider.json
@@ -17,11 +17,13 @@
                 },
                 {
                     "displayName": "server.provider.datetimenow",
-                    "fieldKey": "now"
+                    "fieldKey": "now",
+                    "type": "DATE"
                 },
                 {
                     "displayName": "server.provider.today",
-                    "fieldKey": "today"
+                    "fieldKey": "today",
+                    "type": "DATE"
                 }
             ]
         }

--- a/platform/server-bundle/src/main/resources/commons-data-provider.json
+++ b/platform/server-bundle/src/main/resources/commons-data-provider.json
@@ -1,0 +1,29 @@
+{
+    "name":"MOTECH Commons",
+    "objects": [
+        {
+            "displayName":"server.provider.displayName",
+            "type":"PlatformCommons",
+            "lookupFields": [
+                {
+                    "displayName": "server.provider.lookupDisplayName",
+                    "fields": []
+                }
+            ],
+            "fields":[
+                {
+                    "displayName": "server.provider.motechVersion",
+                    "fieldKey": "motechVersion"
+                },
+                {
+                    "displayName": "server.provider.datetimenow",
+                    "fieldKey": "now"
+                },
+                {
+                    "displayName": "server.provider.today",
+                    "fieldKey": "today"
+                }
+            ]
+        }
+    ]
+}

--- a/platform/server-bundle/src/main/resources/webapp/messages/messages.properties
+++ b/platform/server-bundle/src/main/resources/webapp/messages/messages.properties
@@ -140,3 +140,9 @@ server.jqlayout.slide=Slide Open
 
 server.dataServices=Data Services
 server.apiDocumentation=API Documentation
+
+server.provider.displayName=Platform commons
+server.provider.lookupDisplayName=Platform commons
+server.provider.motechVersion=MOTECH version
+server.provider.datetimenow=DateTime now
+server.provider.today=Today

--- a/platform/server-bundle/src/test/java/org/motechproject/server/CommonsDataProviderTest.java
+++ b/platform/server-bundle/src/test/java/org/motechproject/server/CommonsDataProviderTest.java
@@ -1,0 +1,66 @@
+package org.motechproject.server;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.motechproject.server.commons.PlatformCommons;
+import org.springframework.core.io.ResourceLoader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class CommonsDataProviderTest {
+
+    private static final String MOCK_MOTECH_VERSION = "1.0";
+    private static final DateTime MOCK_NOW = DateTime.now();
+    private static final LocalDate MOCK_TODAY = LocalDate.now();
+
+    private static Map<String, String> lookupFields;
+
+    @Mock
+    private ResourceLoader resourceLoader;
+
+    @Mock
+    private PlatformCommons platformCommons;
+
+    private CommonsDataProvider provider;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        lookupFields = new HashMap<>();
+        provider = new CommonsDataProvider(resourceLoader);
+        provider.setPlatformCommons(platformCommons);
+    }
+
+    @Test
+    public void shouldReturnNullIfClassIsNotSupported() {
+        String clazz = Integer.class.getSimpleName();
+        Object object = provider.lookup(clazz, "Platform commons", lookupFields);
+        assertNull(object);
+    }
+
+    @Test
+    public void shouldReturnCommons() {
+
+        when(platformCommons.getMotechVersion()).thenReturn(MOCK_MOTECH_VERSION);
+        when(platformCommons.getNow()).thenReturn(MOCK_NOW);
+        when(platformCommons.getToday()).thenReturn(MOCK_TODAY);
+
+        PlatformCommons commons =
+                (PlatformCommons) provider.lookup(PlatformCommons.class.getSimpleName(), "Platform commons", lookupFields);
+
+        assertNotNull(commons);
+        assertEquals(commons.getMotechVersion(), MOCK_MOTECH_VERSION);
+        assertEquals(commons.getNow(), MOCK_NOW);
+        assertEquals(commons.getToday(), MOCK_TODAY);
+    }
+}


### PR DESCRIPTION
Added CommonsDataProvider to server-bundle. It provides commonly used values such as dates and MOTECH version as a data source for Tasks module.