### PR TITLE
MOTECH-2175 Removed isolated scope on tasks droppable directive

### DIFF
--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -241,9 +241,6 @@
     directives.directive('droppable', function (ManageTaskUtils, $compile) {
         return {
             restrict: 'A',
-            scope: {
-              ngModel : '='
-            },
             link: function (scope, element, attrs) {
                 element.droppable({
                     drop: function (event, ui) {


### PR DESCRIPTION
A multiple isolated scope warning was showing up in the scheduler module. This was caused by the Droppable directive in the tasks module having an isolated scope (which it didnt even use).