### PR TITLE
MOTECH-2111: Changes color in the error screen to red

### DIFF
--- a/ui/src/css/index.css
+++ b/ui/src/css/index.css
@@ -120,17 +120,6 @@ a:active, a:hover, a:focus {
     vertical-align:bottom;
 }
 
-.header-nav {
-    display: block;
-    margin: 0 0 10px 0;
-    padding: 0;
-    color: #fff;
-    line-height: 20px;
-    font-size: 15px;
-    background: #073863;
-    border: none;
-}
-
 .dropdown ul li a,.dropdown ul li {
     font-size: 13px;
 }


### PR DESCRIPTION
There are two exactly the same styles in index.css and bootstrap-page.css.
It means that after building we've got duplicate style in motech.css.
Because of that in the error page there is a problem with overridding this style.
It looks like a background color of the first one is overridden, however the
second duplicated is not. It's why we can see blue color instead of red.

This commit fixes this bug.