### PR TITLE
MOTECH-2316: Fixed Motech-Commons data provider name [0.28.X]

### DIFF
--- a/platform/server-bundle/src/main/resources/commons-data-provider.json
+++ b/platform/server-bundle/src/main/resources/commons-data-provider.json
@@ -1,5 +1,5 @@
 {
-    "name":"MOTECH Commons",
+    "name":"MOTECH-Commons",
     "objects": [
         {
             "displayName":"server.provider.displayName",


### PR DESCRIPTION
After adding name validation to tasks data provider, names can only consist of
letters, numbers, - and _. So the name for motech commons data provider must be
change to MOTECH-Commons.