### PR TITLE
MOTECH-2108: Fixes integration tests which use AbstractTaskBundleIT

### DIFF
--- a/modules/tasks/tasks-test-utils/pom.xml
+++ b/modules/tasks/tasks-test-utils/pom.xml
@@ -46,6 +46,16 @@
                         <Export-Package>
                             org.motechproject.tasks.osgi.test;version=${project.version}
                         </Export-Package>
+                        <Import-Package>
+                            net.sf.cglib.core,
+                            net.sf.cglib.proxy,
+                            net.sf.cglib.reflect,
+                            org.aopalliance.aop,
+                            org.springframework.aop,
+                            org.springframework.aop.framework,
+                            org.springframework.transaction,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
After adding the @Transactional annotation to the TaskTriggerHandler, we need
to add some import packages to motech-task-test-utils module. Now integration
tests which use AbstractTaskBundleIT will work correctly.

I've already checked Commcare ITs and Schedule-tracking IT