### PR TITLE
FIX Remove dependency int AdminBundleIT test from cms-lite module

### DIFF
--- a/modules/admin/src/test/java/org/motechproject/admin/it/AdminBundleIT.java
+++ b/modules/admin/src/test/java/org/motechproject/admin/it/AdminBundleIT.java
@@ -133,8 +133,8 @@ public class AdminBundleIT extends BasePaxIT {
 
     @Test
     public void testUploadBundleFromRepository() throws IOException, InterruptedException {
-            uploadBundle("Repository", "org.motechproject:cms-lite:LATEST", null,
-                "on","org.motechproject.cms-lite");
+        uploadBundle("Repository", "org.motechproject:motech-tasks:LATEST", null,
+                "on","org.motechproject.motech-tasks");
     }
 
     @Test


### PR DESCRIPTION
test AdminBundleIT.testUploadBundleFromRepository causes errors when something is changed in API. I faced with this problem during https://github.com/motech/motech/pull/359.
This test uses CMS-Lite module which has dependencies to server-api.  I think that using bundle from motech is better than from external module.