### PR TITLE
MOTECH-2187: Adds support for boolean getter 'is...()' in Task data source

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskContext.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskContext.java
@@ -1,6 +1,6 @@
 package org.motechproject.tasks.service;
 
-import org.apache.commons.lang.WordUtils;
+import org.apache.commons.beanutils.PropertyUtils;
 import org.motechproject.commons.api.MotechException;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.events.constants.TaskFailureCause;
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -143,8 +142,7 @@ public class TaskContext {
                 current = ((Map) current).get(subField);
             } else {
                 try {
-                    Method method = current.getClass().getMethod("get" + WordUtils.capitalize(subField));
-                    current = method.invoke(current);
+                    current = PropertyUtils.getProperty(current, subField);
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     throw new MotechException(e.getMessage(), e);
                 }

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskContextTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskContextTest.java
@@ -40,15 +40,21 @@ public class TaskContextTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private class TestDataSourceObject {
+    public class TestDataSourceObject {
         private int id;
+        private boolean checked;
 
         private TestDataSourceObject() {
             this.id = OBJECT_ID.intValue();
+            this.checked = true;
         }
 
         public int getId() {
             return id;
+        }
+
+        public boolean isChecked() {
+            return checked;
         }
     }
 
@@ -122,6 +128,17 @@ public class TaskContextTest {
         KeyInformation key = parse("ad.1.Integer#1.id");
 
         assertEquals(OBJECT_ID.intValue(), taskContext.getDataSourceObjectValue(key.getObjectId().toString(), key.getKey(), key.getObjectType()));
+    }
+
+    @Test
+    public void testGetDataSourceValueForBooleanWithGetterIs() throws Exception {
+        Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
+        TaskContext taskContext = new TaskContext(task, null, activityService);
+        taskContext.addDataSourceObject("1", new TestDataSourceObject(), true);
+
+        KeyInformation key = parse("ad.1.Boolean#1.checked");
+
+        assertEquals(true, taskContext.getDataSourceObjectValue(key.getObjectId().toString(), key.getKey(), key.getObjectType()));
     }
 
     @Test


### PR DESCRIPTION
Now a task data source supports boolean getter 'is...()'.

Note: for Boolean (object wrapper for boolean) you should use getter 'get...()'. Here: http://piotrnowicki.com/2011/01/javabeans-getters-with-boolean-type/ you can find some information about boolean/Boolean getter.