### PR TITLE
MOTECH-2061: Changed the Flyway placeholder prefix

### DIFF
--- a/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
+++ b/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
@@ -39,6 +39,7 @@
         <property name="locations">
             <bean factory-bean="mdsConfig" factory-method="getFlywayLocations" />
         </property>
+        <property name="placeholderPrefix" value="$flyway{"/>
         <property name="initOnMigrate" value="true"/>
     </bean>
 


### PR DESCRIPTION
Changed from the default ${ to $flyway{ . Resolves issues with Velocity
strings in migrations getting parsed.