### PR TITLE
MOTECH-2297: Prevents double listener registration for proxied beans

### DIFF
--- a/platform/event/src/test/java/org/motechproject/event/it/EventHandlerAnnotationProcessorBundleIT.java
+++ b/platform/event/src/test/java/org/motechproject/event/it/EventHandlerAnnotationProcessorBundleIT.java
@@ -2,14 +2,12 @@ package org.motechproject.event.it;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventListenerRegistryService;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.osgi.TestHandler;
+import org.motechproject.event.osgi.TestHandlerProxied;
 import org.motechproject.testing.osgi.BasePaxIT;
 import org.motechproject.testing.osgi.container.MotechNativeTestContainerFactory;
-import org.motechproject.testing.osgi.wait.Wait;
-import org.motechproject.testing.osgi.wait.WaitCondition;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
@@ -17,6 +15,7 @@ import org.ops4j.pax.exam.spi.reactors.PerSuite;
 
 import javax.inject.Inject;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PaxExam.class)
@@ -30,16 +29,12 @@ public class EventHandlerAnnotationProcessorBundleIT extends BasePaxIT {
     private EventRelay eventRelay;
 
     @Test
-    public void testThatBeansWithMotechListenerAnnotationsAreBeingRegistered() throws InterruptedException {
-        eventRelay.sendEventMessage(new MotechEvent(TestHandler.TEST_SUBJECT));
-
-        new Wait(new WaitCondition() {
-            @Override
-            public boolean needsToWait() {
-                return !eventListenerRegistry.hasListener(TestHandler.TEST_SUBJECT);
-            }
-        }, 2000).start();
-
+    public void testThatBeansWithMotechListenerAnnotationsAreBeingRegistered() {
         assertTrue(eventListenerRegistry.hasListener(TestHandler.TEST_SUBJECT));
+    }
+
+    @Test
+    public void shouldRegisterOnlyOneListenerForProxiedBean() {
+        assertEquals(1, eventListenerRegistry.getListenerCount(TestHandlerProxied.TEST_HANDLER_PROXIED_SUBJECT));
     }
 }

--- a/platform/event/src/test/java/org/motechproject/event/osgi/TestHandlerProxied.java
+++ b/platform/event/src/test/java/org/motechproject/event/osgi/TestHandlerProxied.java
@@ -1,0 +1,16 @@
+package org.motechproject.event.osgi;
+
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.annotations.MotechListener;
+
+/*
+This test handler mocks the situation when spring bean is proxied, for example when @Transactional annotation is used.
+In test application context for the event module this bean is proxied manually.
+ */
+public class TestHandlerProxied {
+    public static final String TEST_HANDLER_PROXIED_SUBJECT="test-handler-proxied-subject";
+
+    @MotechListener(subjects = TEST_HANDLER_PROXIED_SUBJECT)
+    public void handle(MotechEvent event) {
+    }
+}

--- a/platform/event/src/test/resources/META-INF/spring/testEventBundleContext.xml
+++ b/platform/event/src/test/resources/META-INF/spring/testEventBundleContext.xml
@@ -5,7 +5,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.eclipse.org/gemini/blueprint/schema/blueprint http://www.eclipse.org/gemini/blueprint/schema/blueprint/gemini-blueprint.xsd">
 
-
     <bean id="testEventListenerOsgi" class="org.motechproject.event.osgi.TestEventListenerOsgi"/>
 
     <osgi:reference id="eventListenerRegistry"
@@ -14,5 +13,15 @@
     <osgi:reference id="eventRelay" interface="org.motechproject.event.listener.EventRelay"/>
 
     <bean id="testHandler" class="org.motechproject.event.osgi.TestHandler"/>
+
+    <bean id="testHandlerProxied" class="org.motechproject.event.osgi.TestHandlerProxied"/>
+
+    <bean class="org.springframework.aop.framework.autoproxy.BeanNameAutoProxyCreator">
+        <property name="beanNames">
+            <list>
+                <value>*Proxied</value>
+            </list>
+        </property>
+    </bean>
 
 </beans>


### PR DESCRIPTION
# **## Overview**
In 'problem description' I describe briefly how it works and how my changes fix the problem. If someone is more curious in section 'understanding proxy usage in Spring' I describe more precisely how it works (pictures and information are from https://spring.io/blog/2012/05/23/transactions-caching-and-aop-understanding-proxy-usage-in-spring). Example 3 and 4, which are mentioned in briefly description are in section 'Understanding proxy usage in Spring'.

## **## Problem description**
If someone annotates method with @MotechListener, the event module will register this method as a listener for subject. By default there will be normal object under the spring bean. However if in the bean is at least one @Transactional annotation (there is no need this two annotations are on the same method), under the bean will be spring proxy (only one even if service is exposed as an OSGi service). Then event module will register all methods annotated with @MotechListener from this proxy and from its superclasses. 

Problem occurs when our bean is constructed similar to example 4. Then two listeners will be registered. All proxy methods are marked as final, so we will have one method from proxy(final), second from proxy parent(not final), which is our real object.

Problem doesn't occur in example 3. Because proxy implements (not extends) our bean. So we will have only one listener - method marked as final in proxy.   

I resolved this double listener registration. Now the event module seeks listeners only in object methods (without superclass methods).
## 
## **## Understanding proxy usage in Spring**
In the Spring framework, some features rely on proxy usage (for example transactions). I will try to explain here how exactly it works.

**Example 1** - Let's assume we've got simple spring component :
```
@Component
public class TestComponent {
}
```

under spring bean there is no proxy, just simple calling to object of type TestComponent

**Example 2 **- Spring service 
```
@Service
public class AccountServiceImpl implements AccountService {
}
```

At runtime :

![no-proxy](https://cloud.githubusercontent.com/assets/9861925/13845997/1f30e062-ec44-11e5-851c-2ddd3e2cad5d.png)

In MOTECH even if a service is exposed as an OSGi service there will be no proxy under spring bean.

**Example 3** - Situation is a bit different when we add the spring @Transactional annotation to bean :
 
```
@Service
public class AccountServiceImpl implements AccountService {
       @Transactional
       public void test() {
       }
}
```

now at startup time, a new class is created, called proxy. This one is in charge of adding Transactional behavior as follows:
![transactional-proxy-after-startup](https://cloud.githubusercontent.com/assets/9861925/13846066/b36ef444-ec44-11e5-9021-971e23099034.png)

Then when we invoke applicationContext.getBean(AccountService.class) we've got our proxy.

**Example 4** - Component with @Transactional :
```
@Component
public class AccountService {
     @Transactional
     public void create() {
     }
}
```

By default, if your bean does not implement an interface, Spring uses technical inheritance: at startup time, a new class is created. It inherits from your bean class and adds behavior in the child methods.

![proxy-transaction-inheritance](https://cloud.githubusercontent.com/assets/9861925/13846121/29140c70-ec45-11e5-9056-96ba1aa7478a.png)
