### PR TITLE
MOTECH-2026: Added a 5m wait for app ctx in listeners

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/HistoryListener.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/HistoryListener.java
@@ -1,8 +1,6 @@
 package org.motechproject.mds.listener.records;
 
 import org.motechproject.mds.service.HistoryService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.jdo.listener.InstanceLifecycleEvent;
 import javax.jdo.listener.StoreLifecycleListener;
@@ -15,8 +13,6 @@ import javax.jdo.listener.StoreLifecycleListener;
  */
 public class HistoryListener extends BaseListener implements StoreLifecycleListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HistoryListener.class);
-
     private HistoryService historyService;
 
     @Override
@@ -27,15 +23,15 @@ public class HistoryListener extends BaseListener implements StoreLifecycleListe
     @Override
     public void preStore(InstanceLifecycleEvent event) {
         Object instance = event.getSource();
-        LOGGER.trace("Pre-store event received for {}", instance);
+        getLogger().trace("Pre-store event received for {}", instance);
     }
 
     @Override
     public void postStore(InstanceLifecycleEvent event) {
         Object instance = event.getSource();
-        LOGGER.trace("Post-store event received for {}", instance);
+        getLogger().trace("Post-store event received for {}", instance);
 
-        LOGGER.debug("Recording history for {}", instance);
+        getLogger().debug("Recording history for {}", instance);
         historyService.record(instance);
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/HistoryListener.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/HistoryListener.java
@@ -11,14 +11,7 @@ import javax.jdo.listener.StoreLifecycleListener;
  * using the {@link org.motechproject.mds.service.HistoryService}. Listener
  * operations are executed in one transaction with the actual store.
  */
-public class HistoryListener extends BaseListener implements StoreLifecycleListener {
-
-    private HistoryService historyService;
-
-    @Override
-    protected void afterContextRegistered() {
-        historyService = getApplicationContext().getBean(HistoryService.class);
-    }
+public class HistoryListener extends BaseListener<HistoryService> implements StoreLifecycleListener {
 
     @Override
     public void preStore(InstanceLifecycleEvent event) {
@@ -32,6 +25,11 @@ public class HistoryListener extends BaseListener implements StoreLifecycleListe
         getLogger().trace("Post-store event received for {}", instance);
 
         getLogger().debug("Recording history for {}", instance);
-        historyService.record(instance);
+        getService().record(instance);
+    }
+
+    @Override
+    protected Class<HistoryService> getServiceClass() {
+        return HistoryService.class;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/TrashListener.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/TrashListener.java
@@ -16,14 +16,7 @@ import javax.jdo.listener.InstanceLifecycleEvent;
  * the object history. Listener operations are executed in one transaction with
  * the actual delete.
  */
-public class TrashListener extends BaseListener implements DeleteLifecycleListener {
-
-    private TrashService trashService;
-
-    @Override
-    protected void afterContextRegistered() {
-        trashService = getApplicationContext().getBean(TrashService.class);
-    }
+public class TrashListener extends BaseListener<TrashService> implements DeleteLifecycleListener {
 
     @Override
     public void preDelete(InstanceLifecycleEvent event) {
@@ -37,9 +30,9 @@ public class TrashListener extends BaseListener implements DeleteLifecycleListen
         MotechDataService dataService = ServiceUtil.getServiceFromAppContext(getApplicationContext(), className);
         Long schemaVersion = dataService.getSchemaVersion();
 
-        if (trashService.isTrashMode()) {
+        if (getService().isTrashMode()) {
             getLogger().debug("Moving to trash {}, schema version {}", new Object[]{instance, schemaVersion});
-            trashService.moveToTrash(instance, schemaVersion);
+            getService().moveToTrash(instance, schemaVersion);
         }
     }
 
@@ -47,5 +40,10 @@ public class TrashListener extends BaseListener implements DeleteLifecycleListen
     public void postDelete(InstanceLifecycleEvent event) {
         Object instance = event.getSource();
         getLogger().trace("Received post-delete for: {}", instance);
+    }
+
+    @Override
+    protected Class<TrashService> getServiceClass() {
+        return TrashService.class;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/TrashListener.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/listener/records/TrashListener.java
@@ -3,8 +3,6 @@ package org.motechproject.mds.listener.records;
 import org.motechproject.mds.service.MotechDataService;
 import org.motechproject.mds.service.ServiceUtil;
 import org.motechproject.mds.service.TrashService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.jdo.listener.DeleteLifecycleListener;
 import javax.jdo.listener.InstanceLifecycleEvent;
@@ -20,8 +18,6 @@ import javax.jdo.listener.InstanceLifecycleEvent;
  */
 public class TrashListener extends BaseListener implements DeleteLifecycleListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TrashListener.class);
-
     private TrashService trashService;
 
     @Override
@@ -34,7 +30,7 @@ public class TrashListener extends BaseListener implements DeleteLifecycleListen
         Object instance = event.getSource();
         String className = instance.getClass().getName();
 
-        LOGGER.trace("Received pre-delete for: {}", instance);
+        getLogger().trace("Received pre-delete for: {}", instance);
 
         // omit events for trash and history instances
         // get the schema version from the data service
@@ -42,7 +38,7 @@ public class TrashListener extends BaseListener implements DeleteLifecycleListen
         Long schemaVersion = dataService.getSchemaVersion();
 
         if (trashService.isTrashMode()) {
-            LOGGER.debug("Moving to trash {}, schema version {}", new Object[]{instance, schemaVersion});
+            getLogger().debug("Moving to trash {}, schema version {}", new Object[]{instance, schemaVersion});
             trashService.moveToTrash(instance, schemaVersion);
         }
     }
@@ -50,6 +46,6 @@ public class TrashListener extends BaseListener implements DeleteLifecycleListen
     @Override
     public void postDelete(InstanceLifecycleEvent event) {
         Object instance = event.getSource();
-        LOGGER.trace("Received post-delete for: {}", instance);
+        getLogger().trace("Received post-delete for: {}", instance);
     }
 }


### PR DESCRIPTION
Trash / history listeners will now wait for 5 minutes
for the application context if it is not available
once they are called. This should resolve the issue
with a null pointer exception thrown, due to listeners
executing too early in rare cases.