### PR TITLE
MOTECH-2103: Improves grid selection fields mechanism

### DIFF
--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/Field.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.motechproject.mds.util.Constants.Util.TRUE;
@@ -626,5 +627,27 @@ public class Field {
 
     public void setUiChanged(boolean uiChanged) {
         this.uiChanged = uiChanged;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, displayName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        Field other = (Field) obj;
+
+        return Objects.equals(this.id, other.id) &&
+                Objects.equals(this.name, other.name) &&
+                Objects.equals(this.displayName, other.displayName);
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/domain/UserPreferences.java
@@ -9,8 +9,8 @@ import javax.jdo.annotations.Join;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The <code>UserPreferences</code> class contains information about an entity user preferences. For example grid size
@@ -33,17 +33,17 @@ public class UserPreferences {
     @Persistent(defaultFetchGroup = "true")
     @Join
     @Element(column = "selectedField",  deleteAction = ForeignKeyAction.CASCADE)
-    private List<Field> selectedFields;
+    private Set<Field> selectedFields;
 
     @Persistent(defaultFetchGroup = "true")
     @Join
     @Element(column = "unselectedField",  deleteAction = ForeignKeyAction.CASCADE)
-    private List<Field> unselectedFields;
+    private Set<Field> unselectedFields;
 
     public UserPreferences() {
     }
 
-    public UserPreferences(String username, String className, Integer gridRowsNumber, List<Field> selectedFields, List<Field> unselectedFields) {
+    public UserPreferences(String username, String className, Integer gridRowsNumber, Set<Field> selectedFields, Set<Field> unselectedFields) {
         this.username = username;
         this.className = className;
         this.gridRowsNumber = gridRowsNumber;
@@ -75,33 +75,32 @@ public class UserPreferences {
         this.gridRowsNumber = gridRowsNumber;
     }
 
-    public List<Field> getSelectedFields() {
+    public Set<Field> getSelectedFields() {
         if (selectedFields == null) {
-            return new ArrayList<>();
+            return new HashSet<>();
         }
         return selectedFields;
     }
 
-    public void setSelectedFields(List<Field> selectedFields) {
+    public void setSelectedFields(Set<Field> selectedFields) {
         this.selectedFields = selectedFields;
     }
 
-
-    public List<Field> getUnselectedFields() {
+    public Set<Field> getUnselectedFields() {
         if (unselectedFields == null) {
-            return new ArrayList<>();
+            return new HashSet<>();
         }
         return unselectedFields;
     }
 
-    public void setUnselectedFields(List<Field> unselectedFields) {
+    public void setUnselectedFields(Set<Field> unselectedFields) {
         this.unselectedFields = unselectedFields;
     }
 
-    public UserPreferencesDto toDto(List<String> displayableFields) {
-        List<String> mergedFields = new ArrayList<>(displayableFields);
-        List<String> selected = new ArrayList<>();
-        List<String> unselected = new ArrayList<>();
+    public UserPreferencesDto toDto(Set<String> displayableFields) {
+        Set<String> mergedFields = new HashSet<>(displayableFields);
+        Set<String> selected = new HashSet<>();
+        Set<String> unselected = new HashSet<>();
 
         for (Field field : getUnselectedFields()) {
             if (mergedFields.contains(field.getName())) {
@@ -122,11 +121,11 @@ public class UserPreferences {
 
     public void selectField(Field field) {
         if (selectedFields == null) {
-            selectedFields = new ArrayList<>();
+            selectedFields = new HashSet<>();
         }
         selectedFields.add(field);
 
-        // if field is selected then we must remove it from unselected list
+        // if field is selected then we must remove it from unselected
         if (unselectedFields != null && unselectedFields.contains(field)) {
             unselectedFields.remove(field);
         }
@@ -134,11 +133,11 @@ public class UserPreferences {
 
     public void unselectField(Field field) {
         if (unselectedFields == null) {
-            unselectedFields = new ArrayList<>();
+            unselectedFields = new HashSet<>();
         }
         unselectedFields.add(field);
 
-        // if field is unselected then we must remove it from selected list
+        // if field is unselected then we must remove it from selected
         if (selectedFields != null && selectedFields.contains(field)) {
             selectedFields.remove(field);
         }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/UserPreferencesDto.java
@@ -1,6 +1,6 @@
 package org.motechproject.mds.dto;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * The <code>UserPreferencesDto</code> contains information about user preferences of an entity.
@@ -23,22 +23,22 @@ public class UserPreferencesDto {
     private Integer gridRowsNumber;
 
     /**
-     * The list of the fields which will be displayed on the UI. It is constructed from selected fields, unselected fields
+     * The set of the fields which will be displayed on the UI. It is constructed from selected fields, unselected fields
      * and advance settings of the entity.
      */
-    private List<String> visibleFields;
+    private Set<String> visibleFields;
 
     /**
-     * The list of the selected fields.
+     * The set of the selected fields.
      */
-    private List<String> selectedFields;
+    private Set<String> selectedFields;
 
     /**
-     * The list of the unselected fields.
+     * The set of the unselected fields.
      */
-    private List<String> unselectedFields;
+    private Set<String> unselectedFields;
 
-    public UserPreferencesDto(String className, String username, Integer gridRowsNumber, List<String> visibleFields, List<String> selectedFields, List<String> unselectedFields) {
+    public UserPreferencesDto(String className, String username, Integer gridRowsNumber, Set<String> visibleFields, Set<String> selectedFields, Set<String> unselectedFields) {
         this.className = className;
         this.username = username;
         this.gridRowsNumber = gridRowsNumber;
@@ -55,11 +55,11 @@ public class UserPreferencesDto {
         this.gridRowsNumber = gridRowsNumber;
     }
 
-    public List<String> getVisibleFields() {
+    public Set<String> getVisibleFields() {
         return visibleFields;
     }
 
-    public void setVisibleFields(List<String> visibleFields) {
+    public void setVisibleFields(Set<String> visibleFields) {
         this.visibleFields = visibleFields;
     }
 
@@ -79,19 +79,19 @@ public class UserPreferencesDto {
         this.className = className;
     }
 
-    public List<String> getSelectedFields() {
+    public Set<String> getSelectedFields() {
         return selectedFields;
     }
 
-    public void setSelectedFields(List<String> selectedFields) {
+    public void setSelectedFields(Set<String> selectedFields) {
         this.selectedFields = selectedFields;
     }
 
-    public List<String> getUnselectedFields() {
+    public Set<String> getUnselectedFields() {
         return unselectedFields;
     }
 
-    public void setUnselectedFields(List<String> unselectedFields) {
+    public void setUnselectedFields(Set<String> unselectedFields) {
         this.unselectedFields = unselectedFields;
     }
 }

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/EntityServiceImpl.java
@@ -469,10 +469,10 @@ public class EntityServiceImpl implements EntityService {
         }
     }
 
-    private List<Field> getFieldsForPreferences(Entity parent, EntityDraft draft, List<String> oldList) {
-        List<Field> newFields = new ArrayList<>();
+    private Set<Field> getFieldsForPreferences(Entity parent, EntityDraft draft, Set<String> oldFields) {
+        Set<Field> newFields = new HashSet<>();
 
-        for (String field : oldList) {
+        for (String field : oldFields) {
 
             String name = field;
             if (draft.getFieldNameChanges().containsKey(name)) {

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/service/impl/UserPreferencesServiceImpl.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Implementation of the {@link org.motechproject.mds.service.UserPreferencesService}.
@@ -34,7 +36,7 @@ public class UserPreferencesServiceImpl implements UserPreferencesService {
         Entity entity = getEntity(id);
         List<UserPreferences> userPreferences =  allUserPreferences.retrieveByClassName(entity.getClassName());
         List<UserPreferencesDto> dtos = new ArrayList<>();
-        List<String> displayableFields = getDisplayableFields(entity);
+        Set<String> displayableFields = getDisplayableFields(entity);
 
         if (userPreferences != null) {
             Integer defaultGridSize = settingsService.getGridSize();
@@ -116,10 +118,10 @@ public class UserPreferencesServiceImpl implements UserPreferencesService {
         UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
         userPreferences = checkPreferences(userPreferences, entity, username);
 
-        List<Field> fields = new ArrayList<>();
+        Set<Field> fields = new HashSet<>();
         fields.addAll(entity.getFields());
         userPreferences.setSelectedFields(fields);
-        userPreferences.setUnselectedFields(new ArrayList<Field>());
+        userPreferences.setUnselectedFields(new HashSet<Field>());
 
         allUserPreferences.update(userPreferences);
     }
@@ -131,10 +133,10 @@ public class UserPreferencesServiceImpl implements UserPreferencesService {
         UserPreferences userPreferences =  allUserPreferences.retrieveByClassNameAndUsername(entity.getClassName(), username);
         userPreferences = checkPreferences(userPreferences, entity, username);
 
-        List<Field> fields = new ArrayList<>();
+        Set<Field> fields = new HashSet<>();
         fields.addAll(entity.getFields());
         userPreferences.setUnselectedFields(fields);
-        userPreferences.setSelectedFields(new ArrayList<Field>());
+        userPreferences.setSelectedFields(new HashSet<Field>());
 
         allUserPreferences.update(userPreferences);
     }
@@ -164,8 +166,8 @@ public class UserPreferencesServiceImpl implements UserPreferencesService {
         return entity;
     }
 
-    private List<String> getDisplayableFields(Entity entity) {
-        List<String> displayFields = new ArrayList<>();
+    private Set<String> getDisplayableFields(Entity entity) {
+        Set<String> displayFields = new HashSet<>();
         for (Field field : entity.getFields()) {
             if (field.isUIDisplayable() && !field.isNonDisplayable()) {
                 displayFields.add(field.getName());
@@ -177,7 +179,7 @@ public class UserPreferencesServiceImpl implements UserPreferencesService {
 
     private UserPreferences checkPreferences(UserPreferences userPreferences, Entity entity, String username) {
         if (userPreferences == null) {
-            return allUserPreferences.create(new UserPreferences(username, entity.getClassName(), null, new ArrayList<Field>(), new ArrayList<Field>()));
+            return allUserPreferences.create(new UserPreferences(username, entity.getClassName(), null, new HashSet<Field>(), new HashSet<Field>()));
         }
         return userPreferences;
     }

--- a/platform/mds/mds/src/main/resources/db/migration/default/V46__MOTECH-2103.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/default/V46__MOTECH-2103.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS "UserPreferences_selectedFields";
+DROP TABLE IF EXISTS "UserPreferences_unselectedFields";
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_selectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "selectedField" bigint,
+  PRIMARY KEY ("className_OID", "username_OID", "selectedField"),
+  CONSTRAINT "UserPreferences_selectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_selectedFields_FK2" FOREIGN KEY ("selectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS "UserPreferences_unselectedFields" (
+  "className_OID" varchar(255) NOT NULL,
+  "username_OID" varchar(255) NOT NULL,
+  "unselectedField" bigint,
+  PRIMARY KEY ("className_OID", "username_OID", "unselectedField"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK1" FOREIGN KEY ("username_OID", "className_OID") REFERENCES "UserPreferences" ("username", "className"),
+  CONSTRAINT "UserPreferences_unselectedFields_FK2" FOREIGN KEY ("unselectedField") REFERENCES "Field" ("id") ON DELETE CASCADE
+);

--- a/platform/mds/mds/src/main/resources/db/migration/mysql/V46__MOTECH-2103.sql
+++ b/platform/mds/mds/src/main/resources/db/migration/mysql/V46__MOTECH-2103.sql
@@ -1,0 +1,24 @@
+DROP TABLE IF EXISTS UserPreferences_selectedFields;
+DROP TABLE IF EXISTS UserPreferences_unselectedFields;
+
+CREATE TABLE IF NOT EXISTS UserPreferences_selectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  selectedField bigint(20),
+  PRIMARY KEY (className_OID, username_OID, selectedField),
+  KEY UserPreferences_selectedFields_N49 (selectedField),
+  KEY UserPreferences_selectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_visibleFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_visibleFields_FK2 FOREIGN KEY (selectedField) REFERENCES Field (id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS UserPreferences_unselectedFields (
+  className_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  username_OID varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL,
+  unselectedField bigint(20),
+  PRIMARY KEY (className_OID, username_OID, unselectedField),
+  KEY UserPreferences_unselectedFields_N49 (unselectedField),
+  KEY UserPreferences_unselectedFields_N50 (className_OID, username_OID),
+  CONSTRAINT UserPreferences_unselectedFields_FK1 FOREIGN KEY (className_OID, username_OID) REFERENCES UserPreferences (className, username),
+  CONSTRAINT UserPreferences_unselectedFields_FK2 FOREIGN KEY (unselectedField) REFERENCES Field (id) ON DELETE CASCADE
+);

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/it/service/EntityServiceContextIT.java
@@ -584,17 +584,26 @@ public class EntityServiceContextIT extends BaseIT {
         userPreferencesService.unselectField(entityId, "motech", "owner");
 
         UserPreferencesDto userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
-        assertEquals(asList( "f1name", "creator", "modifiedBy", "creationDate", "modificationDate"),
-                userPreferencesDto.getVisibleFields());
+        assertEquals(5, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("f1name"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("creator"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("modifiedBy"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("creationDate"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("modificationDate"));
 
         entityService.commitChanges(entityId);
 
         userPreferencesDto = userPreferencesService.getUserPreferences(entityId, "motech");
-        assertEquals(asList("newName", "creator", "modifiedBy", "creationDate", "modificationDate"),
-                userPreferencesDto.getVisibleFields());
+        assertEquals(5, userPreferencesDto.getVisibleFields().size());
+        assertTrue(userPreferencesDto.getVisibleFields().contains("newName"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("creator"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("modifiedBy"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("creationDate"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("modificationDate"));
 
-        assertEquals(asList("id", "owner"),
-                userPreferencesDto.getUnselectedFields());
+        assertEquals(2, userPreferencesDto.getUnselectedFields().size());
+        assertTrue(userPreferencesDto.getUnselectedFields().contains("id"));
+        assertTrue(userPreferencesDto.getUnselectedFields().contains("owner"));
     }
 
     private void assertRelatedField(EntityDto relatedEntity, FieldDto relatedField, String collection) {

--- a/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
+++ b/platform/mds/mds/src/test/java/org/motechproject/mds/service/impl/UserPreferencesServiceTest.java
@@ -21,10 +21,11 @@ import org.motechproject.mds.service.UserPreferencesService;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,10 +54,10 @@ public class UserPreferencesServiceTest {
     ArgumentCaptor<UserPreferences> userPreferencesCaptor;
 
     @Captor
-    ArgumentCaptor<List<Field>> selectedFieldsCaptor;
+    ArgumentCaptor<Set<Field>> selectedFieldsCaptor;
 
     @Captor
-    ArgumentCaptor<List<Field>> unselectedFieldsCaptor;
+    ArgumentCaptor<Set<Field>> unselectedFieldsCaptor;
 
     @Captor
     ArgumentCaptor<Field> fieldCaptor;
@@ -67,7 +68,7 @@ public class UserPreferencesServiceTest {
     @Before
     public void setUp() {
         when(settingsService.getGridSize()).thenReturn(20);
-        when(entity.getFields()).thenReturn(createFields());
+        when(entity.getFields()).thenReturn(new ArrayList<>(createFields()));
         when(entity.getClassName()).thenReturn(CLASS_NAME);
         when(allEntities.retrieveById(15l)).thenReturn(entity);
     }
@@ -90,9 +91,9 @@ public class UserPreferencesServiceTest {
 
     @Test
     public void shouldMergeFieldsInformation() {
-        List<Field> selectedFields = new ArrayList<>();
+        Set<Field> selectedFields = new HashSet<>();
         selectedFields.add(getField3());
-        List<Field> unselectedFields = new ArrayList<>();
+        Set<Field> unselectedFields = new HashSet<>();
         unselectedFields.add(getField2());
 
         UserPreferences preferences = new UserPreferences(USERNAME, CLASS_NAME, 20, selectedFields, unselectedFields);
@@ -105,11 +106,10 @@ public class UserPreferencesServiceTest {
         assertEquals(1, userPreferencesDto.getUnselectedFields().size());
         assertEquals(2, userPreferencesDto.getVisibleFields().size());
 
-        assertEquals("sampleField3", userPreferencesDto.getSelectedFields().get(0));
-        assertEquals("sampleField2", userPreferencesDto.getUnselectedFields().get(0));
-        assertEquals("sampleField1", userPreferencesDto.getVisibleFields().get(0));
-        assertEquals("sampleField3", userPreferencesDto.getVisibleFields().get(1));
-
+        assertTrue(userPreferencesDto.getSelectedFields().contains("sampleField3"));
+        assertTrue(userPreferencesDto.getUnselectedFields().contains("sampleField2"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("sampleField1"));
+        assertTrue(userPreferencesDto.getVisibleFields().contains("sampleField3"));
     }
 
     @Test
@@ -190,7 +190,7 @@ public class UserPreferencesServiceTest {
     public void shouldSelectFields() {
         when(allUserPreferences.retrieveByClassNameAndUsername(CLASS_NAME, USERNAME)).thenReturn(userPreferences);
         when(entity.getField("sampleField1")).thenReturn(getField1());
-        when(userPreferences.getSelectedFields()).thenReturn(new ArrayList<Field>());
+        when(userPreferences.getSelectedFields()).thenReturn(new HashSet<Field>());
 
         userPreferencesService.selectFields(15l, USERNAME);
 
@@ -198,13 +198,13 @@ public class UserPreferencesServiceTest {
         verify(userPreferences).setUnselectedFields(unselectedFieldsCaptor.capture());
         verify(allUserPreferences).update(userPreferences);
 
-        List<Field> fields = selectedFieldsCaptor.getValue();
+        Set<Field> fields = selectedFieldsCaptor.getValue();
         assertNotNull(fields);
         assertEquals(4, fields.size());
-        assertEquals("sampleField1", fields.get(0).getName());
-        assertEquals("sampleField2", fields.get(1).getName());
-        assertEquals("sampleField3", fields.get(2).getName());
-        assertEquals("sampleField4", fields.get(3).getName());
+        assertTrue(fields.contains(getField1()));
+        assertTrue(fields.contains(getField2()));
+        assertTrue(fields.contains(getField3()));
+        assertTrue(fields.contains(getField4()));
 
         fields = unselectedFieldsCaptor.getValue();
         assertNotNull(fields);
@@ -223,21 +223,21 @@ public class UserPreferencesServiceTest {
         verify(userPreferences).setSelectedFields(selectedFieldsCaptor.capture());
         verify(allUserPreferences).update(userPreferences);
 
-        List<Field> fields = unselectedFieldsCaptor.getValue();
+        Set<Field> fields = unselectedFieldsCaptor.getValue();
         assertNotNull(fields);
         assertEquals(4, fields.size());
-        assertEquals("sampleField1", fields.get(0).getName());
-        assertEquals("sampleField2", fields.get(1).getName());
-        assertEquals("sampleField3", fields.get(2).getName());
-        assertEquals("sampleField4", fields.get(3).getName());
+        assertTrue(fields.contains(getField1()));
+        assertTrue(fields.contains(getField2()));
+        assertTrue(fields.contains(getField3()));
+        assertTrue(fields.contains(getField4()));
 
         fields = selectedFieldsCaptor.getValue();
         assertNotNull(fields);
         assertEquals(0, fields.size());
     }
 
-    private List<Field> createFields() {
-        List<Field> fields = new ArrayList<>();
+    private Set<Field> createFields() {
+        Set<Field> fields = new HashSet<>();
         fields.add(getField1());
         fields.add(getField2());
         fields.add(getField3());


### PR DESCRIPTION
First of all, I changed collection type used in UserPreference for
selected/unselected fields. Now we use Set instead of List, which means
that we will not see duplicated rows in this tables.
Secondly, I have overridden hashCode() and equals() methods for Field class.
Now it should always properly remove Field objects from collection.