### PR TITLE
MOTECH-2390: Fixed delete option for permissions in WebSecurity

### DIFF
--- a/platform/web-security/src/main/resources/webapp/css/websecurity.css
+++ b/platform/web-security/src/main/resources/webapp/css/websecurity.css
@@ -64,3 +64,9 @@
 .security .info-block {
     display: none;
 }
+
+.security .disabled-link {
+    cursor: default;
+    color: grey;
+    text-decoration: none;
+}

--- a/platform/web-security/src/main/resources/webapp/messages/messages.properties
+++ b/platform/web-security/src/main/resources/webapp/messages/messages.properties
@@ -115,7 +115,7 @@ security.confirmationRequired=Password confirmation is required
 security.emailTaken=Email already in use
 security.confirm=Confirm
 security.confirm.permissionDelete=Delete this permission?
-security.defaultPermission=You can not delete a default permission
+security.predefinedPermission=You can not delete a predefined permission
 
 security.create.user.saved=User has been saved
 security.create.user.error=User has not been saved

--- a/platform/web-security/src/main/resources/webapp/messages/messages.properties
+++ b/platform/web-security/src/main/resources/webapp/messages/messages.properties
@@ -115,6 +115,7 @@ security.confirmationRequired=Password confirmation is required
 security.emailTaken=Email already in use
 security.confirm=Confirm
 security.confirm.permissionDelete=Delete this permission?
+security.defaultPermission=You can not delete a default permission
 
 security.create.user.saved=User has been saved
 security.create.user.error=User has not been saved

--- a/platform/web-security/src/main/resources/webapp/partials/permission.html
+++ b/platform/web-security/src/main/resources/webapp/partials/permission.html
@@ -62,7 +62,7 @@
                     <a href="" ng-if="!permission.bundleName" ng-click="deletePermission(permission)">
                         <i class="fa fa-fw fa-trash-o" ></i> {{msg('security.delete')}}
                     </a>
-                    <a class="disabled-link" ng-if="permission.bundleName" bs-popover="{{msg('security.defaultPermission')}}"
+                    <a class="disabled-link" ng-if="permission.bundleName" bs-popover="{{msg('security.predefinedPermission')}}"
                        data-toggle="popover" data-placement="left" data-trigger="hover">
                         <i class="fa fa-fw fa-trash-o" ></i> {{msg('security.delete')}}
                     </a>

--- a/platform/web-security/src/main/resources/webapp/partials/permission.html
+++ b/platform/web-security/src/main/resources/webapp/partials/permission.html
@@ -59,8 +59,12 @@
                 <td>{{permission.permissionName}}</td>
                 <td>{{permission.bundleName}}</td>
                 <td>
-                    <a href="" ng-click="deletePermission(permission)" ui-if="!permission.bundleName">
-                        <i class="fa fa-fw fa-trash-o"></i> {{msg('security.delete')}}
+                    <a href="" ng-if="!permission.bundleName" ng-click="deletePermission(permission)">
+                        <i class="fa fa-fw fa-trash-o" ></i> {{msg('security.delete')}}
+                    </a>
+                    <a class="disabled-link" ng-if="permission.bundleName" bs-popover="{{msg('security.defaultPermission')}}"
+                       data-toggle="popover" data-placement="left" data-trigger="hover">
+                        <i class="fa fa-fw fa-trash-o" ></i> {{msg('security.delete')}}
                     </a>
                 </td>
             </tr>


### PR DESCRIPTION
Added delete option for all permissions in Security (permission.html, websecurity.css). If permission is default delete option is disabled and an appropriate message is shown when 'delete' is hovered.
Added content for the message in messages.properties.