### PR TITLE
Bring back javassist export in MDS

### DIFF
--- a/platform/mds/mds/pom.xml
+++ b/platform/mds/mds/pom.xml
@@ -314,6 +314,7 @@
                             org.motechproject.mds.filter;version=${project.version},
                             org.motechproject.mds.helper;version=${project.version},
                             org.motechproject.mds.helper.bundle;version=${project.version},
+                            org.motechproject.mds.javassist;version=${project.version},
                             org.motechproject.mds.jdo;version=${project.version},
                             org.motechproject.mds.listener;version=${project.version},
                             org.motechproject.mds.listener.proxy;version=${project.version},


### PR DESCRIPTION
This package contains classes, that provide some util methods,
that might be used by other modules. One of such examples is
retrieving interface name for data service, which is used in 
MDS performance tests.