### PR TITLE
Added generated test bundle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tools/SMPPSim/
 *.tmp
 platform/server/src/main/webapp/WEB-INF/classes/
 platform/server/src/main/webapp/[0-9]*/
+modules/admin/src/test/resources/motech-upload-test-bundle.jar
 docs/build
 docs/env
 docs/source/packages.rst


### PR DESCRIPTION
For the bundle upload integration test we
now generate a test-bundle, directly in the
admin test resources. This auto-generated file
should not get staged for commits, thus adding
it to .gitignore.