### PR TITLE
MOTECH-2061: Changed the Flyway placeholder prefix

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/SchemaGenerator.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/SchemaGenerator.java
@@ -42,6 +42,8 @@ public class SchemaGenerator implements InitializingBean {
 
     public  static final String CONNECTION_USER_PASSWORD_KEY = "javax.jdo.option.ConnectionPassword";
 
+    public static final String FLYWAY_PLACEHOLDER_PREFIX = "$flyway{";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemaGenerator.class);
 
     private JDOPersistenceManagerFactory persistenceManagerFactory;
@@ -97,6 +99,7 @@ public class SchemaGenerator implements InitializingBean {
         flyway.setSqlMigrationPrefix(Constants.EntitiesMigration.ENTITY_MIGRATIONS_PREFIX);
         flyway.setOutOfOrder(true);
         flyway.setInitOnMigrate(true);
+        flyway.setPlaceholderPrefix(FLYWAY_PLACEHOLDER_PREFIX);
 
         flyway.migrate();
     }

--- a/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
+++ b/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
@@ -45,6 +45,7 @@
         </property>
         <property name="sqlMigrationPrefix" value="V"/>
         <property name="outOfOrder" value="true"/>
+        <property name="placeholderPrefix" value="$flyway{"/>
         <property name="initOnMigrate" value="true"/>
     </bean>
 


### PR DESCRIPTION
Changed from the default ${ to $flyway{ . Resolves issues with Velocity
strings in migrations getting parsed.