### PR TITLE
MOTECH-2124 Modifed Authentication Handler for JSON Login

### DIFF
--- a/platform/osgi-web-util/src/main/java/org/motechproject/osgi/web/extension/HttpRequestEnvironment.java
+++ b/platform/osgi-web-util/src/main/java/org/motechproject/osgi/web/extension/HttpRequestEnvironment.java
@@ -1,0 +1,22 @@
+package org.motechproject.osgi.web.extension;
+
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility class to categorize Http Requests
+ */
+public final class HttpRequestEnvironment {
+
+    private HttpRequestEnvironment() {
+    }
+
+    public static boolean isAjax(HttpServletRequest request) {
+        String header = request.getHeader("x-requested-with");
+        if(header != null && header.equals("XMLHttpRequest")) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginErrorHandler.java
+++ b/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginErrorHandler.java
@@ -13,7 +13,6 @@ import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
-import org.springframework.security.web.authentication.ExceptionMappingAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +28,7 @@ import java.util.Map;
  * It also redirect user to error login page.
  * @see org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
  */
-public class MotechLoginErrorHandler extends ExceptionMappingAuthenticationFailureHandler {
+public class MotechLoginErrorHandler extends MotechLoginErrorJSONHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MotechLoginErrorHandler.class);
 

--- a/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginErrorJSONHandler.java
+++ b/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginErrorJSONHandler.java
@@ -1,0 +1,26 @@
+package org.motechproject.security.authentication;
+
+
+import org.motechproject.osgi.web.extension.HttpRequestEnvironment;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.ExceptionMappingAuthenticationFailureHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MotechLoginErrorJSONHandler extends ExceptionMappingAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
+            throws IOException, ServletException {
+
+        if(HttpRequestEnvironment.isAjax(request)){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("ERROR");
+        }else{
+            super.onAuthenticationFailure(request, response, exception);
+        }
+    }
+}

--- a/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginSuccessHandler.java
+++ b/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginSuccessHandler.java
@@ -23,7 +23,7 @@ import java.io.IOException;
  * sessions that started with the server before web-security was started.
  * @see org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler
  */
-public class MotechLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+public class MotechLoginSuccessHandler extends MotechLoginSuccessJSONHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MotechLoginSuccessHandler.class);
 

--- a/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginSuccessJSONHandler.java
+++ b/platform/web-security/src/main/java/org/motechproject/security/authentication/MotechLoginSuccessJSONHandler.java
@@ -1,0 +1,24 @@
+package org.motechproject.security.authentication;
+
+import org.motechproject.osgi.web.extension.HttpRequestEnvironment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MotechLoginSuccessJSONHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
+        if (HttpRequestEnvironment.isAjax(request)) {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            response.getWriter().write("SUCCESS");
+        } else {
+            super.onAuthenticationSuccess(request, response, authentication);
+        }
+    }
+}


### PR DESCRIPTION
> Added logic to authentication handlers that catches XMLHttpRequests, and
> returns text, instead of redirecting. This was created to support a
> seperated UI that would communicate with MOTECH via JSON.

There is still a little bit of work I need to include, such as
- Returning a user object on successful authentication
- Returning an error message depending on why the login didn't work (ie User Blocked)
- Adding tests...
