### PR TITLE
MOTECH-2121: Adjusted deb packaging config

### DIFF
--- a/packaging/deb/src/main/debian/motech-base/DEBIAN/control
+++ b/packaging/deb/src/main/debian/motech-base/DEBIAN/control
@@ -4,7 +4,7 @@ Section: web
 Priority: optional
 Architecture: all
 Installed-Size: 57000
-Depends: sysv-rc, curl, tomcat7-common
+Depends: sysv-rc, curl, tomcat7-common, openjdk-8-jdk | oracle-java8-installer
 Maintainer: Grameen Foundation <motech-dev@googlegroups.com>
 Description: Mobile Technology for Community Health
  MOTECH is a software system from Grameen Foundation that harnesses the 

--- a/packaging/deb/src/main/debian/motech-base/etc/init.d/motech
+++ b/packaging/deb/src/main/debian/motech-base/etc/init.d/motech
@@ -56,7 +56,7 @@ TOMCAT7_GROUP=motech
 
 # The first existing directory is used for JAVA_HOME (if JAVA_HOME is not
 # defined in $DEFAULT)
-JDK_DIRS="/usr/lib/jvm/java-8-oracle /usr/lib/jvm/default-java /usr/lib/jvm/java-7-openjdk /usr/lib/jvm/java-7-openjdk-i386 /usr/lib/jvm/java-1.7.0-openjdk-amd64 /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-1.7.0-oracle /usr/lib/j2sdk1.7-oracle /usr/lib/j2sdk1.7-ibm /usr/lib/jvm/java-7-sun"
+JDK_DIRS="/usr/lib/jvm/java-1.8.0-openjdk-amd64 /usr/lib/jvm/java-8-openjdk-amd64 /usr/lib/jvm/java-8-oracle"
 
 # Look for the right JVM to use
 for jdir in $JDK_DIRS; do


### PR DESCRIPTION
Since 0.28.X Motech needs Java 8, so I updated paths for JDK. Now it reflects
only Java 8 dirs. Additionally I added Java 8 as dependency in daemon config.