### PR TITLE
MOTECH-2178: Fixed issue with readonly, hidden & auto-gen fields

### DIFF
--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/service/impl/InstanceServiceImpl.java
@@ -547,9 +547,16 @@ public class InstanceServiceImpl implements InstanceService {
 
     private void populateDefaultFields(List<FieldRecord> fieldRecords) {
         for (FieldRecord record : fieldRecords) {
+            // we don't want to pre-populate anything for hidden fields
+            // if we pre-populate the owner field in such a case for example, it will fail validation
             if (Constants.Util.CREATOR_FIELD_NAME.equals(record.getName()) ||
                     Constants.Util.OWNER_FIELD_NAME.equals(record.getName())) {
-                record.setValue(SecurityContextHolder.getContext().getAuthentication().getName());
+                if (record.isNonDisplayable()) {
+                    // make sure this is null, we don't want empty strings for these fields
+                    record.setValue(null);
+                } else {
+                    record.setValue(SecurityContextHolder.getContext().getAuthentication().getName());
+                }
             }
         }
     }

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
@@ -147,6 +147,38 @@ public class InstanceServiceTest {
     }
 
     @Test
+    public void shouldAutoPopulateOwnerAndCreator() {
+        when(entityService.getEntityFields(ENTITY_ID)).thenReturn(asList(
+                FieldTestHelper.fieldDto(1L, "owner", String.class.getName(), "String field", null),
+                FieldTestHelper.fieldDto(1L, "creator", String.class.getName(), "String field", null)
+        ));
+        mockEntity();
+        setUpSecurityContext();
+
+        EntityRecord record = instanceService.newInstance(ENTITY_ID);
+
+        List<FieldRecord> fieldRecords = record.getFields();
+        assertEquals(asList("motech", "motech"), extract(fieldRecords, on(FieldRecord.class).getValue()));
+    }
+
+    @Test
+    public void shouldNotAutoPopulateOwnerAndCreatorForHiddenFields() {
+        FieldDto ownerField = FieldTestHelper.fieldDto(1L, "owner", String.class.getName(), "String field", null);
+        ownerField.setNonDisplayable(true);
+        FieldDto creatorField = FieldTestHelper.fieldDto(1L, "creator", String.class.getName(), "String field", null);
+        creatorField.setNonDisplayable(true);
+
+        when(entityService.getEntityFields(ENTITY_ID)).thenReturn(asList(ownerField, creatorField));
+        mockEntity();
+        setUpSecurityContext();
+
+        EntityRecord record = instanceService.newInstance(ENTITY_ID);
+
+        List<FieldRecord> fieldRecords = record.getFields();
+        assertEquals(asList(null, null), extract(fieldRecords, on(FieldRecord.class).getValue()));
+    }
+
+    @Test
     public void shouldReturnEntityInstance() {
         mockDataService();
         mockSampleFields();

--- a/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
+++ b/platform/mds/mds-web/src/test/java/org/motechproject/mds/web/service/impl/InstanceServiceTest.java
@@ -148,7 +148,7 @@ public class InstanceServiceTest {
 
     @Test
     public void shouldAutoPopulateOwnerAndCreator() {
-        when(entityService.getEntityFields(ENTITY_ID)).thenReturn(asList(
+        when(entityService.getEntityFieldsForUI(ENTITY_ID)).thenReturn(asList(
                 FieldTestHelper.fieldDto(1L, "owner", String.class.getName(), "String field", null),
                 FieldTestHelper.fieldDto(1L, "creator", String.class.getName(), "String field", null)
         ));
@@ -168,7 +168,7 @@ public class InstanceServiceTest {
         FieldDto creatorField = FieldTestHelper.fieldDto(1L, "creator", String.class.getName(), "String field", null);
         creatorField.setNonDisplayable(true);
 
-        when(entityService.getEntityFields(ENTITY_ID)).thenReturn(asList(ownerField, creatorField));
+        when(entityService.getEntityFieldsForUI(ENTITY_ID)).thenReturn(asList(ownerField, creatorField));
         mockEntity();
         setUpSecurityContext();
 

--- a/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
+++ b/platform/mds/mds/src/main/java/org/motechproject/mds/dto/FieldDto.java
@@ -33,7 +33,7 @@ public class FieldDto {
     private List<LookupDto> lookups;
 
     public FieldDto() {
-        this(null, null, null, null, false, false, true, null, null, null, null);
+        this(null, null, null, null, false, false, false, null, null, null, null);
     }
 
     public FieldDto(String name, String displayName, TypeDto type) {


### PR DESCRIPTION
We no longer auto populate the owner and creator fields.
With the values prepopulated, the validation of modifications to
readonly fields would fail.