### PR TITLE
MOTECH-2035: Fixes bug after schema regeneration in MDS

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/MdsJdoAnnotationReader.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/MdsJdoAnnotationReader.java
@@ -1,6 +1,7 @@
 package org.motechproject.mds.jdo;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.felix.framework.BundleWiringImpl;
 import org.datanucleus.api.jdo.metadata.JDOAnnotationReader;
 import org.datanucleus.metadata.MetaDataManager;
 import org.datanucleus.metadata.annotations.AnnotationObject;
@@ -37,7 +38,9 @@ public class MdsJdoAnnotationReader extends JDOAnnotationReader {
         AnnotationObject annotationObject = super.isClassPersistable(cls);
 
         // if super does not recognize this object as PC, then try looking for the Entity annotation
-        if (annotationObject == null && ReflectionsUtil.hasAnnotation(cls, Entity.class)) {
+        // only when class is not loaded by BundleClassLoader
+        if (annotationObject == null && ReflectionsUtil.hasAnnotation(cls, Entity.class) &&
+                !(cls.getClassLoader() instanceof BundleWiringImpl.BundleClassLoader)) {
             // default params
             HashMap<String, Object> annotationParams = new HashMap<>();
             annotationParams.put("identityType", IdentityType.DATASTORE);


### PR DESCRIPTION
This commit fixes bug, when NucleusException was thrown after schema regeneration
in MDS.

In MDS we use MDS JDO annotation reader, which extends the regular
JDOAnnotationReader from datanucleus. This class was introduced because
regular reader would not read field annotations for metadata if there was
no class level JDO annotations. In this class we fake the PersistenceCapable
annotation.

It works as expected, however sometimes after schema regeneration
datanucleus read wrong Metadata for classes. This is connected with this reader.
When we are loading entities using MDSClassLoader our reader implementation is
needed to see field annotations, however after package.jdo file is ready,
there is no need to fake PersistenceCapable annotation. It's why I added the
condition with BundleClassLoader.

After this changes, the bug should be fixed.