### PR TITLE
MOTECH-2389: Fixed more than one same warning in Recent Task Activity

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/DataSourceObject.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/DataSourceObject.java
@@ -38,9 +38,13 @@ public class DataSourceObject {
         return failIfNotFound;
     }
 
-    public boolean isNullWarningPublished() { return nullWarningPublished; }
+    public boolean isNullWarningPublished() {
+        return nullWarningPublished;
+    }
 
-    public void setNullWarningPublished(boolean nullWarningPublished) { this.nullWarningPublished = nullWarningPublished; }
+    public void setNullWarningPublished(boolean nullWarningPublished) {
+        this.nullWarningPublished = nullWarningPublished;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/DataSourceObject.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/DataSourceObject.java
@@ -10,6 +10,7 @@ public class DataSourceObject {
     private String objectId;
     private Object objectValue;
     private boolean failIfNotFound;
+    private boolean nullWarningPublished;
 
     /**
      * Class constructor.
@@ -22,6 +23,7 @@ public class DataSourceObject {
         this.objectId = objectId;
         this.objectValue = objectValue;
         this.failIfNotFound = failIfNotFound;
+        this.nullWarningPublished = false;
     }
 
     public String getObjectId() {
@@ -35,6 +37,10 @@ public class DataSourceObject {
     public boolean isFailIfNotFound() {
         return failIfNotFound;
     }
+
+    public boolean isNullWarningPublished() { return nullWarningPublished; }
+
+    public void setNullWarningPublished(boolean nullWarningPublished) { this.nullWarningPublished = nullWarningPublished; }
 
     @Override
     public boolean equals(Object o) {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/TaskContext.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/TaskContext.java
@@ -88,8 +88,11 @@ public class TaskContext {
             if (dataSourceObject.isFailIfNotFound()) {
                 throw new TaskHandlerException(TaskFailureCause.DATA_SOURCE, "task.error.objectOfTypeNotFound", objectType);
             }
-            LOGGER.warn("Task data source object of type: {} not found", objectType);
-            publishWarningActivity("task.warning.notFoundObjectForType", objectType);
+            if (!dataSourceObject.isNullWarningPublished()) {
+                LOGGER.warn("Task data source object of type: {} not found", objectType);
+                publishWarningActivity("task.warning.notFoundObjectForType", objectType);
+                dataSourceObject.setNullWarningPublished(true);
+            }
             return null;
         }
 

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -112,7 +112,7 @@
                                     '<pre id="stackTraceElement' + k + '" class="collapse">' + stackTraceElement + '</pre>'
                                     ,'ok',{ },'');
                             } else if (message !== undefined) {
-                                $("#taskHistoryTable").jqGrid('setCell',rows[k],'message',scope.msg(message),'ok',{ },'');
+                                $("#taskHistoryTable").jqGrid('setCell',rows[k],'message',scope.msg(messageToShow),'ok',{ },'');
                             }
                         }
                     },

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskTriggerHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskTriggerHandlerTest.java
@@ -1283,7 +1283,7 @@ public class TaskTriggerHandlerTest {
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskActivityService).addWarning(task, "task.warning.serviceUnavailable", actionEvent.getServiceInterface());
-        verify(taskActivityService, times(2)).addWarning(task, "task.warning.notFoundObjectForType", "TestObjectField");
+        verify(taskActivityService).addWarning(task, "task.warning.notFoundObjectForType", "TestObjectField");
         verify(taskActivityService).addSuccess(task);
 
         ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);


### PR DESCRIPTION
Warning about null object of given type is shown only once in recent task activity.
Message of warning specifies object of what type cannot be found.