### PR TITLE
MOTECH-1412: Flyway migrations can run after MDS generates entity schema

### DIFF
--- a/docs/source/get_started/model_data/model_data.rst
+++ b/docs/source/get_started/model_data/model_data.rst
@@ -1961,6 +1961,17 @@ In the Task module, you can also use Data Services as a channel and select an ac
                     :alt: MDS Actions
                     :align: center
 
+
+###################
+Entities Migrations
+###################
+
+In MDS you can use flyway migrations. These migrations will run after entities schema generation. MOTECH will automatically
+copy migration files from installed modules to the :code:`.motech` directory. Files should be placed in :code:`db/migration/default`
+directory(if you are using mysql then use :code:`mysql` instead :code:`default`) in the bundle. Each file muse have
+`a proper name <http://flywaydb.org/documentation/migration/sql.html>`_(e.g. :code:`V1__Description.sql`).
+
+
 #######
 Javadoc
 #######

--- a/platform/mds/mds/pom.xml
+++ b/platform/mds/mds/pom.xml
@@ -32,11 +32,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>motech-platform-commons-sql</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>motech-platform-osgi-web-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -57,6 +52,11 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>motech-platform-config-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>motech-platform-commons-sql</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/MDSInitializer.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/MDSInitializer.java
@@ -1,5 +1,7 @@
 package org.motechproject.mds;
 
+import org.apache.commons.io.FileUtils;
+import org.motechproject.mds.config.MdsConfig;
 import org.motechproject.mds.osgi.EntitiesBundleMonitor;
 import org.motechproject.mds.osgi.MdsBundleWatcher;
 import org.motechproject.mds.osgi.MdsWeavingHook;
@@ -14,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 
@@ -33,10 +36,18 @@ public class MDSInitializer {
     private MdsWeavingHook mdsWeavingHook;
     private EntitiesBundleMonitor monitor;
     private EventAdmin eventAdmin;
+    private MdsConfig mdsConfig;
 
     @PostConstruct
     public void initMDS() throws IOException {
         LOGGER.info("Initializing MOTECH Data Services");
+
+        //we must delete old migration files
+        File migrationDirectory = mdsConfig.getFlywayMigrationDirectory();
+        if (migrationDirectory.exists()) {
+            FileUtils.cleanDirectory(migrationDirectory);
+        }
+        LOGGER.info("Migration directory cleared");
 
         // First register the weaving hook
         bundleContext.registerService(WeavingHook.class.getName(), mdsWeavingHook, null);
@@ -88,4 +99,10 @@ public class MDSInitializer {
     public void setMonitor(EntitiesBundleMonitor monitor) {
         this.monitor = monitor;
     }
+
+    @Autowired
+    public void setMdsConfig(MdsConfig mdsConfig) {
+        this.mdsConfig = mdsConfig;
+    }
+
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/config/MdsConfig.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/config/MdsConfig.java
@@ -7,6 +7,7 @@ import org.motechproject.mds.util.Constants;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -98,6 +99,14 @@ public class MdsConfig {
     public String getFlywayLocations() {
         String driverName = sqlDBManager.getChosenSQLDriver();
         return driverName.equals(Constants.Config.MYSQL_DRIVER_CLASSNAME) ? FLYWAY_MYSQL_MIGRATION_PATH : FLYWAY_DEFAULT_MIGRATION_PATH;
+    }
+
+    public File getFlywayMigrationDirectory() {
+        String flywayLocation = getFlywayLocations();
+        File migrationDirectory = new File(System.getProperty("user.home"), Constants.EntitiesMigration.MIGRATION_DIRECTORY);
+        migrationDirectory = new File(migrationDirectory, flywayLocation.substring(flywayLocation.lastIndexOf('/') + 1));
+
+        return migrationDirectory;
     }
 
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/MigrationMapping.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/MigrationMapping.java
@@ -1,0 +1,60 @@
+package org.motechproject.mds.domain;
+
+import javax.jdo.annotations.IdGeneratorStrategy;
+import javax.jdo.annotations.IdentityType;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+
+/**
+ * The <code>MigrationMapping</code> class contains information about flyway migrations
+ * from modules(It maps module migration version to the flyway migration version).
+ */
+@PersistenceCapable(identityType = IdentityType.DATASTORE)
+public class MigrationMapping {
+
+    @PrimaryKey
+    @Persistent(valueStrategy = IdGeneratorStrategy.INCREMENT)
+    private Integer flywayMigrationVersion;
+
+    @Persistent
+    private Integer moduleMigrationVersion;
+
+    @Persistent
+    private String moduleName;
+
+
+    public MigrationMapping() {
+        this(null, null);
+    }
+
+    public MigrationMapping(String moduleName, Integer moduleMigrationVersion) {
+        this.moduleName = moduleName;
+        this.moduleMigrationVersion = moduleMigrationVersion;
+    }
+
+    public Integer getFlywayMigrationVersion() {
+        return flywayMigrationVersion;
+    }
+
+    public void setFlywayMigrationVersion(Integer flywayMigrationVersion) {
+        this.flywayMigrationVersion = flywayMigrationVersion;
+    }
+
+    public Integer getModuleMigrationVersion() {
+        return moduleMigrationVersion;
+    }
+
+    public void setModuleMigrationVersion(Integer moduleMigrationVersion) {
+        this.moduleMigrationVersion = moduleMigrationVersion;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllMigrationMappings.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/repository/AllMigrationMappings.java
@@ -1,0 +1,21 @@
+package org.motechproject.mds.repository;
+
+import org.motechproject.mds.domain.MigrationMapping;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The <code>AllMigrationMappings</code> class is a repository class that operates on instances of
+ * {@link org.motechproject.mds.domain.MigrationMapping}.
+ */
+@Repository
+public class AllMigrationMappings extends MotechDataRepository<MigrationMapping> {
+
+    public AllMigrationMappings() {
+        super(MigrationMapping.class);
+    }
+
+    public MigrationMapping retrieveByModuleAndMigrationVersion(String moduleName, Integer version) {
+        return retrieve(new String[] {"moduleName", "moduleMigrationVersion"}, new Object[] {moduleName, version});
+    }
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/MigrationService.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/MigrationService.java
@@ -1,0 +1,25 @@
+package org.motechproject.mds.service;
+
+import org.osgi.framework.Bundle;
+
+import java.io.IOException;
+
+/**
+ * This interface provides method for finding flyway migrations within bundle.
+ * Default search location is db/migration.
+ *
+ * @see org.motechproject.mds.jdo.SchemaGenerator
+ * @see org.motechproject.mds.domain.MigrationMapping
+ */
+public interface MigrationService {
+
+    /**
+     * Finds migration files in the given bundle and copy them to the
+     * .motech/migration directory. This method also updates migration mapping.
+     *
+     * @param bundle the bundle to process.
+     * @throws IOException if an I/O error occurs while copying migration files.
+     */
+    void processBundle(Bundle bundle) throws IOException;
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
@@ -3,7 +3,6 @@ package org.motechproject.mds.service.impl;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.motechproject.mds.config.MdsConfig;
 import org.motechproject.mds.domain.MigrationMapping;
 import org.motechproject.mds.repository.AllMigrationMappings;
@@ -18,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -74,7 +74,7 @@ public class MigrationServiceImpl implements MigrationService {
                     try (InputStream inputStream = bundle.getResource(resourcePath).openStream()) {
                         LOGGER.debug("Creating new migration file with name {}, for {} bundle", newFileName, bundle.getSymbolicName());
                         File migrationFile = new File(migrationDirectory.getAbsolutePath(), newFileName);
-                        FileUtils.copyInputStreamToFile(inputStream, migrationFile);
+                        Files.copy(inputStream, migrationFile.toPath());
                     }
                 }
             }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
@@ -74,6 +74,7 @@ public class MigrationServiceImpl implements MigrationService {
                     try (InputStream inputStream = bundle.getResource(resourcePath).openStream()) {
                         LOGGER.debug("Creating new migration file with name {}, for {} bundle", newFileName, bundle.getSymbolicName());
                         File migrationFile = new File(migrationDirectory.getAbsolutePath(), newFileName);
+                        Files.createDirectories(migrationDirectory.toPath());
                         Files.copy(inputStream, migrationFile.toPath());
                     }
                 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/MigrationServiceImpl.java
@@ -1,0 +1,98 @@
+package org.motechproject.mds.service.impl;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.motechproject.mds.config.MdsConfig;
+import org.motechproject.mds.domain.MigrationMapping;
+import org.motechproject.mds.repository.AllMigrationMappings;
+import org.motechproject.mds.service.MigrationService;
+import org.motechproject.mds.util.Constants;
+import org.osgi.framework.Bundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+
+/**
+ * Default implementation of {@link org.motechproject.mds.service.MigrationService} interface.
+ */
+@Service
+public class MigrationServiceImpl implements MigrationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationServiceImpl.class);
+
+    @Autowired
+    private AllMigrationMappings allMigrationMappings;
+
+    @Autowired
+    private MdsConfig mdsConfig;
+
+    @Override
+    public void processBundle(Bundle bundle) throws IOException {
+        LOGGER.debug("Starting to process {} bundle", bundle.getSymbolicName());
+        String flywayLocation = mdsConfig.getFlywayLocations();
+
+        if (bundle.getEntryPaths(flywayLocation) == null) {
+            return;
+        }
+
+        Collection<String> migrationFiles = Collections2.filter(
+                Collections.list(bundle.getEntryPaths(flywayLocation)),
+                new Predicate<String>() {
+                    @Override
+                    public boolean apply(String o) {
+                        return o.substring(o.lastIndexOf('/') + 1).matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN);
+                    }
+                }
+        );
+
+        if (CollectionUtils.isNotEmpty(migrationFiles)) {
+            LOGGER.debug("Bundle {} contains {} migrations files", bundle.getSymbolicName(), migrationFiles.size());
+            File migrationDirectory = mdsConfig.getFlywayMigrationDirectory();
+
+            for (String resourcePath : migrationFiles) {
+                Integer migrationVersion = getMigrationsVersion(resourcePath);
+                MigrationMapping migrationInfo = allMigrationMappings.retrieveByModuleAndMigrationVersion(bundle.getSymbolicName(),
+                        migrationVersion);
+
+                //we must copy migration file
+                if (migrationInfo == null) {
+                    migrationInfo = new MigrationMapping(bundle.getSymbolicName(), migrationVersion);
+                    migrationInfo = allMigrationMappings.create(migrationInfo);
+                    String orginalFileName = resourcePath.substring(resourcePath.lastIndexOf('/') + 1);
+                    String newFileName = generateFlywayMigrationFileName(migrationInfo, orginalFileName);
+
+                    try (InputStream inputStream = bundle.getResource(resourcePath).openStream()) {
+                        LOGGER.debug("Creating new migration file with name {}, for {} bundle", newFileName, bundle.getSymbolicName());
+                        File migrationFile = new File(migrationDirectory.getAbsolutePath(), newFileName);
+                        FileUtils.copyInputStreamToFile(inputStream, migrationFile);
+                    }
+                }
+            }
+        }
+    }
+
+    private String generateFlywayMigrationFileName(MigrationMapping migrationMapping, String orginalFileName) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(Constants.EntitiesMigration.ENTITY_MIGRATIONS_PREFIX).append(migrationMapping.getFlywayMigrationVersion()
+                + Constants.EntitiesMigration.MIGRATION_VERSION_OFFSET);
+        stringBuilder.append("__");
+        stringBuilder.append(orginalFileName.substring(orginalFileName.indexOf('_') + 2));
+        return stringBuilder.toString();
+    }
+
+    private Integer getMigrationsVersion(String resourcePath) {
+        String fileName = resourcePath.substring(resourcePath.lastIndexOf('/') + 1);
+        return Integer.valueOf(fileName.substring(1, fileName.indexOf('_')));
+    }
+
+}

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/util/Constants.java
@@ -562,6 +562,22 @@ public final class Constants {
         public static final int INFINITE = -1;
     }
 
+    /**
+     *  Constants corresponding to the entities migrations.
+     */
+    public static final class EntitiesMigration {
+
+        public static final String ENTITY_MIGRATIONS_PREFIX = "M";
+
+        public static final int MIGRATION_VERSION_OFFSET = 10000;
+
+        public static final String MIGRATION_FILE_NAME_PATTERN = "^V[1-9]{1}[0-9]*__[a-zA-Z0-9\\-_ ]*\\.sql$";
+
+        public static final String MIGRATION_DIRECTORY = "/.motech/migration";
+
+        public static final String FILESYSTEM_PREFIX = "filesystem:";
+    }
+
     private Constants() {
     }
 }

--- a/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
+++ b/platform/mds/mds/src/main/resources/META-INF/motech/mdsContext.xml
@@ -40,6 +40,8 @@
             <bean factory-bean="mdsConfig" factory-method="getFlywayLocations" />
         </property>
         <property name="placeholderPrefix" value="$flyway{"/>
+        <property name="sqlMigrationPrefix" value="V"/>
+        <property name="outOfOrder" value="true"/>
         <property name="initOnMigrate" value="true"/>
     </bean>
 

--- a/platform/mds/mds/src/main/resources/db/migration/default/V36__MOTECH-1412.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V36__MOTECH-1412.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "MigrationMapping" (
+  "flywayMigrationVersion" int NOT NULL,
+  "moduleMigrationVersion" int NOT NULL,
+  "moduleName" varchar(255) NOT NULL,
+  PRIMARY KEY ("flywayMigrationVersion")
+);

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V36__MOTECH-1412.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V36__MOTECH-1412.sql
@@ -1,0 +1,6 @@
+CREATE TABLE MigrationMapping (
+  flywayMigrationVersion int NOT NULL,
+  moduleMigrationVersion int NOT NULL,
+  moduleName varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  PRIMARY KEY (flywayMigrationVersion)
+);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/jdo/SchemaGeneratorTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/jdo/SchemaGeneratorTest.java
@@ -47,7 +47,7 @@ public class SchemaGeneratorTest {
         when(pmf.getNucleusContext()).thenReturn(nucleusContext);
         when(nucleusContext.getStoreManager()).thenReturn(storeManager);
 
-        schemaGenerator.afterPropertiesSet();
+        schemaGenerator.generateSchema();
 
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
         verify((SchemaAwareStoreManager) storeManager).createSchema(captor.capture(), eq(new Properties()));

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MigrationServiceTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MigrationServiceTest.java
@@ -1,0 +1,166 @@
+package org.motechproject.mds.service.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.mds.config.MdsConfig;
+import org.motechproject.mds.domain.MigrationMapping;
+import org.motechproject.mds.repository.AllMigrationMappings;
+import org.motechproject.mds.service.MigrationService;
+import org.motechproject.mds.util.Constants;
+import org.osgi.framework.Bundle;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Vector;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MigrationServiceTest {
+
+    @InjectMocks
+    MigrationService migrationService = new MigrationServiceImpl();
+
+    @Mock
+    Bundle bundle;
+
+    @Mock
+    MdsConfig mdsConfig;
+
+    @Mock
+    AllMigrationMappings allMigrationMappings;
+
+    @Mock
+    InputStream inputStream;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void migrationFileNameRegexTest() {
+        assertTrue("V1__MOTECH-1720.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertTrue("V113__Test1.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertTrue("V1__Test1.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertFalse("V17__sample.".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertFalse("V02__T1.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertFalse("M10__Mig1.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+        assertFalse("V103_Test1.sql".matches(Constants.EntitiesMigration.MIGRATION_FILE_NAME_PATTERN));
+    }
+
+    @Test
+    public void shouldProcessBundleAndCopyMigrationFiles() throws IOException {
+        String migrationsDirectory = System.getProperty("user.home") + Constants.EntitiesMigration.MIGRATION_DIRECTORY + "/mysql/";
+        File migrationFile1 = new File(migrationsDirectory + "M10013__Test1.sql");
+        File migrationFile2 = new File(migrationsDirectory + "M10014__Test2.sql");
+        File migrationFile3 = new File(migrationsDirectory + "M10015__Test3.sql");
+        deleteFiles(new File[] {migrationFile1, migrationFile2, migrationFile3});
+
+        assertFalse(migrationFile1.exists());
+        assertFalse(migrationFile2.exists());
+        assertFalse(migrationFile3.exists());
+
+        URL url = new ClassPathResource("migration/V1__Test1.sql").getURL();
+        List<String> paths = new ArrayList<>();
+        paths.add("db/migration/mysql/V1__Test1.sql");
+        paths.add("db/migration/mysql/V2__Test2.sql");
+        paths.add("db/migration/mysql/V3__Test3.sql");
+        Enumeration<String> enumeration = new Vector<>(paths).elements();
+
+        MigrationMapping migrationInfo1 = new MigrationMapping("testModule", 1);
+        MigrationMapping migrationInfo2 = new MigrationMapping("testModule", 2);
+        MigrationMapping migrationInfo3 = new MigrationMapping("testModule", 3);
+        MigrationMapping newMigrationInfo1 = new MigrationMapping("testModule", 1);
+        MigrationMapping newMigrationInfo2 = new MigrationMapping("testModule", 2);
+        MigrationMapping newMigrationInfo3 = new MigrationMapping("testModule", 3);
+
+        newMigrationInfo1.setFlywayMigrationVersion(13);
+        newMigrationInfo2.setFlywayMigrationVersion(14);
+        newMigrationInfo3.setFlywayMigrationVersion(15);
+
+        when(mdsConfig.getFlywayLocations()).thenReturn(new String[]{"db/migration/mysql"});
+        when(mdsConfig.getFlywayMigrationDirectory()).thenReturn(new File(migrationsDirectory));
+        when(bundle.getEntryPaths(anyString())).thenReturn(enumeration);
+        when(bundle.getSymbolicName()).thenReturn("testModule");
+        when(bundle.getResource(anyString())).thenReturn(url);
+
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 1)).thenReturn(null);
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 2)).thenReturn(null);
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 3)).thenReturn(null);
+
+        when(allMigrationMappings.create(argThat(new MigrationMappingMatcher(migrationInfo1)))).thenReturn(newMigrationInfo1);
+        when(allMigrationMappings.create(argThat(new MigrationMappingMatcher(migrationInfo2)))).thenReturn(newMigrationInfo2);
+        when(allMigrationMappings.create(argThat(new MigrationMappingMatcher(migrationInfo3)))).thenReturn(newMigrationInfo3);
+
+        migrationService.processBundle(bundle);
+
+        assertTrue(migrationFile1.exists());
+        assertTrue(migrationFile2.exists());
+        assertTrue(migrationFile3.exists());
+        verify(allMigrationMappings, times(3)).create(Matchers.<MigrationMapping>anyObject());
+
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 1)).thenReturn(migrationInfo1);
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 2)).thenReturn(migrationInfo2);
+        when(allMigrationMappings.retrieveByModuleAndMigrationVersion("testModule", 3)).thenReturn(migrationInfo3);
+
+        migrationService.processBundle(bundle);
+
+        verify(allMigrationMappings, times(3)).create(Matchers.<MigrationMapping>anyObject());
+        deleteFiles(new File[] {migrationFile1, migrationFile2, migrationFile3});
+    }
+
+    private void deleteFiles(File[] files) {
+        for (File file : files) {
+            if (file.exists()) {
+                file.delete();
+            }
+        }
+    }
+
+    private class MigrationMappingMatcher extends ArgumentMatcher<MigrationMapping> {
+
+        private MigrationMapping migrationMapping;
+
+        public MigrationMappingMatcher(MigrationMapping migrationMapping) {
+            super();
+            this.migrationMapping = migrationMapping;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            if (o == null) {
+                return false;
+            }
+            MigrationMapping mapping = (MigrationMapping) o;
+            if (!StringUtils.equals(mapping.getModuleName(), migrationMapping.getModuleName())) {
+                return false;
+            }
+            if (!mapping.getModuleMigrationVersion().equals(migrationMapping.getModuleMigrationVersion())) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+}

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MigrationServiceTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/MigrationServiceTest.java
@@ -99,7 +99,7 @@ public class MigrationServiceTest {
         newMigrationInfo2.setFlywayMigrationVersion(14);
         newMigrationInfo3.setFlywayMigrationVersion(15);
 
-        when(mdsConfig.getFlywayLocations()).thenReturn(new String[]{"db/migration/mysql"});
+        when(mdsConfig.getFlywayLocations()).thenReturn("db/migration/mysql");
         when(mdsConfig.getFlywayMigrationDirectory()).thenReturn(new File(migrationsDirectory));
         when(bundle.getEntryPaths(anyString())).thenReturn(enumeration);
         when(bundle.getSymbolicName()).thenReturn("testModule");

--- a/platform/mds/mds/src/test/resources/migration/V1__Test1.sql
+++ b/platform/mds/mds/src/test/resources/migration/V1__Test1.sql
@@ -1,0 +1,1 @@
+CREATE TABLE testTable (id bigint(20) NOT NULL);


### PR DESCRIPTION
The so called "module migrations" allow modules to define migrations, that run after MDS generates tables backing up created entities. The modules should expose their migrations in their resource directory, under db/migrations/(default/mysql). Those migrations will be copied to the .motech directory and ran after MDS generates schema.