### PR TITLE
MOTECH-2447: Fixed two Scheduler Task actions in Scheduler [0.27.X]

### DIFF
--- a/modules/scheduler/scheduler/src/main/resources/task-channel.json
+++ b/modules/scheduler/scheduler/src/main/resources/task-channel.json
@@ -58,7 +58,7 @@
         }, {
           "key": "repeatIntervalInMilliSeconds",
           "displayName": "scheduler.repeatIntervalInMilliSeconds",
-          "type": "LONG"
+          "type": "INTEGER"
         }, {
           "key": "ignorePastFiresAtStart",
           "displayName": "scheduler.ignorePastFiresAtStart",
@@ -125,9 +125,9 @@
       ]
     },
 {
-      "displayName": "scheduler.schedulePeriodRepeatingJob",
+      "displayName": "scheduler.scheduleRepeatingPeriodJob",
       "serviceInterface": "org.motechproject.scheduler.service.MotechSchedulerActionProxyService",
-      "serviceMethod": "schedulePeriodRepeatingJob",
+      "serviceMethod": "scheduleRepeatingPeriodJob",
       "actionParameters": [
         {
           "key": "motechEventSubject",

--- a/modules/scheduler/scheduler/src/main/resources/webapp/messages/messages.properties
+++ b/modules/scheduler/scheduler/src/main/resources/webapp/messages/messages.properties
@@ -3,7 +3,7 @@ scheduler.scheduleCronJob=Schedule cron job
 scheduler.scheduleRepeatingJob=Schedule repeating job
 scheduler.scheduleRunOnceJob=Schedule run once job
 scheduler.scheduleDayOfWeekJob=Schedule day of week job
-scheduler.schedulePeriodRepeatingJob=Schedule repeating job with period interval
+scheduler.scheduleRepeatingPeriodJob=Schedule repeating job with period interval
 scheduler.unscheduleJobs=Unschedule jobs
 
 scheduler.motechEventSubject=Motech event subject


### PR DESCRIPTION
- Fixed the name of the RepeatingPeriodJob.
- Changed parameter type for INTEGER in repeatIntervalInMilliSeconds in RepeatingJob.
- Fixed the name of the message used when adding action for Scheduler in Task module for proper displaying.

Now it is possible to Schedule RepeatingJob and RepeatingPeriodJob in Task action.