### PR TITLE
Fixes Motech build [0.28.X]

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bower": "~1.6.8",
     "gulp": "^3.9.0",
-    "gulp-bless": "^3.0.1",
+    "gulp-bless": "3.0.1",
     "gulp-concat": "~2.6.0",
     "gulp-rename": "~1.2.2",
     "gulp-sequence": "~0.4.1",


### PR DESCRIPTION
Recently gulp-bless version has been updated to 3.1.0. This version doesn't work
properly with Motech using css files. I changed bower dependency to use version
3.0.1 not the latest one.