### PR TITLE
MOTECH-2057: Prevent saving "null" String in settings

### DIFF
--- a/modules/admin/src/main/java/org/motechproject/admin/internal/service/impl/SettingsServiceImpl.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/internal/service/impl/SettingsServiceImpl.java
@@ -154,7 +154,8 @@ public class SettingsServiceImpl implements SettingsService {
     @Override
     public void savePlatformSettings(Settings settings) {
         for (SettingsOption option : settings.getSettings()) {
-            configurationService.setPlatformSetting(option.getKey(), String.valueOf(option.getValue()));
+            Object val = option.getValue();
+            configurationService.setPlatformSetting(option.getKey(), val == null ? null : String.valueOf(val));
         }
 
         Map<String, Object> params = new HashMap<>();

--- a/modules/admin/src/main/java/org/motechproject/admin/settings/SettingsOption.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/settings/SettingsOption.java
@@ -44,7 +44,11 @@ public class SettingsOption {
     }
 
     public SettingsOption(Map.Entry<Object, Object> entry) {
-        this.value = entry.getValue();
-        this.key = String.valueOf(entry.getKey());
+        this(String.valueOf(entry.getKey()), entry.getValue());
+    }
+
+    public SettingsOption(String key, Object value) {
+        this.value = value;
+        this.key = key;
     }
 }

--- a/modules/admin/src/test/java/org/motechproject/admin/internal/service/impl/SettingsServiceTest.java
+++ b/modules/admin/src/test/java/org/motechproject/admin/internal/service/impl/SettingsServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.security.web.savedrequest.Enumerator;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -117,9 +117,9 @@ public class SettingsServiceTest {
 
     @Test
     public void testSaveBundleSettings() throws IOException {
-        SettingsOption option = new SettingsOption(new AbstractMap.SimpleEntry<Object, Object>(OPTION_KEY, OPTION_VALUE));
+        SettingsOption option = new SettingsOption(OPTION_KEY, OPTION_VALUE);
 
-        Settings settings = new Settings(BUNDLE_FILENAME, asList(option));
+        Settings settings = new Settings(BUNDLE_FILENAME, singletonList(option));
         settingsService.saveBundleSettings(settings, BUNDLE_ID);
 
         verify(configurationService).addOrUpdateProperties(BUNDLE_SYMBOLIC_NAME, "", BUNDLE_FILENAME, bundleProperty, null);
@@ -132,6 +132,16 @@ public class SettingsServiceTest {
         InOrder inOrder = inOrder(configurationService, configFileMonitor);
         inOrder.verify(configurationService).updateConfigLocation(path);
         inOrder.verify(configFileMonitor).updateFileMonitor();
+    }
+
+    @Test
+    public void shouldSaveNullSettingAsNullValue() {
+        SettingsOption option = new SettingsOption(OPTION_KEY, null);
+        Settings settings = new Settings("section", singletonList(option));
+
+        settingsService.savePlatformSettings(settings);
+
+        verify(configurationService).setPlatformSetting(OPTION_KEY, null);
     }
 
     private void initConfigService() throws IOException {


### PR DESCRIPTION
* Check for null
* Added a contructor to SettingsOptions (why should we need to use a
map entry?)