### PR TITLE
MOTECH-2035: Fixes bug after schema regeneration in MDS

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/MdsJdoAnnotationReader.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/jdo/MdsJdoAnnotationReader.java
@@ -37,7 +37,9 @@ public class MdsJdoAnnotationReader extends JDOAnnotationReader {
         AnnotationObject annotationObject = super.isClassPersistable(cls);
 
         // if super does not recognize this object as PC, then try looking for the Entity annotation
-        if (annotationObject == null && ReflectionsUtil.hasAnnotation(cls, Entity.class)) {
+        // only when FileMetadata has been already loaded
+        if (annotationObject == null && ReflectionsUtil.hasAnnotation(cls, Entity.class) &&
+                 !ArrayUtils.isEmpty(mgr.getFileMetaData())) {
             // default params
             HashMap<String, Object> annotationParams = new HashMap<>();
             annotationParams.put("identityType", IdentityType.DATASTORE);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/jdo/MdsJdoAnnotationReaderTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/jdo/MdsJdoAnnotationReaderTest.java
@@ -1,5 +1,6 @@
 package org.motechproject.mds.jdo;
 
+import org.datanucleus.metadata.FileMetaData;
 import org.datanucleus.metadata.MetaDataManager;
 import org.datanucleus.metadata.annotations.AnnotationManager;
 import org.datanucleus.metadata.annotations.AnnotationObject;
@@ -20,6 +21,7 @@ import javax.jdo.annotations.PersistenceCapable;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -58,12 +60,20 @@ public class MdsJdoAnnotationReaderTest {
 
     @Test
     public void shouldRecognizeEntityAnnotation() {
+        when(metaDataManager.getFileMetaData()).thenReturn(new FileMetaData[1]);
         AnnotationObject result = mdsJdoAnnotationReader.isClassPersistable(Record.class);
 
         assertEquals(PersistenceCapable.class.getName(), result.getName());
         assertNotNull(result.getNameValueMap());
         assertEquals(IdentityType.DATASTORE, result.getNameValueMap().get("identityType"));
         assertEquals("true", result.getNameValueMap().get("detachable"));
+    }
+
+    @Test
+    public void shouldNotRecognizeEntityAnnotationWhenFileMetadataIsEmpty() {
+        AnnotationObject result = mdsJdoAnnotationReader.isClassPersistable(Record.class);
+
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
This commit fixes bug, when NucleusException was thrown after schema regeneration
in MDS.

In MDS we use MDS JDO annotation reader, which extends the regular
JDOAnnotationReader from datanucleus. This class was introduced because
regular reader would not read field annotations for metadata if there was
no class level JDO annotations. In this class we fake the PersistenceCapable
annotation.

It works as expected, however sometimes after schema regeneration
datanucleus try to read annotations from class before populate FileMetadata.
In this case we have wrong metadata. We always want to read class annotations
after FileMetada is populated.

After this changes, the bug should be fixed.

This is another fix after the changes https://github.com/motech/motech/pull/271 were reverted because of problem with Commcare integration tests.