### PR TITLE
MOTECH-2105 IE9 CSS Breaking

### DIFF
--- a/ui/gulpfile.js/tasks/css.js
+++ b/ui/gulpfile.js/tasks/css.js
@@ -2,6 +2,7 @@ var config = require('../config');
 var gulp = require('gulp');
 var lib = require('bower-files')();
 var concat = require('gulp-concat');
+var bless = require('gulp-bless');
 var path = require('path');
 
 var paths = {
@@ -14,5 +15,6 @@ gulp.task('css', function () {
     files.push(paths.src);
     gulp.src(files)
         .pipe(concat('motech.css'))
+        .pipe(bless())
         .pipe(gulp.dest(paths.dest));
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "bower": "~1.6.8",
     "gulp": "^3.9.0",
+    "gulp-bless": "^3.0.1",
     "gulp-concat": "~2.6.0",
     "gulp-rename": "~1.2.2",
     "gulp-sequence": "~0.4.1",


### PR DESCRIPTION
CSS styles in IE9 were breaking because there were too many selectors in the CSS file. BlessCss is able to split the css files properly.