### PR TITLE
MOTECH-2113 Changed Select2 icon paths

### DIFF
--- a/ui/src/css/select2.css
+++ b/ui/src/css/select2.css
@@ -1,0 +1,26 @@
+/*
+Update icon paths for select2 library
+*/
+
+.select2-search input,
+.select2-search-choice-close,
+.select2-container .select2-choice abbr,
+.select2-container .select2-choice .select2-arrow b {
+    background-image: url('../img/select2.png') !important;
+}
+
+.select2-search input.select2-active,
+.select2-more-results.select2-active,
+.select2-container-multi .select2-choices .select2-search-field input.select2-active {
+    background-image: url('../img/select2-spinner.gif') !important;
+}
+
+/* Retina-ize icons */
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 2dppx) {
+    .select2-search input,
+    .select2-search-choice-close,
+    .select2-container .select2-choice abbr,
+    .select2-container .select2-choice .select2-arrow b {
+        background-image: url('../img/select2x2.png') !important;
+    }
+}


### PR DESCRIPTION
The CSS for Select2 was causing 404 errors because they requested icons that were located somewhere else. The new CSS file corrects those paths.