### PR TITLE
Fix for missing Tasks module after building MOTECH [0.28.X]

### DIFF
--- a/platform/server/pom.xml
+++ b/platform/server/pom.xml
@@ -292,24 +292,6 @@
                 <inherited>false</inherited>
                 <executions>
                     <execution>
-                        <id>clean-bundles</id>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                        <configuration>
-                            <filesets>
-                                <fileset>
-                                    <directory>${user.home}/.motech/bundles</directory>
-                                    <includes>
-                                        <include>**/*.jar</include>
-                                    </includes>
-                                    <followSymlinks>false</followSymlinks>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>clean-config</id>
                         <goals>
                             <goal>clean</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -1234,6 +1234,32 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.5</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <inherited>false</inherited>
+                        <id>clean-bundles</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${user.home}/.motech/bundles</directory>
+                                    <includes>
+                                        <include>**/*.jar</include>
+                                    </includes>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.3.2</version>


### PR DESCRIPTION
After making Tasks dependency in Scheduler module optional, the build order of the modules has changed and made "motech-platform-server" remove some of the modules build before it. MOTECH build will now clean .motech/bundles directory before building any of the modules.