### PR TITLE
[0.27.X] MOTECH-2316: Switching provider IDs used in tasks to provider names

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrationManager.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrationManager.java
@@ -12,6 +12,11 @@ import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * The manager used for applying migrations to tasks. It gets all {@link TaskMigrator} beans from the
+ * Spring context and applies them to the task being migrated. It can be called manually, it also triggers during
+ * initialization to make sure the tasks in the database are up to date.
+ */
 @Component
 public class TaskMigrationManager {
 
@@ -21,8 +26,12 @@ public class TaskMigrationManager {
     @Autowired
     private TasksDataService tasksDataService;
 
+    /**
+     * Migrates all tasks in the database.
+     */
     @PostConstruct
     public void init() {
+        // @Transactional does not work with @PostConstruct
         tasksDataService.doInTransaction(new TransactionCallbackWithoutResult() {
             @Override
             protected void doInTransactionWithoutResult(TransactionStatus status) {
@@ -34,6 +43,10 @@ public class TaskMigrationManager {
         });
     }
 
+    /**
+     * Migrates a single task.
+     * @param task the task to migrate
+     */
     @Transactional
     public void migrateTask(Task task) {
         for (TaskMigrator migrator : migrators) {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrationManager.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrationManager.java
@@ -1,0 +1,43 @@
+package org.motechproject.tasks.compatibility;
+
+import org.motechproject.tasks.domain.Task;
+import org.motechproject.tasks.repository.TasksDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class TaskMigrationManager {
+
+    @Autowired
+    private Set<TaskMigrator> migrators;
+
+    @Autowired
+    private TasksDataService tasksDataService;
+
+    @PostConstruct
+    public void init() {
+        tasksDataService.doInTransaction(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                List<Task> allTasks = tasksDataService.retrieveAll();
+                for (Task task : allTasks) {
+                    migrateTask(task);
+                }
+            }
+        });
+    }
+
+    @Transactional
+    public void migrateTask(Task task) {
+        for (TaskMigrator migrator : migrators) {
+            migrator.migrate(task);
+        }
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrator.java
@@ -2,7 +2,14 @@ package org.motechproject.tasks.compatibility;
 
 import org.motechproject.tasks.domain.Task;
 
+/**
+ * An interface that can be implemented by classes which want to apply migrations to tasks.
+ */
 public interface TaskMigrator {
 
+    /**
+     * Applies migration to tasks.
+     * @param task the task to migrate
+     */
     void migrate(Task task);
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/TaskMigrator.java
@@ -1,0 +1,8 @@
+package org.motechproject.tasks.compatibility;
+
+import org.motechproject.tasks.domain.Task;
+
+public interface TaskMigrator {
+
+    void migrate(Task task);
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
@@ -99,6 +99,6 @@ public class ProviderNameTaskMigrator implements TaskMigrator {
                 return dataSource.getProviderName();
             }
         }
-        throw new ProviderNotFoundException(providerId);
+        throw new ProviderNotFoundException(task.getName(), providerId);
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
@@ -1,5 +1,6 @@
 package org.motechproject.tasks.compatibility.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.tasks.compatibility.TaskMigrator;
 import org.motechproject.tasks.domain.DataSource;
 import org.motechproject.tasks.domain.Filter;
@@ -7,17 +8,25 @@ import org.motechproject.tasks.domain.FilterSet;
 import org.motechproject.tasks.domain.Lookup;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
+import org.motechproject.tasks.ex.ProviderNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
+/**
+ * This class is responsible for migrating tasks that use the database id as the provider id.
+ * Since the database ID is not reliable, and it will not work across different systems (in case of import/export)  we
+ * have decided to drop it in favor of using provider names. This migrator will switch the provider ids used in expressions
+ * to provider names. Provider names already stored in the current task config are used.
+ */
 @Component
 public class ProviderNameTaskMigrator implements TaskMigrator {
 
     private static final Pattern EXPR_PATTERN = Pattern.compile("(\\{\\{ad\\.)(\\d+)(.+?\\}\\})");
-    private static final Pattern FILTER_KEY_PATTERN = Pattern.compile("(ad\\.)(\\d+)(.?+)");
+    private static final Pattern FILTER_KEY_PATTERN = Pattern.compile("(ad\\.)(\\d+)(.+?)");
     private static final int ID_GROUP_INDEX = 2;
 
     @Override
@@ -69,17 +78,19 @@ public class ProviderNameTaskMigrator implements TaskMigrator {
     }
 
     private String replaceTaskValue(String oldValue, Pattern pattern, Task task) {
-        Matcher matcher = pattern.matcher(oldValue);
-        if (matcher.matches()) {
-            long providerId = Long.parseLong(matcher.group(ID_GROUP_INDEX));
+        String result = oldValue;
+        if (StringUtils.isNotBlank(oldValue)) {
+            Matcher matcher = pattern.matcher(oldValue);
+            if (matcher.matches()) {
+                long providerId = Long.parseLong(matcher.group(ID_GROUP_INDEX));
 
-            String providerName = providerIdToName(providerId, task);
+                String providerName = providerIdToName(providerId, task);
 
-            // replace provider id with provider name using regex groups
-            return matcher.replaceAll("$1" + providerName + "$3");
-        } else {
-            return oldValue;
+                // replace provider id with provider name using regex groups
+                result = matcher.replaceAll("$1" + providerName + "$3");
+            }
         }
+        return result;
     }
 
     private String providerIdToName(long providerId, Task task) {
@@ -88,6 +99,6 @@ public class ProviderNameTaskMigrator implements TaskMigrator {
                 return dataSource.getProviderName();
             }
         }
-        throw new IllegalArgumentException("Unable to migrate task. Data provider with id " + providerId + " not found");
+        throw new ProviderNotFoundException(providerId);
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigrator.java
@@ -1,0 +1,93 @@
+package org.motechproject.tasks.compatibility.impl;
+
+import org.motechproject.tasks.compatibility.TaskMigrator;
+import org.motechproject.tasks.domain.DataSource;
+import org.motechproject.tasks.domain.Filter;
+import org.motechproject.tasks.domain.FilterSet;
+import org.motechproject.tasks.domain.Lookup;
+import org.motechproject.tasks.domain.Task;
+import org.motechproject.tasks.domain.TaskActionInformation;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ProviderNameTaskMigrator implements TaskMigrator {
+
+    private static final Pattern EXPR_PATTERN = Pattern.compile("(\\{\\{ad\\.)(\\d+)(.+?\\}\\})");
+    private static final Pattern FILTER_KEY_PATTERN = Pattern.compile("(ad\\.)(\\d+)(.?+)");
+    private static final int ID_GROUP_INDEX = 2;
+
+    @Override
+    public void migrate(Task task) {
+        migrateActions(task);
+        migrateDataSources(task);
+        migrateFilters(task);
+    }
+
+    private void migrateActions(Task task) {
+        // replace data source references in actions
+        for (TaskActionInformation action : task.getActions()) {
+            for (Map.Entry<String, String> entry : action.getValues().entrySet()) {
+                String oldVal = entry.getValue();
+
+                String newVal = replaceTaskValue(oldVal, EXPR_PATTERN, task);
+                entry.setValue(newVal);
+            }
+        }
+    }
+
+    private void migrateDataSources(Task task) {
+        // replace data source references in other data source lookups
+        for (DataSource dataSource : task.getTaskConfig().getDataSources()) {
+            for (Lookup lookup : dataSource.getLookup()) {
+                String oldVal = lookup.getValue();
+
+                String newVal = replaceTaskValue(oldVal, EXPR_PATTERN, task);
+                lookup.setValue(newVal);
+            }
+        }
+    }
+
+    private void migrateFilters(Task task) {
+        for (FilterSet filterSet : task.getTaskConfig().getFilters()) {
+            for (Filter filter : filterSet.getFilters()) {
+                // replace data source references in filter expressions
+                String oldVal = filter.getExpression();
+
+                String newVal = replaceTaskValue(oldVal, EXPR_PATTERN, task);
+                filter.setExpression(newVal);
+                // also make sure the key is correct
+                oldVal = filter.getKey();
+
+                newVal = replaceTaskValue(oldVal, FILTER_KEY_PATTERN, task);
+                filter.setKey(newVal);
+            }
+        }
+    }
+
+    private String replaceTaskValue(String oldValue, Pattern pattern, Task task) {
+        Matcher matcher = pattern.matcher(oldValue);
+        if (matcher.matches()) {
+            long providerId = Long.parseLong(matcher.group(ID_GROUP_INDEX));
+
+            String providerName = providerIdToName(providerId, task);
+
+            // replace provider id with provider name using regex groups
+            return matcher.replaceAll("$1" + providerName + "$3");
+        } else {
+            return oldValue;
+        }
+    }
+
+    private String providerIdToName(long providerId, Task task) {
+        for (DataSource dataSource : task.getTaskConfig().getDataSources()) {
+            if (providerId == dataSource.getProviderId()) {
+                return dataSource.getProviderName();
+            }
+        }
+        throw new IllegalArgumentException("Unable to migrate task. Data provider with id " + providerId + " not found");
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/DataSource.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/DataSource.java
@@ -44,22 +44,7 @@ public class DataSource extends TaskConfigStep {
      * Constructor.
      */
     public DataSource() {
-        this(null, null, null, "id", null, false);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param providerId  the provider ID
-     * @param objectId  the object ID
-     * @param type  the data source object
-     * @param name  the data source name
-     * @param lookup  the lookup name
-     * @param failIfDataNotFound  defines if task should fail if no data was found
-     */
-    public DataSource(Long providerId, Long objectId, String type, String name, List<Lookup> lookup,
-                      boolean failIfDataNotFound) {
-        this("", providerId, objectId, type, name, lookup, failIfDataNotFound);
+        this(null, null, null, null, "id", null, false);
     }
 
     /**
@@ -176,15 +161,14 @@ public class DataSource extends TaskConfigStep {
 
         final DataSource other = (DataSource) obj;
 
-        return objectEquals(other.providerId, other.objectId, other.type)
-                && Objects.equals(this.providerName, other.providerName)
+        return objectEquals(other.providerName, other.objectId, other.type)
                 && Objects.equals(this.lookup, other.lookup)
                 && Objects.equals(this.failIfDataNotFound, other.failIfDataNotFound);
     }
 
     @JsonIgnore
-    public boolean objectEquals(Long providerId, Long objectId, String type) {
-        return Objects.equals(this.providerId, providerId)
+    public boolean objectEquals(String providerName, Long objectId, String type) {
+        return Objects.equals(this.providerName, providerName)
                 && Objects.equals(this.objectId, objectId)
                 && Objects.equals(this.type, type);
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/KeyInformation.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/KeyInformation.java
@@ -31,14 +31,14 @@ public final class KeyInformation {
      */
     public static final String ADDITIONAL_DATA_PREFIX = "ad";
 
-    private static final int DATA_PROVIDER_ID_IDX = 1;
+    private static final int DATA_PROVIDER_NAME_IDX = 1;
     private static final int OBJECT_TYPE_IDX = 2;
     private static final int OBJECT_ID_IDX = 3;
     private static final int EVENT_KEY_IDX = 4;
 
     private String originalKey;
     private String prefix;
-    private Long dataProviderId;
+    private String dataProviderName;
     private String objectType;
     private Long objectId;
     private String key;
@@ -51,11 +51,11 @@ public final class KeyInformation {
         this.manipulations = manipulations;
     }
 
-    private KeyInformation(String originalKey, String prefix, Long dataProviderId, String objectType,
+    private KeyInformation(String originalKey, String prefix, String dataProviderName, String objectType,
                            Long objectId, String key, List<String> manipulations) {
         this.originalKey = originalKey;
         this.prefix = prefix;
-        this.dataProviderId = dataProviderId;
+        this.dataProviderName = dataProviderName;
         this.objectType = objectType;
         this.objectId = objectId;
         this.key = key;
@@ -110,16 +110,16 @@ public final class KeyInformation {
         if (prefix.equalsIgnoreCase(TRIGGER_PREFIX)) {
             key = new KeyInformation(input, prefix, withoutManipulation, manipulations);
         } else if (prefix.equalsIgnoreCase(ADDITIONAL_DATA_PREFIX)) {
-            Pattern pattern = Pattern.compile("([a-zA-Z0-9]+)\\.([\\.a-zA-Z0-9\\-_]+)#(\\d+)\\.(.+)");
+            Pattern pattern = Pattern.compile("([a-zA-Z0-9\\-_]+)\\.([\\.a-zA-Z0-9\\-_]+)#([a-zA-Z0-9])\\.(.+)");
             Matcher matcher = pattern.matcher(withoutManipulation);
 
             if (matcher.matches()) {
-                String dataProviderId = matcher.group(DATA_PROVIDER_ID_IDX);
+                String dataProviderName = matcher.group(DATA_PROVIDER_NAME_IDX);
                 String objectType = matcher.group(OBJECT_TYPE_IDX);
                 Long objectId = Long.valueOf(matcher.group(OBJECT_ID_IDX));
                 String eventKey = matcher.group(EVENT_KEY_IDX);
 
-                key = new KeyInformation(input, prefix, Long.parseLong(dataProviderId), objectType, objectId, eventKey, manipulations);
+                key = new KeyInformation(input, prefix, dataProviderName, objectType, objectId, eventKey, manipulations);
             } else {
                 throw new IllegalArgumentException("Incorrect format for key from additional data");
             }
@@ -206,8 +206,8 @@ public final class KeyInformation {
         return originalKey;
     }
 
-    public Long getDataProviderId() {
-        return dataProviderId;
+    public String getDataProviderName() {
+        return dataProviderName;
     }
 
     public String getObjectType() {
@@ -242,7 +242,7 @@ public final class KeyInformation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(originalKey, prefix, dataProviderId, objectType, objectId, key, manipulations);
+        return Objects.hash(originalKey, prefix, dataProviderName, objectType, objectId, key, manipulations);
     }
 
     @Override
@@ -259,7 +259,7 @@ public final class KeyInformation {
 
         return Objects.equals(this.originalKey, other.originalKey) &&
             Objects.equals(this.prefix, other.prefix) &&
-            Objects.equals(this.dataProviderId, other.dataProviderId) &&
+            Objects.equals(this.dataProviderName, other.dataProviderName) &&
             Objects.equals(this.objectType, other.objectType) &&
             Objects.equals(this.objectId, other.objectId) &&
             Objects.equals(this.key, other.key) &&

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskConfig.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/TaskConfig.java
@@ -82,11 +82,11 @@ public class TaskConfig implements Serializable {
     }
 
     @JsonIgnore
-    public SortedSet<DataSource> getDataSources(Long providerId) {
+    public SortedSet<DataSource> getDataSources(String providerName) {
         SortedSet<DataSource> set = new TreeSet<>();
 
         for (DataSource source : getDataSources()) {
-            if (source.getProviderId().equals(providerId)) {
+            if (source.getProviderName().equals(providerName)) {
                 set.add(source);
             }
         }
@@ -97,19 +97,19 @@ public class TaskConfig implements Serializable {
     /**
      * Returns the data source for the given information.
      *
-     * @param providerId  the provider ID
+     * @param providerName  the provider name
      * @param objectId  the object ID
      * @param objectType  the object type
      * @return the object matching the given data.
      */
     @JsonIgnore
-    public DataSource getDataSource(final Long providerId, final Long objectId,
+    public DataSource getDataSource(final String providerName, final Long objectId,
                                     final String objectType) {
         return (DataSource) CollectionUtils.find(getDataSources(), new Predicate() {
             @Override
             public boolean evaluate(Object object) {
                 return object instanceof DataSource
-                        && ((DataSource) object).objectEquals(providerId, objectId, objectType);
+                        && ((DataSource) object).objectEquals(providerName, objectId, objectType);
             }
         });
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/ProviderNotFoundException.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/ProviderNotFoundException.java
@@ -5,7 +5,9 @@ package org.motechproject.tasks.ex;
  */
 public class ProviderNotFoundException extends IllegalArgumentException {
 
-    public ProviderNotFoundException(long providerId) {
-        super("Unable to migrate task. Data provider with id " + providerId + " not found");
+    private static final long serialVersionUID = -5419738008480651643L;
+
+    public ProviderNotFoundException(String taskName, long providerId) {
+        super("Unable to migrate task: " + taskName + ". Data provider with id " + providerId + " not found");
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/ProviderNotFoundException.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/ex/ProviderNotFoundException.java
@@ -1,0 +1,11 @@
+package org.motechproject.tasks.ex;
+
+/**
+ * Signals that provider with a given id was not found.
+ */
+public class ProviderNotFoundException extends IllegalArgumentException {
+
+    public ProviderNotFoundException(long providerId) {
+        super("Unable to migrate task. Data provider with id " + providerId + " not found");
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskServiceImpl.java
@@ -14,15 +14,12 @@ import org.motechproject.mds.query.QueryExecution;
 import org.motechproject.mds.query.QueryExecutor;
 import org.motechproject.mds.util.InstanceSecurityRestriction;
 import org.motechproject.osgi.web.util.WebBundleUtil;
+import org.motechproject.tasks.compatibility.TaskMigrationManager;
 import org.motechproject.tasks.domain.ActionEvent;
 import org.motechproject.tasks.domain.Channel;
 import org.motechproject.tasks.domain.DataSource;
-import org.motechproject.tasks.domain.Filter;
-import org.motechproject.tasks.domain.FilterSet;
-import org.motechproject.tasks.domain.Lookup;
 import org.motechproject.tasks.domain.Task;
 import org.motechproject.tasks.domain.TaskActionInformation;
-import org.motechproject.tasks.domain.TaskConfigStep;
 import org.motechproject.tasks.domain.TaskDataProvider;
 import org.motechproject.tasks.domain.TaskError;
 import org.motechproject.tasks.domain.TaskTriggerInformation;
@@ -85,6 +82,7 @@ public class TaskServiceImpl implements TaskService {
     private TaskDataProviderService providerService;
     private EventRelay eventRelay;
     private BundleContext bundleContext;
+    private TaskMigrationManager taskMigrationManager;
 
 
     private static final String[] TASK_TRIGGER_VALIDATION_ERRORS = new String[]{"task.validation.error.triggerNotExist",
@@ -180,7 +178,7 @@ public class TaskServiceImpl implements TaskService {
         List<Task> list = null;
 
         if (isNotBlank(subject)) {
-            List enabledTasks = tasksDataService.executeQuery(new QueryExecution<List<Task>>() {
+            List<Task> enabledTasks = tasksDataService.executeQuery(new QueryExecution<List<Task>>() {
                 @Override
                 public List<Task> execute(Query query, InstanceSecurityRestriction restriction) {
                     String byTriggerSubject = "trigger.subject == param";
@@ -305,7 +303,7 @@ public class TaskServiceImpl implements TaskService {
         LOGGER.debug("Handling a task data provider update: {}", providerName);
 
         for (Task task : getAllTasks()) {
-            SortedSet<DataSource> dataSources = task.getTaskConfig().getDataSources(provider.getId());
+            SortedSet<DataSource> dataSources = task.getTaskConfig().getDataSources(provider.getName());
             if (isNotEmpty(dataSources)) {
                 Set<TaskError> errors = new HashSet<>();
                 for (DataSource dataSource : dataSources) {
@@ -374,22 +372,8 @@ public class TaskServiceImpl implements TaskService {
         removeIgnoredFields(node);
 
         Task task = mapper.readValue(node, Task.class);
-        List<DataSource> sources = task.getTaskConfig().getDataSources();
 
-        // update data provider IDs
-        for (DataSource ds : sources) {
-            TaskDataProvider provider = findProviderByName(ds);
-
-            if (null != provider) {
-                Long oldId = ds.getProviderId();
-                Long newId = provider.getId();
-
-                if (!oldId.equals(newId)) {
-                    replaceProviderId(task, oldId, newId);
-                    ds.setProviderId(newId);
-                }
-            }
-        }
+        taskMigrationManager.migrateTask(task);
 
         save(task);
         return task;
@@ -414,46 +398,6 @@ public class TaskServiceImpl implements TaskService {
         checkChannelAvailableInTasks(tasks);
 
         return tasks;
-    }
-
-    private void replaceProviderId(Task task, Long oldId, Long newId) {
-        for (TaskConfigStep step : task.getTaskConfig().getSteps()) {
-            if (step instanceof DataSource) {
-                DataSource source = (DataSource) step;
-
-                for (Lookup lookup : source.getLookup()) {
-                    lookup.setValue(lookup.getValue().replace(oldId.toString(), newId.toString()));
-                }
-            } else if (step instanceof FilterSet) {
-                FilterSet set = (FilterSet) step;
-
-                for (Filter filter : set.getFilters()) {
-                    filter.setKey(filter.getKey().replace(oldId.toString(), newId.toString()));
-                }
-            }
-        }
-
-        for (TaskActionInformation action : task.getActions()) {
-            for (Map.Entry<String, String> row : action.getValues().entrySet()) {
-                action.getValues().put(
-                        row.getKey(),
-                        row.getValue().replace(oldId.toString(), newId.toString())
-                );
-            }
-        }
-    }
-
-    private TaskDataProvider findProviderByName(DataSource ds) {
-        TaskDataProvider provider = null;
-
-        for (TaskDataProvider p : providerService.getProviders()) {
-            if (p.getName().equalsIgnoreCase(ds.getProviderName())) {
-                provider = p;
-                break;
-            }
-        }
-
-        return provider;
     }
 
     private Set<TaskError> validateTrigger(Task task) {
@@ -493,7 +437,7 @@ public class TaskServiceImpl implements TaskService {
         Map<Long, TaskDataProvider> availableDataProviders = new HashMap<>();
 
         for (DataSource dataSource : task.getTaskConfig().getDataSources()) {
-            TaskDataProvider provider = providerService.getProviderById(dataSource.getProviderId());
+            TaskDataProvider provider = providerService.getProvider(dataSource.getProviderName());
 
             errors.addAll(validateProvider(provider, dataSource, task, availableDataProviders));
             if (provider != null) {
@@ -590,7 +534,7 @@ public class TaskServiceImpl implements TaskService {
         Map<Long, TaskDataProvider> dataProviders = new HashMap<>();
 
         for (DataSource dataSource : task.getTaskConfig().getDataSources()) {
-            TaskDataProvider provider = providerService.getProviderById(dataSource.getProviderId());
+            TaskDataProvider provider = providerService.getProvider(dataSource.getProviderName());
 
             if (provider != null) {
                 dataProviders.put(provider.getId(), provider);
@@ -738,5 +682,10 @@ public class TaskServiceImpl implements TaskService {
     @Autowired
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
+    }
+
+    @Autowired
+    public void setTaskMigrationManager(TaskMigrationManager taskMigrationManager) {
+        this.taskMigrationManager = taskMigrationManager;
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/validation/TaskDataProviderValidator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/validation/TaskDataProviderValidator.java
@@ -1,11 +1,14 @@
 package org.motechproject.tasks.validation;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.tasks.domain.TaskDataProvider;
 import org.motechproject.tasks.domain.TaskDataProviderObject;
 import org.motechproject.tasks.domain.TaskError;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
@@ -32,7 +35,7 @@ public final class TaskDataProviderValidator extends GeneralValidator {
     public static Set<TaskError> validate(TaskDataProvider provider) {
         Set<TaskError> errors = new HashSet<>();
 
-        checkBlankValue(errors, TASK_DATA_PROVIDER, "name", provider.getName());
+        validateProviderName(errors, provider.getName());
 
         boolean empty = checkEmpty(errors, TASK_DATA_PROVIDER, "objects", provider.getObjects());
 
@@ -70,4 +73,16 @@ public final class TaskDataProviderValidator extends GeneralValidator {
         return errors;
     }
 
+    private static void validateProviderName(Set<TaskError> errors, String providerName) {
+        checkBlankValue(errors, TASK_DATA_PROVIDER, "name", providerName);
+
+        // check only non-blank, we already validated against blank names one line above
+        if (StringUtils.isNotBlank(providerName)) {
+            Pattern pattern = Pattern.compile("^[A-Za-z0-9\\-_]+$");
+            Matcher matcher = pattern.matcher(providerName);
+            if (!matcher.matches()) {
+                errors.add(new TaskError("task.validation.error.provider.name", providerName));
+            }
+        }
+    }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/validation/TaskValidator.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/validation/TaskValidator.java
@@ -283,7 +283,7 @@ public final class TaskValidator extends GeneralValidator {
         String field = String.format("taskConfig.filterSet[%d].filters[%d]", setOrder, index);
         KeyInformation key = parse(filter.getKey());
         DataSource dataSource = config.getDataSource(
-                key.getDataProviderId(), key.getObjectId(), key.getObjectType()
+                key.getDataProviderName(), key.getObjectId(), key.getObjectType()
         );
 
         checkNullValue(errors, TASK, field, filter);
@@ -323,11 +323,11 @@ public final class TaskValidator extends GeneralValidator {
                         fieldType
                 ));
             }
-        } else if (key.fromAdditionalData() && providers.containsKey(key.getDataProviderId()) && providers.get(key.getDataProviderId()).containsProviderObjectField(key.getObjectType(), key.getKey()) && key.hasManipulations()) {
+        } else if (key.fromAdditionalData() && providers.containsKey(key.getDataProviderName()) && providers.get(key.getDataProviderName()).containsProviderObjectField(key.getObjectType(), key.getKey()) && key.hasManipulations()) {
             for (String manipulations : key.getManipulations()) {
                 errors.addAll(validateManipulations(manipulations,
                         key,
-                        ParameterType.fromString(providers.get(key.getDataProviderId()).getKeyType(key.getKey())),
+                        ParameterType.fromString(providers.get(key.getDataProviderName()).getKeyType(key.getKey())),
                         fieldType
                 ));
             }
@@ -424,7 +424,6 @@ public final class TaskValidator extends GeneralValidator {
                 String objectName = "task." + field;
 
                 checkNullValue(errors, objectName, "objectId", dataSource.getObjectId());
-                checkNullValue(errors, objectName, "providerId", dataSource.getProviderId());
 
                 checkBlankValue(errors, objectName, "type", dataSource.getType());
                 checkBlankValue(errors, objectName, "lookup.field", lookup.getField());

--- a/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
@@ -334,7 +334,7 @@
                         });
 
                         if (step['@type'] === 'DataSource') {
-                            source = $scope.findDataSource(step.providerId);
+                            source = $scope.findDataSource(step.providerName);
                             object = $scope.util.find({
                                 where: source.objects,
                                 by: {
@@ -585,7 +585,7 @@
                     });
 
                     if (select) {
-                        text = $scope.findObject(select.providerId, text[0]);
+                        text = $scope.findObject(select.providerName, text[0]);
                         text = $scope.util.find({
                             msg: $scope.msg,
                             where: text.fields,
@@ -618,7 +618,7 @@
                 filter.type = select.type;
                 break;
             case $scope.util.DATA_SOURCE_PREFIX:
-                filter.key = "{0}.{1}.{2}#{3}.{4}".format($scope.util.DATA_SOURCE_PREFIX, select.providerId, select.type, select.objectId, field.fieldKey);
+                filter.key = "{0}.{1}.{2}#{3}.{4}".format($scope.util.DATA_SOURCE_PREFIX, select.providerName, select.type, select.objectId, field.fieldKey);
                 filter.displayName = "{0}.{1}.{2}#{3}.{4}".format($scope.util.DATA_SOURCE_PREFIX, select.providerName, select.type, select.objectId, field.fieldKey);
                 filter.type = field.type;
                 break;
@@ -687,18 +687,18 @@
             });
         };
 
-        $scope.findDataSource = function (providerId) {
+        $scope.findDataSource = function (providerName) {
             return $scope.util.find({
                 where: $scope.dataSources,
                 by: {
-                    what: 'id',
-                    equalTo: providerId
+                    what: 'name',
+                    equalTo: providerName
                 }
             });
         };
 
-        $scope.findObject = function (providerId, type, id) {
-            var dataSource = $scope.findDataSource(providerId),
+        $scope.findObject = function (providerName, type, id) {
+            var dataSource = $scope.findDataSource(providerName),
                 by,
                 found;
 
@@ -723,7 +723,7 @@
         };
 
         $scope.selectDataSource = function (dataSource, selected) {
-            if (dataSource.providerId) {
+            if (dataSource.providerName) {
                 motechConfirm('task.confirm.changeDataSource', 'task.header.confirm', function (val) {
                     if (val) {
                         dataSource.name = '';
@@ -801,7 +801,7 @@
                     val = '{{{0}.{1}}}'.format(prefix, key);
                     break;
                 case $scope.util.DATA_SOURCE_PREFIX:
-                    val = '{{{0}.{1}.{2}#{3}.{4}}}'.format(prefix, $scope.msg(source), object.type, object.id, key);
+                    val = '{{{0}.{1}.{2}#{3}.{4}}}'.format(prefix, source, object.type, object.id, key);
                     break;
                 default:
                     val = key;
@@ -945,7 +945,7 @@
                                 });
 
                                 if (ds) {
-                                    newValue = element.replace(splittedValue[1], ds.providerId);
+                                    newValue = element.replace(splittedValue[1], ds.providerName);
                                     joinSeparator = joinSeparator.replace(element, newValue);
                                 }
                             }
@@ -965,7 +965,7 @@
             element = value.replace(regex, function (data) {
                 var indexOf = data.indexOf('.'),
                     prefix, dataArray, key, manipulations,
-                    span, cuts = {dot: [], hash: []}, param, type, field, dataSource, providerId, object, id;
+                    span, cuts = {dot: [], hash: []}, param, type, field, dataSource, providerName, object, id;
 
                     if (forFormat === 'true') {
                         prefix = data.slice(1, indexOf);
@@ -1009,7 +1009,7 @@
                     cuts.dot[0] = cuts.hash[0].split('.');
                     cuts.dot[1] = cuts.hash[1].split('.');
 
-                    providerId = cuts.dot[0][0];
+                    providerName = cuts.dot[0][0];
                     id = cuts.dot[1][0];
 
                     type = cuts.dot[0].slice(1).join('.');
@@ -1021,12 +1021,12 @@
                             what: '@type',
                             equalTo: 'DataSource'
                         }, {
-                            what: 'providerId',
-                            equalTo: parseInt(providerId, 10)
+                            what: 'providerName',
+                            equalTo: providerName
                         }]
                     });
 
-                    object = dataSource && $scope.findObject(dataSource.providerId, dataSource.type);
+                    object = dataSource && $scope.findObject(dataSource.providerName, dataSource.type);
 
                     param = object && $scope.util.find({
                         where: object.fields,
@@ -1353,7 +1353,7 @@
                                         what: '@type',
                                         equalTo: 'DataSource'
                                     }, {
-                                        what: 'providerId',
+                                        what: 'providerName',
                                         equalTo: splittedValue[1]
                                     }]
                                 });

--- a/modules/tasks/tasks/src/main/resources/webapp/js/services.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/services.js
@@ -1,4 +1,4 @@
-(function () {
+ (function () {
     'use strict';
 
     /* Services */

--- a/modules/tasks/tasks/src/main/resources/webapp/js/util.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/util.js
@@ -409,7 +409,7 @@
 
                     replaced.push({
                         find: '{{ad.{0}{1}}}'.format(found[1], found[3]),
-                        value: '{{ad.{0}{1}}}'.format(ds.providerId, found[3])
+                        value: '{{ad.{0}{1}}}'.format(ds.providerName, found[3])
                     });
                 }
 

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
@@ -335,6 +335,7 @@ task.validation.error.wrongStringManipulation=Manipulation ''{0}'' at ''{1}'' is
 task.validation.error.wrongDateManipulation=Manipulation ''{0}'' at ''{1}'' is not allowed for Date type field.
 task.validation.error.wrongDateManipulationTarget=Manipulation ''{0}'' at ''{1}'' is not allowed for Date type field if the parameter type is already Date.
 task.validation.error.wrongAnotherManipulation=Manipulation ''{0}'' at ''{1}'' is not allowed for that field.
+task.validation.error.provider.name=Invalid data provider name: ''{0}''. Provider names can only consist of letters, numbers, ''-'' and ''_''.
 
 task.string=String
 task.number=Number

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/form.html
@@ -133,7 +133,7 @@
                                                                             <li ng-show="ds.displayName != undefined" class="dropdown-submenu" ng-repeat="ds in task.taskConfig.steps">
                                                                                 <a tabindex="-1">{{taskMsg(ds.displayName)}}#{{ds.objectId}} ({{msg(ds.providerName)}})</a>
                                                                                 <ul class="dropdown-menu">
-                                                                                    <li ng-repeat="field in findObject(ds.providerId, ds.type).fields">
+                                                                                    <li ng-repeat="field in findObject(ds.providerName, ds.type).fields">
                                                                                         <a ng-click="selectParam(filter, 'ad', ds, field)">{{taskMsg(field.displayName)}}</a>
                                                                                     </li>
                                                                                 </ul>
@@ -230,7 +230,7 @@
                                             <div class="form-inline col-md-10 col-sm-9 move-element">
                                                 <span contenteditable="false" ng-repeat="i in selectedTrigger.eventParameters" class="badge badge-info triggerField" draggable data-prefix="trigger" data-index="{{$index}}" data-type="{{i.type}}" data-eventkey="{{i.eventKey}}">{{taskMsg(i.displayName)}}</span>​
                                                 <span ng-repeat="ds in getDataSources() | idLessThan:step.objectId">
-                                                    <span contenteditable="false" ng-repeat="i in findObject(ds.providerId, ds.type).fields" class="badge badge-warning triggerField" draggable
+                                                    <span contenteditable="false" ng-repeat="i in findObject(ds.providerName, ds.type).fields" class="badge badge-warning triggerField" draggable
                                                           data-prefix="ad" data-source="{{ds.providerName}}" data-object="{{ds.displayName}}" data-object-type="{{ds.type}}"
                                                           data-field="{{i.fieldKey}}" data-index="{{$index}}" data-object-id="{{ds.objectId}}" data-type="{{i.type}}">
                                                         {{taskMsg(ds.providerName)}}.{{taskMsg(ds.displayName)}}#{{ds.objectId}}.{{taskMsg(i.displayName)}}
@@ -258,12 +258,12 @@
                                                     <span class="caret"></span>
                                                 </button>
                                                 <ul class="dropdown-menu">
-                                                    <li class="search-data-source" ng-show="findDataSource(step.providerId).objects && findDataSource(step.providerId).objects.length &gt; 8" task-stop-propagation>
+                                                    <li class="search-data-source" ng-show="findDataSource(step.providerName).objects && findDataSource(step.providerName).objects.length &gt; 8" task-stop-propagation>
                                                         <input class="form-control" type="text" ng-model="searchData.displayName" placeholder="{{msg('task.placeholder.searchData')}}">
                                                     </li>
                                                     <li>
                                                         <ul class="select-limit">
-                                                            <li ng-repeat="object in findDataSource(step.providerId).objects | filter:searchData">
+                                                            <li ng-repeat="object in findDataSource(step.providerName).objects | filter:searchData">
                                                                 <a ng-click="selectObject(step, object)">{{taskMsg(object.displayName)}}</a>
                                                             </li>
                                                         </ul>
@@ -280,7 +280,7 @@
                                                         <span class="caret"></span>
                                                     </button>
                                                     <ul class="dropdown-menu">
-                                                        <li ng-repeat="lookup in findObject(step.providerId, step.type).lookupFields">
+                                                        <li ng-repeat="lookup in findObject(step.providerName, step.type).lookupFields">
                                                             <a ng-click="selectLookup(step, lookup)">{{taskMsg(lookup.displayName)}}</a>
                                                         </li>
                                                     </ul>
@@ -331,7 +331,7 @@
                                         <div class="form-group margin-before3 control-section" ng-hide="step.displayName == undefined">
                                             <label class="col-md-2 col-sm-3 control-label task-label">{{msg('task.subsubsection.objectFields')}}</label>
                                             <div class="form-inline col-md-10 col-sm-9 move-element">
-                                                <span ng-repeat="field in findObject(step.providerId, step.type).fields" class="badge badge-warning">{{taskMsg(field.displayName)}}</span>​
+                                                <span ng-repeat="field in findObject(step.providerName, step.type).fields" class="badge badge-warning">{{taskMsg(field.displayName)}}</span>​
                                             </div>
                                         </div>
                                     </div>
@@ -373,7 +373,7 @@
                                         <div class="form-inline col-md-10 col-sm-9 move-element">
                                             <span contenteditable="false" ng-repeat="i in selectedTrigger.eventParameters" class="badge badge-info triggerField" draggable data-prefix="trigger" data-index="{{$index}}" data-type="{{i.type}}" data-eventkey="{{i.eventKey}}">{{taskMsg(i.displayName)}}</span>​
                                             <span ng-repeat="ds in getDataSources()">
-                                                <span contenteditable="false" ng-repeat="i in findObject(ds.providerId, ds.type).fields" class="badge badge-warning triggerField" draggable
+                                                <span contenteditable="false" ng-repeat="i in findObject(ds.providerName, ds.type).fields" class="badge badge-warning triggerField" draggable
                                                       data-prefix="ad" data-source="{{ds.providerName}}" data-object="{{ds.displayName}}" data-object-type="{{ds.type}}"
                                                       data-field="{{i.fieldKey}}" data-index="{{$index}}" data-object-id="{{ds.objectId}}" data-type="{{i.type}}">
                                                     {{taskMsg(ds.providerName)}}.{{taskMsg(ds.displayName)}}#{{ds.objectId}}.{{taskMsg(i.displayName)}}

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/widgets/string-manipulation-format.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/widgets/string-manipulation-format.html
@@ -11,7 +11,7 @@
                     <div class="move-element col-md-9 col-sm-8">
                         <span contenteditable="false" ng-repeat="i in selectedTrigger.eventParameters track by $index" class="badge badge-info triggerField" draggable data-prefix="trigger" data-index="{{$index}}" data-type="{{i.type}}" data-popover="no">{{taskMsg(i.displayName)}}</span>​
                         <span ng-repeat="ds in getDataSources() track by $index">
-                            <span contenteditable="false" ng-repeat="i in findObject(ds.providerId, ds.type).fields" class="badge badge-warning triggerField" draggable
+                            <span contenteditable="false" ng-repeat="i in findObject(ds.providerName, ds.type).fields" class="badge badge-warning triggerField" draggable
                                 data-prefix="ad" data-source="{{ds.providerName}}" data-object="{{ds.displayName}}" data-object-type="{{ds.type}}"
                                 data-field="{{i.fieldKey}}" data-index="{{$index}}" data-object-id="{{ds.objectId}}" data-type="{{i.type}}" data-popover="no">
                                 {{msg(ds.providerName)}}.{{taskMsg(ds.displayName)}}#{{ds.objectId}}.{{taskMsg(i.displayName)}}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/compatibility/TaskMigrationManagerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/compatibility/TaskMigrationManagerTest.java
@@ -1,0 +1,44 @@
+package org.motechproject.tasks.compatibility;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.tasks.domain.Task;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskMigrationManagerTest {
+
+    private TaskMigrationManager taskMigrationManager = new TaskMigrationManager();
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private TaskMigrator migrator1;
+
+    @Mock
+    private TaskMigrator migrator2;
+
+    @Before
+    public void setUp() {
+        Set<TaskMigrator> migrators = new HashSet<>(asList(migrator1, migrator2));
+        ReflectionTestUtils.setField(taskMigrationManager, "migrators", migrators);
+    }
+
+    @Test
+    public void shouldMigrateTasks() {
+        taskMigrationManager.migrateTask(task);
+
+        verify(migrator1).migrate(task);
+        verify(migrator2).migrate(task);
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigratorTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/compatibility/impl/ProviderNameTaskMigratorTest.java
@@ -1,0 +1,114 @@
+package org.motechproject.tasks.compatibility.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.tasks.domain.DataSource;
+import org.motechproject.tasks.domain.Filter;
+import org.motechproject.tasks.domain.FilterSet;
+import org.motechproject.tasks.domain.Lookup;
+import org.motechproject.tasks.domain.Task;
+import org.motechproject.tasks.domain.TaskActionInformation;
+import org.motechproject.tasks.domain.TaskConfig;
+import org.motechproject.tasks.ex.ProviderNotFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProviderNameTaskMigratorTest {
+
+    private ProviderNameTaskMigrator migrator = new ProviderNameTaskMigrator();
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private TaskConfig taskConfig;
+
+    @Mock
+    private TaskActionInformation action1;
+
+    @Mock
+    private TaskActionInformation action2;
+
+    @Mock
+    private DataSource dataSource1;
+
+    @Mock
+    private DataSource dataSource2;
+
+    @Mock
+    private FilterSet filterSet;
+
+    @Mock
+    private Filter filter;
+
+    @Mock
+    private Lookup lookup;
+
+    private Map<String, String> action1Values;
+
+    private Map<String, String> action2Values;
+
+    @Test
+    public void shouldMigrateTasks() {
+        prepareTask();
+
+        migrator.migrate(task);
+
+        // make sure the maps for actions were change accordingly
+        assertEquals("{{ad.data-services.MotechPermission#0.name}}", action1Values.get("key-to-change"));
+        assertEquals("{{ad.data-services.MotechPermission#1.name}}", action1Values.get("key-to-leave"));
+
+        assertEquals("{{ad.cms-lite.StringResource#0.value}}", action2Values.get("key-to-change"));
+        assertEquals("test", action2Values.get("key-to-leave"));
+
+        //verify changes to task config
+        verify(filter).setKey("ad.data-services.MotechPermission#0.name");
+        verify(lookup).setValue("{{ad.data-services.MotechPermission#0.name}}");
+    }
+
+    @Test(expected = ProviderNotFoundException.class)
+    public void shouldThrowExceptionOnNonExistentProvider() {
+        prepareTask();
+        action1Values.put("invalid", "{{ad.3.something#1.val}}");
+
+        migrator.migrate(task);
+    }
+
+    private void prepareTask() {
+        when(task.getTaskConfig()).thenReturn(taskConfig);
+        when(task.getActions()).thenReturn(asList(action1, action2));
+        when(taskConfig.getDataSources()).thenReturn(asList(dataSource1, dataSource2));
+        when(taskConfig.getFilters()).thenReturn(singletonList(filterSet));
+        when(filterSet.getFilters()).thenReturn(singletonList(filter));
+
+        action1Values = new HashMap<>();
+        action1Values.put("key-to-change", "{{ad.1.MotechPermission#0.name}}");
+        action1Values.put("key-to-leave", "{{ad.data-services.MotechPermission#1.name}}");
+        when(action1.getValues()).thenReturn(action1Values);
+
+        action2Values = new HashMap<>();
+        action2Values.put("key-to-change", "{{ad.2.StringResource#0.value}}");
+        action2Values.put("key-to-leave", "test");
+        when(action2.getValues()).thenReturn(action2Values);
+
+        when(filter.getKey()).thenReturn("ad.1.MotechPermission#0.name");
+
+        when(dataSource1.getProviderId()).thenReturn(1L);
+        when(dataSource1.getProviderName()).thenReturn("data-services");
+
+        when(dataSource2.getProviderId()).thenReturn(2L);
+        when(dataSource2.getProviderName()).thenReturn("cms-lite");
+        when(dataSource2.getLookup()).thenReturn(singletonList(lookup));
+        when(lookup.getValue()).thenReturn("{{ad.1.MotechPermission#0.name}}");
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/domain/KeyInformationTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/domain/KeyInformationTest.java
@@ -14,7 +14,7 @@ import static org.motechproject.tasks.domain.KeyInformation.TRIGGER_PREFIX;
 
 public class KeyInformationTest {
     private static final String KEY_VALUE = "key";
-    private static final Long DATA_PROVIDER_ID = 12345L;
+    private static final String DATA_PROVIDER_NAME = "TestProvider";
     private static final String OBJECT_TYPE = "Test";
     private static final String OBJECT_TYPE_2 = "Test_Data";
     private static final Long OBJECT_ID = 1L;
@@ -37,12 +37,12 @@ public class KeyInformationTest {
 
     @Test
     public void shouldGetInformationFromAdditionalDataKey() {
-        String original = String.format("%s.%s.%s#%d.%s", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
+        String original = String.format("%s.%s.%s#%d.%s", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
         KeyInformation key = KeyInformation.parse(original);
 
         assertKeyFromAdditionalData(original, key);
 
-        original = String.format("%s.%s.%s#%d.%s", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE_2, OBJECT_ID, KEY_VALUE);
+        original = String.format("%s.%s.%s#%d.%s", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE_2, OBJECT_ID, KEY_VALUE);
         key = KeyInformation.parse(original);
 
         assertKeyFromAdditionalData(original, key, OBJECT_TYPE_2);
@@ -50,12 +50,12 @@ public class KeyInformationTest {
 
     @Test
     public void shouldGetInformationFromAdditionalDataKeyWithManipulations() {
-        String original = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
+        String original = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
         KeyInformation key = KeyInformation.parse(original);
 
         assertKeyFromAdditionalData(original, key);
 
-        original = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE_2, OBJECT_ID, KEY_VALUE);
+        original = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE_2, OBJECT_ID, KEY_VALUE);
         key = KeyInformation.parse(original);
 
         assertKeyFromAdditionalData(original, key, OBJECT_TYPE_2);
@@ -64,7 +64,7 @@ public class KeyInformationTest {
     @Test
     public void shouldFindAllKeysInString() {
         String trigger = String.format("%s.%s?toupper?join(-)", TRIGGER_PREFIX, KEY_VALUE);
-        String additionalData = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
+        String additionalData = String.format("%s.%s.%s#%d.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE, OBJECT_ID, KEY_VALUE);
         String original = String.format("Trigger: {{%s}} Additional data: {{%s}}", trigger, additionalData);
 
         List<KeyInformation> keys = KeyInformation.parseAll(original);
@@ -81,7 +81,7 @@ public class KeyInformationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionWhenAdditionalDataKeyHasIncorrectFormat() {
-        String original = String.format("%s.%s.%s#.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_ID, OBJECT_TYPE, KEY_VALUE);
+        String original = String.format("%s.%s.%s#.%s?toupper?join(-)", ADDITIONAL_DATA_PREFIX, DATA_PROVIDER_NAME, OBJECT_TYPE, KEY_VALUE);
         KeyInformation.parse(original);
     }
 
@@ -106,7 +106,7 @@ public class KeyInformationTest {
 
         assertNull(triggerKey.getObjectId());
         assertNull(triggerKey.getObjectType());
-        assertNull(triggerKey.getDataProviderId());
+        assertNull(triggerKey.getDataProviderName());
 
         assertManipulations(triggerKey);
     }
@@ -119,7 +119,7 @@ public class KeyInformationTest {
         assertTrue(additionalDataKey.fromAdditionalData());
         assertFalse(additionalDataKey.fromTrigger());
 
-        assertEquals(DATA_PROVIDER_ID, additionalDataKey.getDataProviderId());
+        assertEquals(DATA_PROVIDER_NAME, additionalDataKey.getDataProviderName());
         assertEquals(objectType, additionalDataKey.getObjectType());
         assertEquals(OBJECT_ID, additionalDataKey.getObjectId());
         assertEquals(KEY_VALUE, additionalDataKey.getKey());

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/it/TasksBundleIT.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/it/TasksBundleIT.java
@@ -95,14 +95,14 @@ public class TasksBundleIT extends BasePaxIT {
         int tries = 0;
 
         do {
-            fromFile = taskDataProviderService.getProvider("mrs.name");
+            fromFile = taskDataProviderService.getProvider("mrs-name");
             ++tries;
             Thread.sleep(500);
         } while (fromFile == null && tries < TRIES_COUNT);
 
         assertNotNull(fromFile);
 
-        TaskDataProvider fromDB = dataProviderDataService.findByName("mrs.name");
+        TaskDataProvider fromDB = dataProviderDataService.findByName("mrs-name");
 
         assertNotNull(fromDB);
         assertEquals(fromDB, fromFile);

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/json/TaskDeserializerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/json/TaskDeserializerTest.java
@@ -45,7 +45,7 @@ public class TaskDeserializerTest {
 
         Map<String, String> actionValues = new HashMap<>();
         actionValues.put("delivery_time", "12:00");
-        actionValues.put("message", "Congratulations,    {{ad.6899548.Person#1.firstName}}, your pregnancy test was positive. Please reply to schedule a clinic visit with your midwife.");
+        actionValues.put("message", "Congratulations,    {{ad.TestProvider.Person#1.firstName}}, your pregnancy test was positive. Please reply to schedule a clinic visit with your midwife.");
         actionValues.put("message", "{{trigger.PatientId}}");
 
         TaskActionInformation actionInformation = new TaskActionInformation(null, "sms.api", "motech-sms-api-bundle", "0.19.0.SNAPSHOT", "SendSMS", actionValues);
@@ -56,7 +56,7 @@ public class TaskDeserializerTest {
 
         EXPECTED_TASK = new Task();
         EXPECTED_TASK.getTaskConfig().add(new FilterSet(filters));
-        EXPECTED_TASK.getTaskConfig().add(new DataSource(6899548L, 1L, "Person", "id", asList(new Lookup("mrs.person.lookupField.id", "trigger.PatientId")), false));
+        EXPECTED_TASK.getTaskConfig().add(new DataSource("TestProvider", 6899548L, 1L, "Person", "id", asList(new Lookup("mrs.person.lookupField.id", "trigger.PatientId")), false));
         EXPECTED_TASK.setName(name);
         EXPECTED_TASK.setEnabled(false);
         EXPECTED_TASK.setHasRegisteredChannel(true);

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskFilterExecutorTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/TaskFilterExecutorTest.java
@@ -59,9 +59,9 @@ public class TaskFilterExecutorTest {
     public void testcheckFilters() throws TaskHandlerException {
         DateTime dateTime = DateTime.now().minusDays(2);
 
-        DataSource dataSource = new DataSource(null, 0L, "", "", null, false);
+        DataSource dataSource = new DataSource("TestProvider", null, 0L, "", "", null, false);
         TaskConfig taskConfig = mock(TaskConfig.class);
-        when(taskConfig.getDataSource(anyLong(), anyLong(), anyString())).thenReturn(dataSource);
+        when(taskConfig.getDataSource(anyString(), anyLong(), anyString())).thenReturn(dataSource);
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
         TaskContext taskContext = new TaskContext(task, null, activityService);

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/validation/TaskDataProviderValidatorTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/validation/TaskDataProviderValidatorTest.java
@@ -1,0 +1,106 @@
+package org.motechproject.tasks.validation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.motechproject.tasks.domain.LookupFieldsParameter;
+import org.motechproject.tasks.domain.TaskDataProvider;
+import org.motechproject.tasks.domain.TaskDataProviderObject;
+import org.motechproject.tasks.domain.TaskError;
+
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskDataProviderValidatorTest {
+
+    @Mock
+    private TaskDataProvider provider;
+
+    @Mock
+    private TaskDataProviderObject providerObject;
+
+    @Test
+    public void shouldValidateValidNames() {
+        mockValidProviderObjects();
+
+        testValidName("test");
+        testValidName("MyName");
+        testValidName("data-services");
+        testValidName("cms_lite_123");
+    }
+
+    @Test
+    public void shouldValidateAgainstBlankName() {
+        when(provider.getName()).thenReturn("");
+        mockValidProviderObjects();
+
+        Set<TaskError> errors = TaskDataProviderValidator.validate(provider);
+
+        assertSingleError(errors, "task.validation.error.blank", "name", "taskDataProvider");
+    }
+
+    @Test
+    public void shouldValidateAgainstNullName() {
+        when(provider.getName()).thenReturn(null);
+        mockValidProviderObjects();
+
+        Set<TaskError> errors = TaskDataProviderValidator.validate(provider);
+
+        assertSingleError(errors, "task.validation.error.blank", "name", "taskDataProvider");
+    }
+
+    @Test
+    public void shouldValidateAgainstInvalidName() {
+        mockValidProviderObjects();
+
+        testInvalidName("A space");
+        testInvalidName("Symbols$#");
+        testInvalidName(";wrong");
+    }
+
+    private void testValidName(String name) {
+        when(provider.getName()).thenReturn(name);
+
+        Set<TaskError> errors = TaskDataProviderValidator.validate(provider);
+
+        assertNotNull(errors);
+        assertTrue(errors.isEmpty());
+    }
+
+    private void testInvalidName(String name) {
+        when(provider.getName()).thenReturn(name);
+
+        Set<TaskError> errors = TaskDataProviderValidator.validate(provider);
+
+        assertSingleError(errors, "task.validation.error.provider.name", name);
+    }
+
+    private void assertSingleError(Set<TaskError> errors, String reason, String... args) {
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+
+        TaskError error = errors.iterator().next();
+
+        assertNotNull(error);
+        assertEquals(reason, error.getMessage());
+        assertEquals(asList(args), error.getArgs());
+    }
+
+    private void mockValidProviderObjects() {
+        when(providerObject.getLookupFields()).thenReturn(singletonList(
+                new LookupFieldsParameter("disp", singletonList("field"))));
+        when(providerObject.getType()).thenReturn("type");
+        when(providerObject.getDisplayName()).thenReturn("disp");
+
+        when(provider.getObjects()).thenReturn(singletonList(providerObject));
+    }
+}

--- a/modules/tasks/tasks/src/test/resources/mrs-test-data-provider.json
+++ b/modules/tasks/tasks/src/test/resources/mrs-test-data-provider.json
@@ -1,5 +1,5 @@
 {
-    "name": "mrs.name",
+    "name": "mrs-name",
     "objects": [
         {
             "displayName": "mrs.patient.name",

--- a/modules/tasks/tasks/src/test/resources/new-task-version.json
+++ b/modules/tasks/tasks/src/test/resources/new-task-version.json
@@ -23,6 +23,7 @@
         }, {
             "@type": "DataSource",
             "providerId": 6899548,
+            "providerName": "TestProvider",
             "objectId": 1,
             "type": "Person",
             "name":"id",
@@ -45,7 +46,7 @@
             "serviceMethod": null,
             "values": {
                 "delivery_time": "12:00",
-                "message": "Congratulations,                {{ad.6899548.Person#1.firstName}}, your pregnancy test was positive. Please reply to schedule a clinic visit with your midwife.",
+                "message": "Congratulations,                {{ad.TestProvider.Person#1.firstName}}, your pregnancy test was positive. Please reply to schedule a clinic visit with your midwife.",
                 "message": "{{trigger.PatientId}}"
             }
         }

--- a/modules/tasks/tasks/src/test/resources/task-data-provider.json
+++ b/modules/tasks/tasks/src/test/resources/task-data-provider.json
@@ -1,5 +1,5 @@
 {
-    "name": "mrs.name",
+    "name": "mrs-name",
     "objects": [
         {
             "displayName": "mrs.patient.name",


### PR DESCRIPTION
Using IDs was a wrong design decision here, they cause a plethora of issues. Compatibility for old tasks is retained thanks to the introduction of a task migrator mechanism. Moreover, a fix for tasks event listeners not being unregistered was also introduced.