### PR TITLE
Fixes Motech build [0.28.X]

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "nunjucks": "~2.2.0",
     "path": "~0.12.7",
     "require-dir": "~0.3.0",
-    "yargs": "~3.31.0"
+    "yargs": "3.32.0"
   },
   "devDependencies": {
     "bower-files": "~3.11.3"


### PR DESCRIPTION
There is still a problem with build on 0.28.X branch. The build randomly fails.
I noticed that when the build is failing there are info about two different
version of yargs. I updated the yargs version to the latest from 3.x.x
It should solve the problem.