### PR TITLE
MOTECH-1411: Scheduler API uses now Joda time

### DIFF
--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/CronSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/CronSchedulableJob.java
@@ -1,8 +1,8 @@
 package org.motechproject.scheduler.contract;
 
+import org.joda.time.DateTime;
 import org.motechproject.event.MotechEvent;
 
-import java.util.Date;
 import java.util.Objects;
 
 /**
@@ -19,8 +19,8 @@ public class CronSchedulableJob extends SchedulableJob {
 
     private MotechEvent motechEvent;
     private String cronExpression;
-    private Date startTime;
-    private Date endTime;
+    private DateTime startTime;
+    private DateTime endTime;
     private boolean ignorePastFiresAtStart;
 
     /**
@@ -28,10 +28,10 @@ public class CronSchedulableJob extends SchedulableJob {
      *
      * @param motechEvent  the {@code MotechEvent} fired, when job triggers, not null
      * @param cronExpression  the cron expression, which defines when job should be fired, not null
-     * @param startTime  the {@code Date} at which job should become ACTIVE, not null
-     * @param endTime  the {@code Date} at which job should be stopped, null treated as never end
+     * @param startTime  the {@code DateTime} at which job should become ACTIVE, not null
+     * @param endTime  the {@code DateTime} at which job should be stopped, null treated as never end
      */
-    public CronSchedulableJob(MotechEvent motechEvent, String cronExpression, Date startTime, Date endTime) {
+    public CronSchedulableJob(MotechEvent motechEvent, String cronExpression, DateTime startTime, DateTime endTime) {
         this(motechEvent, cronExpression, startTime, endTime, false);
     }
 
@@ -50,11 +50,11 @@ public class CronSchedulableJob extends SchedulableJob {
      *
      * @param motechEvent  the {@code MotechEvent} fired, when job triggers, not null
      * @param cronExpression  the cron expression, which defines when job should be fired, not null
-     * @param startTime  the {@code Date} at which job should become ACTIVE, not null
-     * @param endTime  the {@code Date} at which job should be stopped, null treated as never end
+     * @param startTime  the {@code DateTime} at which job should become ACTIVE, not null
+     * @param endTime  the {@code DateTime} at which job should be stopped, null treated as never end
      * @param ignorePastFiresAtStart  the flag defining, whether job should ignore past fires at start or not
      */
-    public CronSchedulableJob(MotechEvent motechEvent, String cronExpression, Date startTime, Date endTime, boolean ignorePastFiresAtStart) {
+    public CronSchedulableJob(MotechEvent motechEvent, String cronExpression, DateTime startTime, DateTime endTime, boolean ignorePastFiresAtStart) {
         if (motechEvent == null) {
             throw new IllegalArgumentException("MotechEvent can not be null");
         }
@@ -69,11 +69,11 @@ public class CronSchedulableJob extends SchedulableJob {
         this.ignorePastFiresAtStart = ignorePastFiresAtStart;
     }
 
-    public Date getStartTime() {
+    public DateTime getStartTime() {
         return startTime;
     }
 
-    public Date getEndTime() {
+    public DateTime getEndTime() {
         return endTime;
     }
 

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RepeatingPeriodSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RepeatingPeriodSchedulableJob.java
@@ -1,10 +1,9 @@
 package org.motechproject.scheduler.contract;
 
 import org.apache.commons.lang.ObjectUtils;
+import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.motechproject.event.MotechEvent;
-
-import java.util.Date;
 
 /**
  * Job that will be fired every {@link org.joda.time.Period} of time
@@ -13,8 +12,8 @@ public class RepeatingPeriodSchedulableJob extends SchedulableJob {
     private static final long serialVersionUID = 1L;
 
     private MotechEvent motechEvent;
-    private Date startTime;
-    private Date endTime;
+    private DateTime startTime;
+    private DateTime endTime;
     private Period repeatPeriod;
     private boolean ignorePastFiresAtStart;
     private boolean useOriginalFireTimeAfterMisfire;
@@ -33,12 +32,12 @@ public class RepeatingPeriodSchedulableJob extends SchedulableJob {
      * Constructor.
      *
      * @param motechEvent  the {@code MotechEvent} which will be fired when the job triggers, not null
-     * @param startTime  the {@code Date} at which job should become ACTIVE, not null
-     * @param endTime  the {@code Date} at which job should be stopped, null treated as never end
+     * @param startTime  the {@code DateTime} at which job should become ACTIVE, not null
+     * @param endTime  the {@code DateTime} at which job should be stopped, null treated as never end
      * @param repeatPeriod the {@code Period} between job fires, not null
      * @param ignorePastFiresAtStart the flag defining whether job should ignore past fires at start or not
      */
-    public RepeatingPeriodSchedulableJob(final MotechEvent motechEvent, final Date startTime, final Date endTime, final Period repeatPeriod, boolean ignorePastFiresAtStart) {
+    public RepeatingPeriodSchedulableJob(final MotechEvent motechEvent, final DateTime startTime, final DateTime endTime, final Period repeatPeriod, boolean ignorePastFiresAtStart) {
         this.motechEvent = motechEvent;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -56,20 +55,20 @@ public class RepeatingPeriodSchedulableJob extends SchedulableJob {
         return this;
     }
 
-    public Date getStartTime() {
+    public DateTime getStartTime() {
         return startTime;
     }
 
-    public RepeatingPeriodSchedulableJob setStartTime(final Date startTime) {
+    public RepeatingPeriodSchedulableJob setStartTime(final DateTime startTime) {
         this.startTime = startTime;
         return this;
     }
 
-    public Date getEndTime() {
+    public DateTime getEndTime() {
         return endTime;
     }
 
-    public RepeatingPeriodSchedulableJob setEndTime(final Date endTime) {
+    public RepeatingPeriodSchedulableJob setEndTime(final DateTime endTime) {
         this.endTime = endTime;
         return this;
     }

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RepeatingSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RepeatingSchedulableJob.java
@@ -1,9 +1,8 @@
 package org.motechproject.scheduler.contract;
 
 import org.apache.commons.lang.ObjectUtils;
+import org.joda.time.DateTime;
 import org.motechproject.event.MotechEvent;
-
-import java.util.Date;
 
 /**
  * Schedulable Job - a data carrier class for a scheduled job that can be fired set number of times
@@ -16,8 +15,8 @@ public class RepeatingSchedulableJob extends SchedulableJob {
     private MotechEvent motechEvent;
     private Integer repeatCount;
     private Integer repeatIntervalInSeconds;
-    private Date startTime;
-    private Date endTime;
+    private DateTime startTime;
+    private DateTime endTime;
     private boolean ignorePastFiresAtStart;
     private boolean useOriginalFireTimeAfterMisfire;
 
@@ -37,11 +36,12 @@ public class RepeatingSchedulableJob extends SchedulableJob {
      * @param motechEvent  the {@code MotechEvent} which will be fired when the job triggers, not null
      * @param repeatCount  the number of times job should be repeated, null treated as infinite
      * @param repeatIntervalInSeconds  the interval(in seconds) between job fires
-     * @param startTime  the {@code Date} at which job should become ACTIVE, not null
-     * @param endTime  the {@code Date} at which job should be stopped, null treated as never end
+     * @param startTime  the {@code DateTime} at which job should become ACTIVE, not null
+     * @param endTime  the {@code DateTime} at which job should be stopped, null treated as never end
      * @param ignorePastFiresAtStart  the flag defining whether job should ignore past fires at start or not
      */
-    public RepeatingSchedulableJob(final MotechEvent motechEvent, final Integer repeatCount, final Integer repeatIntervalInSeconds, final Date startTime, final Date endTime, boolean ignorePastFiresAtStart) {
+    public RepeatingSchedulableJob(final MotechEvent motechEvent, final Integer repeatCount, final Integer repeatIntervalInSeconds,
+                                   final DateTime startTime, final DateTime endTime, boolean ignorePastFiresAtStart) {
         this.motechEvent = motechEvent;
         this.repeatCount = repeatCount;
         this.repeatIntervalInSeconds = repeatIntervalInSeconds;
@@ -56,11 +56,12 @@ public class RepeatingSchedulableJob extends SchedulableJob {
      *
      * @param motechEvent  the {@code MotechEvent} which will be fired when the job triggers, not null
      * @param repeatIntervalInSeconds  the interval(in seconds) between job fires
-     * @param startTime  the {@code Date} at which job should become ACTIVE, not null
-     * @param endTime  the {@code Date} at which job should be stopped, null treated as never end
+     * @param startTime  the {@code DateTime} at which job should become ACTIVE, not null
+     * @param endTime  the {@code DateTime} at which job should be stopped, null treated as never end
      * @param ignorePastFiresAtStart  the flag defining whether job should ignore past fires at start or not
      */
-    public RepeatingSchedulableJob(final MotechEvent motechEvent, final Integer repeatIntervalInSeconds, final Date startTime, final Date endTime, boolean ignorePastFiresAtStart) {
+    public RepeatingSchedulableJob(final MotechEvent motechEvent, final Integer repeatIntervalInSeconds,
+                                   final DateTime startTime, final DateTime endTime, boolean ignorePastFiresAtStart) {
         this(motechEvent, null, repeatIntervalInSeconds, startTime, endTime, ignorePastFiresAtStart);
     }
 
@@ -73,20 +74,20 @@ public class RepeatingSchedulableJob extends SchedulableJob {
         return this;
     }
 
-    public Date getStartTime() {
+    public DateTime getStartTime() {
         return startTime;
     }
 
-    public RepeatingSchedulableJob setStartTime(final Date startTime) {
+    public RepeatingSchedulableJob setStartTime(final DateTime startTime) {
         this.startTime = startTime;
         return this;
     }
 
-    public Date getEndTime() {
+    public DateTime getEndTime() {
         return endTime;
     }
 
-    public RepeatingSchedulableJob setEndTime(final Date endTime) {
+    public RepeatingSchedulableJob setEndTime(final DateTime endTime) {
         this.endTime = endTime;
         return this;
     }

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RunOnceSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/contract/RunOnceSchedulableJob.java
@@ -1,8 +1,7 @@
 package org.motechproject.scheduler.contract;
 
+import org.joda.time.DateTime;
 import org.motechproject.event.MotechEvent;
-
-import java.util.Date;
 
 /**
  * Run Once Schedulable Job - a data carrier class for a job scheduled in the future that can be fired only once
@@ -18,7 +17,7 @@ public final class RunOnceSchedulableJob extends SchedulableJob {
     private static final long serialVersionUID = 1L;
 
     private MotechEvent motechEvent;
-    private Date startDate;
+    private DateTime startDate;
 
     /**
      * Constructor
@@ -27,7 +26,7 @@ public final class RunOnceSchedulableJob extends SchedulableJob {
      * @param startDate   - date and time when the job fill be fired
      * @throws IllegalArgumentException if motechEvent or startDate is null or startDate is in past
      */
-    public RunOnceSchedulableJob(MotechEvent motechEvent, Date startDate) {
+    public RunOnceSchedulableJob(MotechEvent motechEvent, DateTime startDate) {
 
         if (motechEvent == null) {
             throw new IllegalArgumentException("MotechEvent can not be null");
@@ -50,7 +49,7 @@ public final class RunOnceSchedulableJob extends SchedulableJob {
         return true;
     }
 
-    public Date getStartDate() {
+    public DateTime getStartDate() {
         return startDate;
     }
 

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/MotechSchedulerService.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/MotechSchedulerService.java
@@ -10,7 +10,6 @@ import org.motechproject.scheduler.contract.RepeatingPeriodSchedulableJob;
 import org.motechproject.scheduler.contract.RepeatingSchedulableJob;
 import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
 
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -215,7 +214,7 @@ public interface MotechSchedulerService {
      * @param endDate  the {@code Date} before which dates should be added, not null
      * @return the list of dates, null if exception was thrown
      */
-    List<Date> getScheduledJobTimings(String subject, String externalJobId, Date startDate, Date endDate);
+    List<DateTime> getScheduledJobTimings(String subject, String externalJobId, DateTime startDate, DateTime endDate);
 
     /**
      * Returns list of dates at which jobs will be triggered.
@@ -226,7 +225,7 @@ public interface MotechSchedulerService {
      * @param endDate  the {@code Date} before which dates should be added, not null
      * @return the list of dates
      */
-    List<Date> getScheduledJobTimingsWithPrefix(String subject, String externalJobIdPrefix, Date startDate, Date endDate);
+    List<DateTime> getScheduledJobTimingsWithPrefix(String subject, String externalJobIdPrefix, DateTime startDate, DateTime endDate);
 
     /**
      * Pauses the job based on the given {@code info}.

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerActionProxyServiceImpl.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerActionProxyServiceImpl.java
@@ -32,8 +32,7 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
     @Override
     public void scheduleCronJob(String subject, Map<Object, Object> parameters, String cronExpression, DateTime startTime, DateTime endTime, Boolean ignorePastFiresAtStart) {
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
-        CronSchedulableJob job = new CronSchedulableJob(motechEvent, cronExpression, startTime.toDate(),
-                endTime != null ? endTime.toDate() : null, ignorePastFiresAtStart);
+        CronSchedulableJob job = new CronSchedulableJob(motechEvent, cronExpression, startTime, endTime, ignorePastFiresAtStart);
 
         scheduler.scheduleJob(job);
     }
@@ -46,8 +45,8 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
         RepeatingSchedulableJob job = new RepeatingSchedulableJob()
                 .setMotechEvent(motechEvent)
-                .setStartTime(startTime.toDate())
-                .setEndTime(endTime != null ? endTime.toDate() : null)
+                .setStartTime(startTime)
+                .setEndTime(endTime)
                 .setRepeatCount(repeatCount)
                 .setRepeatIntervalInSeconds(repeatIntervalInSeconds)
                 .setIgnorePastFiresAtStart(ignorePastFiresAtStart)
@@ -59,7 +58,7 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
     @Override
     public void scheduleRunOnceJob(String subject, Map<Object, Object> parameters, DateTime startDate) {
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
-        RunOnceSchedulableJob job = new RunOnceSchedulableJob(motechEvent, startDate.toDate());
+        RunOnceSchedulableJob job = new RunOnceSchedulableJob(motechEvent, startDate);
 
         scheduler.scheduleRunOnceJob(job);
     }
@@ -81,7 +80,7 @@ public class MotechSchedulerActionProxyServiceImpl implements MotechSchedulerAct
                                      Period repeatPeriod, Boolean ignorePastFiresAtStart, Boolean useOriginalFireTimeAfterMisfire) {
         MotechEvent motechEvent = new MotechEvent(subject, createMotechEventParameters(parameters));
         RepeatingPeriodSchedulableJob job = new RepeatingPeriodSchedulableJob(motechEvent,
-                startTime.toDate(), endTime != null ? endTime.toDate() : null, repeatPeriod, ignorePastFiresAtStart);
+                startTime, endTime, repeatPeriod, ignorePastFiresAtStart);
                 job.setUseOriginalFireTimeAfterMisfire(useOriginalFireTimeAfterMisfire);
 
         scheduler.scheduleRepeatingPeriodJob(job);

--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerServiceImpl.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/service/impl/MotechSchedulerServiceImpl.java
@@ -140,8 +140,8 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
                 .withIdentity(triggerKey(jobId.value(), JOB_GROUP_NAME))
                 .forJob(jobDetail)
                 .withSchedule(cronSchedule)
-                .startAt(cronSchedulableJob.getStartTime() != null ? cronSchedulableJob.getStartTime() : now().toDate())
-                .endAt(cronSchedulableJob.getEndTime())
+                .startAt(cronSchedulableJob.getStartTime() != null ? cronSchedulableJob.getStartTime().toDate() : now().toDate())
+                .endAt(DateUtil.toDate(cronSchedulableJob.getEndTime()))
                 .build();
 
         Trigger existingTrigger;
@@ -156,7 +156,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
 
         DateTime now = now();
 
-        if (cronSchedulableJob.isIgnorePastFiresAtStart() && newDateTime(cronSchedulableJob.getStartTime()).isBefore(now)) {
+        if (cronSchedulableJob.isIgnorePastFiresAtStart() && cronSchedulableJob.getStartTime().isBefore(now)) {
 
             Date newStartTime = trigger.getFireTimeAfter(now.toDate());
             if (newStartTime == null) {
@@ -168,7 +168,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
                 .forJob(jobDetail)
                 .withSchedule(cronSchedule)
                 .startAt(newStartTime)
-                .endAt(cronSchedulableJob.getEndTime())
+                .endAt(DateUtil.toDate(cronSchedulableJob.getEndTime()))
                 .build();
         }
 
@@ -277,7 +277,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
             throw new MotechSchedulerException(String.format("Can not reschedule the job: %s.\n The trigger associated with that job is not a CronTrigger", jobId), e);
         }
 
-        CronScheduleBuilder newCronSchedule = null;
+        CronScheduleBuilder newCronSchedule;
         try {
             newCronSchedule = cronSchedule(cronExpression);
         } catch (RuntimeException e) {
@@ -305,8 +305,8 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
 
         MotechEvent motechEvent = assertArgumentNotNull(repeatingSchedulableJob);
 
-        Date jobStartTime = repeatingSchedulableJob.getStartTime();
-        Date jobEndTime = repeatingSchedulableJob.getEndTime();
+        DateTime jobStartTime = repeatingSchedulableJob.getStartTime();
+        DateTime jobEndTime = repeatingSchedulableJob.getEndTime();
         assertArgumentNotNull("Job start date", jobStartTime);
 
         Integer repeatIntervalInSeconds = repeatingSchedulableJob.getRepeatIntervalInSeconds();
@@ -339,14 +339,15 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
         } else {
             if (repeatingSchedulableJob.getRepeatCount() != null) {
                 final double half = 0.5;
-                jobEndTime = new Date((long) (repeatingSchedulableJob.getStartTime().getTime() + repeatIntervalInSeconds * MILLISECOND * (repeatingSchedulableJob.getRepeatCount() + half)));
+                jobEndTime = new DateTime((long) (repeatingSchedulableJob.getStartTime().getMillis() + repeatIntervalInSeconds * MILLISECOND * (repeatingSchedulableJob.getRepeatCount() + half)));
             }
             scheduleBuilder = CalendarIntervalScheduleBuilder.calendarIntervalSchedule()
                     .withIntervalInSeconds(repeatIntervalInSeconds)
                     .withMisfireHandlingInstructionFireAndProceed();
         }
 
-        Trigger trigger = buildJobDetail(repeatingSchedulableJob, jobStartTime, jobEndTime, jobId, jobDetail, scheduleBuilder);
+        Trigger trigger = buildJobDetail(repeatingSchedulableJob, DateUtil.toDate(jobStartTime),
+                DateUtil.toDate(jobEndTime), jobId, jobDetail, scheduleBuilder);
         scheduleJob(jobDetail, trigger);
     }
 
@@ -375,8 +376,8 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
             .withRepeatPeriod(repeatPeriod)
             .withMisfireHandlingInstructionFireAndProceed();
 
-        Trigger trigger = buildJobDetail(repeatingPeriodSchedulableJob, repeatingPeriodSchedulableJob.getStartTime(),
-                repeatingPeriodSchedulableJob.getEndTime(), jobId, jobDetail, scheduleBuilder);
+        Trigger trigger = buildJobDetail(repeatingPeriodSchedulableJob, DateUtil.toDate(repeatingPeriodSchedulableJob.getStartTime()),
+                DateUtil.toDate(repeatingPeriodSchedulableJob.getEndTime()), jobId, jobDetail, scheduleBuilder);
         scheduleJob(jobDetail, trigger);
     }
 
@@ -488,10 +489,10 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
         assertArgumentNotNull("RunOnceSchedulableJob", schedulableJob);
         MotechEvent motechEvent = schedulableJob.getMotechEvent();
 
-        Date jobStartDate = schedulableJob.getStartDate();
+        DateTime jobStartDate = schedulableJob.getStartDate();
         assertArgumentNotNull("Job start date", jobStartDate);
-        Date currentDate = DateUtil.now().toDate();
-        if (jobStartDate.before(currentDate)) {
+        DateTime currentDate = DateUtil.now();
+        if (jobStartDate.isBefore(currentDate)) {
             String errorMessage = "Invalid RunOnceSchedulableJob. The job start date can not be in the past. \n" +
                     " Job start date: " + jobStartDate.toString() +
                     " Attempted to schedule at:" + currentDate.toString();
@@ -515,7 +516,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
                 .withIdentity(triggerKey(jobId.value(), JOB_GROUP_NAME))
                 .forJob(jobDetail)
                 .withSchedule(simpleSchedule)
-                .startAt(jobStartDate)
+                .startAt(DateUtil.toDate(jobStartDate))
                 .build();
 
         scheduleJob(jobDetail, trigger);
@@ -552,10 +553,12 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
         Time time = dayOfWeekSchedulableJob.getTime();
 
         CronScheduleBuilder cronScheduleBuilder = CronScheduleBuilder.atHourAndMinuteOnGivenDaysOfWeek(time.getHour(),
-                time.getMinute(), dayOfWeekSchedulableJob.getCronDays().toArray(new Integer[0]));
+                time.getMinute(), dayOfWeekSchedulableJob.getCronDays()
+                        .toArray(new Integer[dayOfWeekSchedulableJob.getCronDays().size()]));
+
         CronTriggerImpl cronTrigger = (CronTriggerImpl) cronScheduleBuilder.build();
         CronSchedulableJob cronSchedulableJob = new CronSchedulableJob(motechEvent, cronTrigger.getCronExpression(),
-                start.toDate(), end != null ? end.toDate() : null, dayOfWeekSchedulableJob.isIgnorePastFiresAtStart());
+                start.toDateMidnight().toDateTime(), end != null ? end.toDateMidnight().toDateTime() : null, dayOfWeekSchedulableJob.isIgnorePastFiresAtStart());
 
         scheduleJob(cronSchedulableJob);
     }
@@ -734,13 +737,13 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
      * Uses quartz API to fetch the exact triggers. Fast
      */
     @Override
-    public List<Date> getScheduledJobTimings(String subject, String externalJobId, Date startDate, Date endDate) {
+    public List<DateTime> getScheduledJobTimings(String subject, String externalJobId, DateTime startDate, DateTime endDate) {
         JobId jobId = new CronJobId(subject, externalJobId);
         Trigger trigger;
         try {
             trigger = scheduler.getTrigger(triggerKey(jobId.value(), JOB_GROUP_NAME));
-            return TriggerUtils.computeFireTimesBetween(
-                    (OperableTrigger) trigger, new BaseCalendar(), startDate, endDate);
+            return DateUtil.datesToDateTimes(TriggerUtils.computeFireTimesBetween(
+                    (OperableTrigger) trigger, new BaseCalendar(), DateUtil.toDate(startDate), DateUtil.toDate(endDate)));
 
         } catch (SchedulerException e) {
             throw new MotechSchedulerException(String.format(
@@ -754,8 +757,8 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
      * will work regardless of the jobId being cron or repeating.
      */
     @Override
-    public List<Date> getScheduledJobTimingsWithPrefix(
-            String subject, String externalJobIdPrefix, Date startDate, Date endDate) {
+    public List<DateTime> getScheduledJobTimingsWithPrefix(
+            String subject, String externalJobIdPrefix, DateTime startDate, DateTime endDate) {
 
         JobId jobId = new CronJobId(subject, externalJobIdPrefix);
         List<Date> messageTimings = new ArrayList<>();
@@ -766,7 +769,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
                 if (StringUtils.isNotEmpty(externalJobIdPrefix) && triggerKey.getName().contains(jobId.value())) {
                     Trigger trigger = scheduler.getTrigger(triggerKey);
                     messageTimings.addAll(TriggerUtils.computeFireTimesBetween(
-                            (OperableTrigger) trigger, new BaseCalendar(), startDate, endDate));
+                            (OperableTrigger) trigger, new BaseCalendar(), DateUtil.toDate(startDate), DateUtil.toDate(endDate)));
                 }
             }
 
@@ -776,7 +779,7 @@ public class MotechSchedulerServiceImpl implements MotechSchedulerService {
                     subject, externalJobIdPrefix, startDate.toString(), endDate.toString(), e.getMessage()), e);
         }
 
-        return messageTimings;
+        return DateUtil.datesToDateTimes(messageTimings);
     }
 
     @Override

--- a/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/JobStorePerformanceAssessment.java
+++ b/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/JobStorePerformanceAssessment.java
@@ -76,13 +76,14 @@ public class JobStorePerformanceAssessment {
 
             DateTime startTime = now().plusSeconds(0);
             Integer repeatInterval = 1;
-            System.out.println("startTime: " + startTime.toDate());
+            System.out.println("startTime: " + startTime);
 
             MotechSchedulerServiceImpl schedulerService = new MotechSchedulerServiceImpl(schedulerFactoryBean, settings);
             NanoStopWatch timeToSchedule = new NanoStopWatch().start();
             for (int i = 0; i < maxJobs; i++) {
                 params.put(MotechSchedulerService.JOB_ID_KEY, "test_job_" + String.valueOf(i));
-                RepeatingSchedulableJob repeatingJob = new RepeatingSchedulableJob(motechEvent,repeatCount, repeatInterval, startTime.toDate(), null, false);
+                RepeatingSchedulableJob repeatingJob = new RepeatingSchedulableJob(motechEvent, repeatCount, repeatInterval,
+                        startTime, null, false);
                 repeatingJob.setUseOriginalFireTimeAfterMisfire(false);
                 schedulerService.scheduleRepeatingJob(repeatingJob);
             }

--- a/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/domain/TestRunOnceSchedulableJob.java
+++ b/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/domain/TestRunOnceSchedulableJob.java
@@ -1,12 +1,12 @@
 package org.motechproject.scheduler.domain;
 
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
+import org.motechproject.commons.date.util.DateUtil;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.scheduler.contract.RunOnceSchedulableJob;
 
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -21,21 +21,20 @@ public class TestRunOnceSchedulableJob {
     private MotechEvent motechEvent1;
     private MotechEvent motechEvent2;
 
-    private Date currentDate;
+    private DateTime currentDate;
 
     @Before
     public void setUp() {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("JobID", uuidStr);
         motechEvent1 = new MotechEvent("TestEvent", params);
 
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("JobID", uuidStr2);
         motechEvent2 = new MotechEvent("TestEvent", params);
 
-        Calendar cal = Calendar.getInstance();
-        currentDate = cal.getTime();
-        cal.add(Calendar.DATE, -1);
+        currentDate = DateUtil.now();
+        currentDate = currentDate.minusDays(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -50,12 +49,9 @@ public class TestRunOnceSchedulableJob {
 
     @Test
     public void equalsTest() throws Exception {
-        Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.DATE, +1);
-        Date date = cal.getTime();
-
-        cal.add(Calendar.DATE, +1);
-        Date date2 = cal.getTime();
+        DateTime now = DateUtil.now();
+        DateTime date = now.plusDays(1);
+        DateTime date2 = now.plusDays(2);
 
         RunOnceSchedulableJob job1 = new RunOnceSchedulableJob(motechEvent1, date);
         RunOnceSchedulableJob job1Same = new RunOnceSchedulableJob(motechEvent1, date);

--- a/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/MotechSchedulerDatabaseServiceImplBundleIT.java
+++ b/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/MotechSchedulerDatabaseServiceImplBundleIT.java
@@ -37,7 +37,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,13 +99,13 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
                     ));
 
 
-            List<Date> eventTimes = schedulerService.getScheduledJobTimings("test_event", "job_id",
-                    newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate(),
-                    newDateTime(CURRENT_YEAR + 6, 7, 17, 12, 0, 0).toDate());
+            List<DateTime> eventTimes = schedulerService.getScheduledJobTimings("test_event", "job_id",
+                    newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0),
+                    newDateTime(CURRENT_YEAR + 6, 7, 17, 12, 0, 0));
             assertEquals(asList(
-                    newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate(),
-                    newDateTime(CURRENT_YEAR + 6, 7, 16, 12, 0, 0).toDate(),
-                    newDateTime(CURRENT_YEAR + 6, 7, 17, 12, 0, 0).toDate()),
+                    newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0),
+                    newDateTime(CURRENT_YEAR + 6, 7, 16, 12, 0, 0),
+                    newDateTime(CURRENT_YEAR + 6, 7, 17, 12, 0, 0)),
                     eventTimes);
         } finally {
             stopFakingTime();
@@ -131,7 +130,7 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRunOnceJob(
                     new RunOnceSchedulableJob(
                             new MotechEvent("test_event_2", params),
-                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate()
+                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0)
                     )
             );
 
@@ -139,8 +138,8 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
                     new RepeatingSchedulableJob(
                             new MotechEvent("test_event_2", params),
                             DateTimeConstants.SECONDS_PER_DAY,
-                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate(),
-                            newDateTime(CURRENT_YEAR + 6, 7, 18, 12, 0, 0).toDate(),
+                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0),
+                            newDateTime(CURRENT_YEAR + 6, 7, 18, 12, 0, 0),
                             false
                     )
             );
@@ -231,7 +230,7 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRunOnceJob(
                     new RunOnceSchedulableJob(
                             new MotechEvent("test_event_2b", params),
-                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate()
+                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0)
                     )
             );
 
@@ -239,8 +238,8 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
                     new RepeatingSchedulableJob(
                             new MotechEvent("test_event_2c", params),
                             DateTimeConstants.SECONDS_PER_DAY,
-                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate(),
-                            newDateTime(CURRENT_YEAR + 6, 7, 18, 12, 0, 0).toDate(),
+                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0),
+                            newDateTime(CURRENT_YEAR + 6, 7, 18, 12, 0, 0),
                             false
                     )
             );
@@ -282,7 +281,7 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRunOnceJob(
                     new RunOnceSchedulableJob(
                             new MotechEvent("test_event_2", params),
-                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate()
+                            newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0)
                     ));
 
             JobsSearchSettings jobsSearchSettings = getGridSettings(0, 10, "name", "asc");
@@ -484,7 +483,7 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
         schedulerService.scheduleRunOnceJob(
                 new RunOnceSchedulableJob(
                         new MotechEvent("test_event_5", params),
-                        newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0).toDate()
+                        newDateTime(CURRENT_YEAR + 6, 7, 15, 12, 0, 0)
                 )
         );
         params = new HashMap<>();
@@ -493,8 +492,8 @@ public class MotechSchedulerDatabaseServiceImplBundleIT extends BasePaxIT {
                 new RepeatingSchedulableJob(
                         new MotechEvent("test_event_6", params),
                         DateTimeConstants.SECONDS_PER_DAY,
-                        newDateTime(CURRENT_YEAR + 4, 7, 15, 12, 0, 0).toDate(),
-                        newDateTime(CURRENT_YEAR + 4, 7, 18, 12, 0, 0).toDate(),
+                        newDateTime(CURRENT_YEAR + 4, 7, 15, 12, 0, 0),
+                        newDateTime(CURRENT_YEAR + 4, 7, 18, 12, 0, 0),
                         false
                 )
         );

--- a/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/MotechSchedulerServiceImplBundleIT.java
+++ b/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/MotechSchedulerServiceImplBundleIT.java
@@ -130,7 +130,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
             DateTime jobStartTime = now.minusMinutes(3);
             Map<String, Object> params = new HashMap<>();
             params.put(MotechSchedulerService.JOB_ID_KEY, "job_id");
-            schedulerService.scheduleJob(new CronSchedulableJob(new MotechEvent(subject, params), "0 0/1 * 1/1 * ? *", jobStartTime.toDate(), null, true));
+            schedulerService.scheduleJob(new CronSchedulableJob(new MotechEvent(subject, params), "0 0/1 * 1/1 * ? *", jobStartTime, null, true));
 
             synchronized (listener.getReceivedEvents()) {
                 listener.getReceivedEvents().wait(2000);
@@ -156,7 +156,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
             params.put(MotechSchedulerService.JOB_ID_KEY, "job_id");
             DateTime jobStartTimeInPast = now.minusMinutes(3);
             schedulerService.scheduleJob(new CronSchedulableJob(new MotechEvent(eventSubject, params),
-                    "0 0/1 * 1/1 * ? *", jobStartTimeInPast.toDate(), null, false));
+                    "0 0/1 * 1/1 * ? *", jobStartTimeInPast, null, false));
 
             synchronized (listener.getReceivedEvents()) {
                 listener.getReceivedEvents().wait(5000);
@@ -314,7 +314,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRunOnceJob(
                     new RunOnceSchedulableJob(
                             new MotechEvent("test_event", params),
-                            newDateTime(2020, 7, 15, 12, 0, 0).toDate()
+                            newDateTime(2020, 7, 15, 12, 0, 0)
                     ));
 
             List<DateTime> fireTimes = getFireTimes("test_event-job_id-runonce");
@@ -336,7 +336,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRunOnceJob(
                 new RunOnceSchedulableJob(
                     new MotechEvent("test_event", params),
-                    newDateTime(2020, 6, 15, 12, 0, 0).toDate()
+                    newDateTime(2020, 6, 15, 12, 0, 0)
                 ));
         } finally {
             stopFakingTime();
@@ -361,7 +361,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                             new MotechEvent("test_event", params),
                             2,
                             DateTimeConstants.SECONDS_PER_DAY,
-                            newDateTime(2020, 7, 15, 12, 0, 0).toDate(),
+                            newDateTime(2020, 7, 15, 12, 0, 0),
                             null,
                             false)
             );
@@ -389,8 +389,8 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                     new RepeatingSchedulableJob(
                             new MotechEvent("test_event", params),
                             DateTimeConstants.SECONDS_PER_DAY,
-                            newDateTime(2020, 7, 15, 12, 0, 0).toDate(),
-                            newDateTime(2020, 7, 18, 12, 0, 0).toDate(),
+                            newDateTime(2020, 7, 15, 12, 0, 0),
+                            newDateTime(2020, 7, 18, 12, 0, 0),
                             false)
             );
 
@@ -415,8 +415,8 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
             schedulerService.scheduleRepeatingPeriodJob(
                     new RepeatingPeriodSchedulableJob(
                             new MotechEvent("test_event_3", params),
-                            newDateTime(2020, 7, 15, 12, 0, 0).toDate(),
-                            newDateTime(2020, 7, 16, 12, 0, 0).toDate(),
+                            newDateTime(2020, 7, 15, 12, 0, 0),
+                            newDateTime(2020, 7, 16, 12, 0, 0),
                             new Period(4, 0, 0, 0),
                             true
                     )
@@ -448,8 +448,8 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                     new RepeatingSchedulableJob(
                             new MotechEvent("test_event", params),
                             DateTimeConstants.SECONDS_PER_DAY,
-                            newDateTime(2020, 7, 14, 12, 0, 0).toDate(),
-                            newDateTime(2020, 7, 18, 12, 0, 0).toDate(),
+                            newDateTime(2020, 7, 14, 12, 0, 0),
+                            newDateTime(2020, 7, 18, 12, 0, 0),
                             true)
             );
 
@@ -475,7 +475,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                 new MotechEvent("test_event", params),
                     3,
                     DateTimeConstants.SECONDS_PER_DAY,
-                    newDateTime(2020, 7, 13, 12, 0, 0).toDate(),
+                    newDateTime(2020, 7, 13, 12, 0, 0),
                     null,
                     true);
             repeatJob.setUseOriginalFireTimeAfterMisfire(false);
@@ -504,8 +504,8 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                 new RepeatingSchedulableJob(
                         null,
                         DateTimeConstants.SECONDS_PER_DAY,
-                        newDateTime(2020, 7, 15, 12, 0, 0).toDate(),
-                        newDateTime(2020, 7, 18, 12, 0, 0).toDate(),
+                        newDateTime(2020, 7, 15, 12, 0, 0),
+                        newDateTime(2020, 7, 18, 12, 0, 0),
                         false)
         );
     }
@@ -519,7 +519,7 @@ public class MotechSchedulerServiceImplBundleIT extends BasePaxIT {
                         new MotechEvent("test_event", params),
                         DateTimeConstants.SECONDS_PER_DAY,
                         null,
-                        newDateTime(2020, 7, 18, 12, 0, 0).toDate(),
+                        newDateTime(2020, 7, 18, 12, 0, 0),
                         false)
         );
     }

--- a/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/SchedulerBundleIT.java
+++ b/modules/scheduler/scheduler/src/test/java/org/motechproject/scheduler/it/SchedulerBundleIT.java
@@ -61,7 +61,7 @@ public class SchedulerBundleIT extends BasePaxIT {
         final MotechEvent motechEvent = new MotechEvent(TEST_SUBJECT);
         motechEvent.getParameters().put(MotechSchedulerService.JOB_ID_KEY, "jobId");
         schedulerService.unscheduleAllJobs("SchedulerBundleIT");
-        schedulerService.scheduleRunOnceJob(new RunOnceSchedulableJob(motechEvent, DateTime.now().plusSeconds(5).toDate()));
+        schedulerService.scheduleRunOnceJob(new RunOnceSchedulableJob(motechEvent, DateTime.now().plusSeconds(5)));
         synchronized (receivedEvents) {
             System.out.print("\nEvent waiting " + new Date() + "\n");
             receivedEvents.wait(15000);

--- a/platform/commons-date/src/main/java/org/motechproject/commons/date/util/DateUtil.java
+++ b/platform/commons-date/src/main/java/org/motechproject/commons/date/util/DateUtil.java
@@ -417,6 +417,43 @@ public final class DateUtil {
     }
 
     /**
+     * Converts a list of {@link Date} to a list of {@link DateTime}.
+     * @param dates the input dates
+     * @return the dates converted to Joda DateTimes
+     */
+    public static List<DateTime> datesToDateTimes(List<Date> dates) {
+        List<DateTime> dateTimes = new ArrayList<>();
+        for (Date date : dates) {
+            if (date == null) {
+                dateTimes.add(null);
+            } else {
+                dateTimes.add(new DateTime(date));
+            }
+        }
+        return dateTimes;
+    }
+
+    /**
+     * Converts the provided {@link DateTime} to a {@link Date} using the {@link DateTime#toDate()} method.
+     * This method is null safe and will return null for a null datetime.
+     * @param dateTime the datetime to convert
+     * @return the datetime converted to a date, or null if null was passed
+     */
+    public static Date toDate(DateTime dateTime) {
+        return dateTime == null ? null : dateTime.toDate();
+    }
+
+    /**
+     * Converts the provided {@link LocalDate} to a {@link DateTime} using the {@link LocalDate#toDateTimeAtStartOfDay()} method.
+     * This method is null safe and will return null for a null datetime.
+     * @param localDate the local date to convert
+     * @return the local date converted to a datetime, or null if null was passed
+     */
+    public static DateTime toDateTimeAtStartOfDay(LocalDate localDate) {
+        return localDate == null ? null : localDate.toDateTimeAtStartOfDay();
+    }
+
+    /**
      * This is a utility class and should not be instantiated
      */
     private DateUtil() {

--- a/platform/commons-date/src/test/java/org/motechproject/commons/date/util/DateUtilTest.java
+++ b/platform/commons-date/src/test/java/org/motechproject/commons/date/util/DateUtilTest.java
@@ -12,6 +12,7 @@ import org.motechproject.commons.date.util.datetime.DateTimeSource;
 import org.motechproject.commons.date.util.datetime.DefaultDateTimeSource;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -19,6 +20,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.motechproject.commons.date.model.DayOfWeek.Monday;
@@ -148,6 +150,31 @@ public class DateUtilTest {
             Assert.fail("expected invalid argument exception");
         } catch (IllegalArgumentException iae) {
         }
+    }
+
+    @Test
+    public void shouldConvertListOfDatesToDateTimes() {
+        List<Date> dates = asList(new Date(115, 9, 10, 8, 10, 10), null, new Date(116, 10, 23, 20, 22, 33));
+
+        List<DateTime> dateTimes = DateUtil.datesToDateTimes(dates);
+
+        assertEquals(asList(new DateTime(2015, 10, 10, 8, 10, 10), null, new DateTime(2016, 11, 23, 20, 22,33)), dateTimes);
+    }
+
+    @Test
+    public void shouldConvertDtToDateNullSafe() {
+        DateTime dt = DateUtil.now();
+
+        assertEquals(dt.toDate(), DateUtil.toDate(dt));
+        assertNull(DateUtil.toDate(null));
+    }
+
+    @Test
+    public void shouldConvertLocalDateToDateNullSafe() {
+        LocalDate ld = new LocalDate(2015, 10, 23);
+
+        assertEquals(new DateTime(2015, 10, 23, 0, 0), DateUtil.toDateTimeAtStartOfDay(ld));
+        assertEquals(null, DateUtil.toDateTimeAtStartOfDay(null));
     }
 
     private void mockCurrentDate(final DateTime currentDate) {


### PR DESCRIPTION
* The contract was changed to use Joda instead
  of java.util.Date
* For now we are holding off from migrating to
  Java 8 time handling completely