### PR TITLE
MOTECH-2317: Retry count for task failure has higher priority than possible errors in settings

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskTriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskTriggerHandler.java
@@ -240,7 +240,8 @@ public class TaskTriggerHandler implements TriggerHandler {
         int failureNumber = task.getFailuresInRow();
         int possibleErrorsNumber = getPossibleErrorsNumber();
 
-        if (failureNumber >= possibleErrorsNumber) {
+        // Retry count for task failure has higher priority than possible errors number in settings
+        if (!task.retryTaskOnFailure() && failureNumber >= possibleErrorsNumber) {
             task.setEnabled(false);
 
             activityService.addWarning(task);


### PR DESCRIPTION
Now retry count for task failure has higher priority than possible errors
number in settings.

I added an unit test and remove one redundant line from TaskTriggerHandlerTest.