### PR TITLE
MOTECH-2089: Clean up the Email API

### DIFF
--- a/docs/source/modules/email.rst
+++ b/docs/source/modules/email.rst
@@ -81,7 +81,7 @@ The Email module exposes two OSGi services. First service provides possibility t
         void send(Mail message);
     }
 
-Email message is represented by an object of :code:`org.motechproject.email.contract.Mail` class which contains following fields:
+Email message is represented by an object of :code:`org.motechproject.email.domain.Mail` class which contains following fields:
 
 - :code:`String fromAddress` - sender address.
 - :code:`String toAddress` - recipient address.

--- a/modules/admin/src/main/java/org/motechproject/admin/notification/EmailNotifier.java
+++ b/modules/admin/src/main/java/org/motechproject/admin/notification/EmailNotifier.java
@@ -5,7 +5,6 @@ import org.apache.velocity.app.VelocityEngine;
 import org.joda.time.format.DateTimeFormat;
 import org.motechproject.admin.domain.StatusMessage;
 import org.motechproject.config.service.ConfigurationService;
-import org.motechproject.email.contract.Mail;
 import org.motechproject.email.exception.EmailSendException;
 import org.motechproject.email.service.EmailSenderService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +46,8 @@ public class EmailNotifier {
     public void send(StatusMessage statusMessage, String recipient) throws EmailSendException {
         Map<String, Object> model = templateParams(statusMessage);
         String text = mergeTemplateIntoString(model);
-        emailSender.send(new Mail(senderAddress(), recipient,
-                statusMessage.getLevel() + " notification raised in Motech", text));
+        emailSender.send(senderAddress(), recipient,
+                statusMessage.getLevel() + " notification raised in Motech", text);
     }
 
     protected String mergeTemplateIntoString(Map<String, Object> model) {

--- a/modules/admin/src/test/java/org/motechproject/admin/notification/EmailNotifierTest.java
+++ b/modules/admin/src/test/java/org/motechproject/admin/notification/EmailNotifierTest.java
@@ -14,7 +14,7 @@ import org.mockito.MockitoAnnotations;
 import org.motechproject.admin.domain.StatusMessage;
 import org.motechproject.admin.messages.Level;
 import org.motechproject.config.service.ConfigurationService;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.service.EmailSenderService;
 import org.motechproject.server.config.domain.MotechSettings;
 
@@ -76,13 +76,8 @@ public class EmailNotifierTest {
         Assert.assertTrue(velocityArgumentCaptor.getValue().get("dateTime").toString().matches("^(12[./]20|20[./]12)[./]10 10:50(| AM)$"));
         assertEquals(moduleName, velocityArgumentCaptor.getValue().get("module"));
 
-        ArgumentCaptor<Mail> argument = ArgumentCaptor.forClass(Mail.class);
-        Mockito.verify(emailSenderService).send(argument.capture());
-        Mail mail = argument.getValue();
+        Mockito.verify(emailSenderService).send( "noreply@serverurl", "recipients", "WARN notification raised in Motech", "Mail msg" );
 
-        assertEquals(text, mail.getMessage());
-        assertEquals("recipients", mail.getToAddress());
-        assertEquals("noreply@serverurl", mail.getFromAddress());
     }
 
     @Test

--- a/platform/email/pom.xml
+++ b/platform/email/pom.xml
@@ -161,7 +161,6 @@
                         <Blueprint-Enabled>true</Blueprint-Enabled>
                         <Export-Package>
                             org.motechproject.email.builder;version=${project.version},
-                            org.motechproject.email.contract;version=${project.version},
                             org.motechproject.email.domain;version=${project.version},
                             org.motechproject.email.exception;version=${project.version},
                             org.motechproject.email.service;version=${project.version}

--- a/platform/email/src/main/java/org/motechproject/email/domain/Mail.java
+++ b/platform/email/src/main/java/org/motechproject/email/domain/Mail.java
@@ -1,4 +1,4 @@
-package org.motechproject.email.contract;
+package org.motechproject.email.domain;
 
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.motechproject.email.json.MailDeserializer;

--- a/platform/email/src/main/java/org/motechproject/email/json/MailDeserializer.java
+++ b/platform/email/src/main/java/org/motechproject/email/json/MailDeserializer.java
@@ -5,7 +5,7 @@ import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 import org.codehaus.jackson.map.JsonMappingException;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 
 import java.io.IOException;
 

--- a/platform/email/src/main/java/org/motechproject/email/service/EmailSenderService.java
+++ b/platform/email/src/main/java/org/motechproject/email/service/EmailSenderService.java
@@ -1,7 +1,6 @@
 package org.motechproject.email.service;
 
 
-import org.motechproject.email.contract.Mail;
 import org.motechproject.email.exception.EmailSendException;
 
 /**
@@ -12,8 +11,10 @@ public interface EmailSenderService {
     /**
      * Attempts to send the supplied email message. Adds an {@link org.motechproject.email.domain.EmailRecord}
      * entry to the log with the details of the activity.
-     *
-     * @param message  the message to send
+     * @param fromAddress  the email address of the sender
+     * @param toAddress  the email address of the recipient
+     * @param subject  the subject of the email
+     * @param message  the body of the email
      */
-    void send(Mail message) throws EmailSendException;
+    void send(String fromAddress, String toAddress, String subject, String message) throws EmailSendException;
 }

--- a/platform/email/src/main/java/org/motechproject/email/service/impl/EmailSenderServiceImpl.java
+++ b/platform/email/src/main/java/org/motechproject/email/service/impl/EmailSenderServiceImpl.java
@@ -1,6 +1,6 @@
 package org.motechproject.email.service.impl;
 
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.domain.DeliveryStatus;
 import org.motechproject.email.domain.EmailRecord;
 import org.motechproject.email.exception.EmailSendException;
@@ -45,7 +45,8 @@ public class EmailSenderServiceImpl implements EmailSenderService {
 
     @Override
     @Transactional
-    public void send(final Mail mail) throws EmailSendException {
+    public void send(String fromAddress, String toAddress, String subject, String message) throws EmailSendException {
+        Mail mail = new Mail(fromAddress, toAddress, subject, message);
         LOGGER.info(String.format("Sending message [%s] from [%s] to [%s] with subject [%s].",
                 mail.getMessage(), mail.getFromAddress(), mail.getToAddress(), mail.getSubject()));
         try {

--- a/platform/email/src/main/java/org/motechproject/email/service/impl/MotechMimeMessagePreparator.java
+++ b/platform/email/src/main/java/org/motechproject/email/service/impl/MotechMimeMessagePreparator.java
@@ -1,7 +1,7 @@
 package org.motechproject.email.service.impl;
 
 import org.apache.commons.lang.StringUtils;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 

--- a/platform/email/src/main/java/org/motechproject/email/service/impl/SendEmailEventHandlerImpl.java
+++ b/platform/email/src/main/java/org/motechproject/email/service/impl/SendEmailEventHandlerImpl.java
@@ -1,7 +1,6 @@
 package org.motechproject.email.service.impl;
 
 import org.motechproject.email.constants.SendEmailConstants;
-import org.motechproject.email.contract.Mail;
 import org.motechproject.email.exception.EmailSendException;
 import org.motechproject.email.service.EmailSenderService;
 import org.motechproject.event.MotechEvent;
@@ -35,6 +34,6 @@ public class SendEmailEventHandlerImpl {
                     fromAddress, toAddress, subject, message);
         }
 
-        emailSenderService.send(new Mail(fromAddress, toAddress, subject, message));
+        emailSenderService.send(fromAddress, toAddress, subject, message);
     }
 }

--- a/platform/email/src/main/java/org/motechproject/email/web/SendEmailController.java
+++ b/platform/email/src/main/java/org/motechproject/email/web/SendEmailController.java
@@ -1,7 +1,7 @@
 package org.motechproject.email.web;
 
 import org.motechproject.email.constants.EmailRolesConstants;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.exception.EmailSendException;
 import org.motechproject.email.service.EmailSenderService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,8 +38,9 @@ public class SendEmailController {
     @RequestMapping(value = "/send", method = RequestMethod.POST)
     @PreAuthorize(EmailRolesConstants.HAS_ANY_EMAIL_ROLE)
     @ResponseStatus(HttpStatus.OK)
-    public void sendEmail(@RequestBody Mail mail) throws EmailSendException {
-        senderService.send(mail);
+
+    public void sendEmail(@RequestBody Mail email) throws EmailSendException {
+        senderService.send(email.getFromAddress(), email.getToAddress(), email.getSubject(), email.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/platform/email/src/test/java/org/motechproject/email/it/EmailBundleIT.java
+++ b/platform/email/src/test/java/org/motechproject/email/it/EmailBundleIT.java
@@ -4,7 +4,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.exception.EmailSendException;
 import org.motechproject.email.service.EmailRecordService;
 import org.motechproject.email.service.EmailSenderService;
@@ -55,7 +55,7 @@ public class EmailBundleIT extends BasePaxIT {
         ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-            mailService.send(new Mail("from@from.com", "to@to.com", "test", "test"));
+            mailService.send("from@from.com", "to@to.com", "test", "test");
         } finally {
             Thread.currentThread().setContextClassLoader(oldCl);
         }

--- a/platform/email/src/test/java/org/motechproject/email/json/MailDeserializerTest.java
+++ b/platform/email/src/test/java/org/motechproject/email/json/MailDeserializerTest.java
@@ -6,7 +6,7 @@ import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Test;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 
 import java.io.IOException;
 

--- a/platform/email/src/test/java/org/motechproject/email/service/impl/EmailSenderServiceTest.java
+++ b/platform/email/src/test/java/org/motechproject/email/service/impl/EmailSenderServiceTest.java
@@ -4,8 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.motechproject.email.contract.Mail;
-import org.motechproject.email.service.EmailAuditService;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.service.EmailRecordService;
 import org.motechproject.email.service.EmailSenderService;
 import org.motechproject.server.config.SettingsFacade;
@@ -37,11 +36,11 @@ public class EmailSenderServiceTest {
 
     @Test
     public void shouldSendCriticalNotification() throws Exception {
-        Mail mail = new Mail("from", "to", "subject", "text");
-        when(settings.getProperty(anyString())).thenReturn("true");
-        emailSender.send(mail);
 
-        verify(javaMailSender).send(new MotechMimeMessagePreparator(mail));
+        when(settings.getProperty(anyString())).thenReturn("true");
+        emailSender.send( "from", "to", "subject", "text");
+
+        verify(javaMailSender).send(new MotechMimeMessagePreparator(new Mail ("from", "to", "subject", "text")));
     }
 
 }

--- a/platform/email/src/test/java/org/motechproject/email/service/impl/MotechMimeMessagePreparatorTest.java
+++ b/platform/email/src/test/java/org/motechproject/email/service/impl/MotechMimeMessagePreparatorTest.java
@@ -2,7 +2,7 @@ package org.motechproject.email.service.impl;
 
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 
 import javax.mail.MessagingException;
 import javax.mail.Session;

--- a/platform/email/src/test/java/org/motechproject/email/service/impl/SendEmailEventHandlerImplTest.java
+++ b/platform/email/src/test/java/org/motechproject/email/service/impl/SendEmailEventHandlerImplTest.java
@@ -2,11 +2,9 @@ package org.motechproject.email.service.impl;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.motechproject.email.contract.Mail;
 import org.motechproject.email.exception.EmailSendException;
 import org.motechproject.email.service.EmailSenderService;
 import org.motechproject.event.MotechEvent;
@@ -16,7 +14,6 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Mockito.verify;
@@ -58,13 +55,9 @@ public class SendEmailEventHandlerImplTest {
         values.put(SUBJECT, subject);
 
         emailEventHandler.handle(new MotechEvent(SEND_EMAIL_SUBJECT, values));
-        ArgumentCaptor<Mail> captor = ArgumentCaptor.forClass(Mail.class);
-        verify(emailSenderService).send(captor.capture());
 
-        assertEquals(captor.getValue().getFromAddress(), from);
-        assertEquals(captor.getValue().getToAddress(), to);
-        assertEquals(captor.getValue().getSubject(), subject);
-        assertEquals(captor.getValue().getMessage(), message);
+        verify(emailSenderService).send(from, to, subject, message);
+
     }
 
 }

--- a/platform/email/src/test/java/org/motechproject/email/web/SendEmailControllerTest.java
+++ b/platform/email/src/test/java/org/motechproject/email/web/SendEmailControllerTest.java
@@ -6,7 +6,7 @@ import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.motechproject.email.contract.Mail;
+import org.motechproject.email.domain.Mail;
 import org.motechproject.email.service.EmailSenderService;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.server.MockMvc;
@@ -43,7 +43,7 @@ public class SendEmailControllerTest {
     public void shouldSendEmail() throws Exception {
         sendEmailController.sendEmail(mail);
 
-        verify(senderService).send(mail);
+        verify(senderService).send(mail.getFromAddress(),mail.getToAddress(),mail.getSubject(),mail.getMessage());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SendEmailControllerTest {
     @Test
     public void shouldHandleExceptionDuringExecutionSendEmailRequest() throws Exception {
         String message = "There are problems with sending email";
-        doThrow(new IllegalStateException(message)).when(senderService).send(mail);
+        doThrow(new IllegalStateException(message)).when(senderService).send(mail.getFromAddress(),mail.getToAddress(),mail.getSubject(),mail.getMessage());
 
         controller.perform(
                 post("/send").body(convertMailToJson()).contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
* Moved contract.Mail to domain.Mail, in order to reduce package export.
* Changed EmailSenderService's method send. It wasn't necessary to send method  contained Mail parameter. I changed it and now send method has four string parameters. Now to use platform-email doesn't need to import two classes, but only one, EmailSenderService.