### PR TITLE
MOTECH-2174 Made common DatePicker create child scope, not isolated s…

### DIFF
--- a/ui/src/js/directives.js
+++ b/ui/src/js/directives.js
@@ -670,7 +670,7 @@
     widgetModule.directive('datePicker', function() {
         return {
             restrict: 'A',
-            scope: {},
+            scope: true,
             link: function(scope, element, attrs) {
                 var elem = angular.element(element),
                    otherDateTextBox = {},


### PR DESCRIPTION
…cope

The common DatePicker was creating an isolated scope and causing the Scheduler module to crash after the Tasks module was loaded. Neither of these modules have their own date-picker module, so the reason for why the Tasks module caused this problem is still unknown.

Additionally, I changed the DatePicker directive to create a child scope because it does use scope variables, and I didn't want to polute potential parent scopes.