### PR TITLE
MOTECH-2407: Fixed execution of lookup with related field on the UI

### DIFF
--- a/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/util/query/QueryParamsBuilder.java
+++ b/platform/mds/mds-web/src/main/java/org/motechproject/mds/web/util/query/QueryParamsBuilder.java
@@ -100,8 +100,10 @@ public final class QueryParamsBuilder {
         List<Order> orderList = new ArrayList<>();
 
         for (String fieldName : lookupMap.keySet()) {
-            // we do ascending on each lookup field by default
-            orderList.add(new Order(fieldName, Order.Direction.ASC));
+            // we do ascending on each lookup field, which is not related, by default
+            if (!fieldName.contains(".")) {
+                orderList.add(new Order(fieldName, Order.Direction.ASC));
+            }
         }
 
         if (!lookupMap.containsKey(Constants.Util.ID_FIELD_NAME)) {


### PR DESCRIPTION
The bug regards lookups which use related lookup field. During execution on the UI
by default there is added a default order for a lookup using its fields. The problem
occurs when this field is a related collection. I know it is not easy to understand,
so let use an example.

@Entity
Author {

    String name

}

@Entity
Book {

    @Field
    List<Author> authors

    @Field
    Author mainAuthor

}

If we execute a lookup 'By Authors name' the error will pop out. Because jdo
query looks like the following:
... ORDER BY authors.name ascending ...
However should be :
... ORDER BY elementauthorsname.name ascending ...

A lookup 'By Main Author name' works properly.

I have tried to separate this two cases, however it requires using some magic code.
Moreover I think that sorting by related field does not make sense especially
when this is 1:M relation (how should it sort ?).

I decided to remove sorting by related lookup field.