### PR TITLE
MOTECH-2296 Ability to register callbacks to MotechEvents

### DIFF
--- a/platform/event/src/main/java/org/motechproject/event/MotechEvent.java
+++ b/platform/event/src/main/java/org/motechproject/event/MotechEvent.java
@@ -24,6 +24,8 @@ public class MotechEvent implements Serializable {
     private int redeliveryCount;
     private String subject;
     private String messageDestination;
+    private String callbackName;
+    private Map<String, Object> metadata;
     private Map<String, Object> parameters;
 
     public MotechEvent() {
@@ -47,9 +49,22 @@ public class MotechEvent implements Serializable {
      * @throws IllegalArgumentException if the subject is null or contains <code>'*', '..'</code>
      */
     public MotechEvent(String subject, Map<String, Object> parameters) {
+        this(subject, parameters, null);
+    }
+
+    /**
+     * Constructs a MotechEvent with the given subject, parameters and the callback name.
+     *
+     * @param subject the subject of the event
+     * @param parameters the map of additional parameters
+     * @param callbackName the name of the callback
+     * @throws IllegalArgumentException if the subject is null or contains <code>'*', '..'</code>
+     */
+    public MotechEvent(String subject, Map<String, Object> parameters, String callbackName) {
         validateSubject(subject);
         this.subject = subject;
         this.parameters = parameters;
+        this.callbackName = callbackName;
     }
 
     /**
@@ -152,6 +167,23 @@ public class MotechEvent implements Serializable {
     }
 
     /**
+     * Returns the name of the callback to invoke after this event is handled
+     *
+     * @return callback name
+     */
+    public String getCallbackName() {
+        return callbackName;
+    }
+
+    /**
+     * Sets the name of the callback to invoke after this event is handled
+     * @param callbackName
+     */
+    public void setCallbackName(String callbackName) {
+        this.callbackName = callbackName;
+    }
+
+    /**
      * Returns the parameters, if null returns
      * empty <code>HashMap</code>.
      *
@@ -164,7 +196,28 @@ public class MotechEvent implements Serializable {
         return parameters;
     }
 
-    @Override
+    /**
+     * Returns the metadata of this MotechEvent. It can store any additional data, that is not meant to be the event's payload.
+     * If null, returns empty <code>HashMap</code>.
+     *
+     * @return the map of metadata
+     */
+    public Map<String, Object> getMetadata() {
+        if (metadata == null) {
+            metadata = new HashMap<>();
+        }
+        return metadata;
+    }
+
+    /**
+     * Sets the metadata of this MotechEvent. It can store any additional data, that is not meant to be the event's payload.
+     * @param metadata the metadata map
+     */
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override //NO CHECKSTYLE CyclomaticComplexity
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -181,6 +234,8 @@ public class MotechEvent implements Serializable {
                 Objects.equals(redeliveryCount, that.redeliveryCount) &&
                 Objects.equals(subject, that.subject) &&
                 Objects.equals(messageDestination, that.messageDestination) &&
+                Objects.equals(callbackName, that.callbackName) &&
+                Objects.equals(metadata, that.metadata) &&
                 Objects.equals(parameters, that.parameters);
     }
 
@@ -192,6 +247,8 @@ public class MotechEvent implements Serializable {
                 redeliveryCount,
                 subject,
                 messageDestination,
+                callbackName,
+                metadata,
                 parameters);
     }
 
@@ -206,6 +263,8 @@ public class MotechEvent implements Serializable {
         sb.append(", discarded=").append(discarded);
         sb.append(", broadcast=").append(broadcast);
         sb.append(", destination='").append(messageDestination).append('\'');
+        sb.append(", callbackName=").append(callbackName);
+        sb.append(", metadata=").append(metadata);
         sb.append(", parameters=").append(parameters);
         sb.append('}');
         return sb.toString();

--- a/platform/event/src/main/java/org/motechproject/event/exception/CallbackServiceNotFoundException.java
+++ b/platform/event/src/main/java/org/motechproject/event/exception/CallbackServiceNotFoundException.java
@@ -1,0 +1,17 @@
+package org.motechproject.event.exception;
+
+/**
+ * Signals that the callback service of the name, specified by {@link org.motechproject.event.MotechEvent#callbackName}
+ * could not be found in the running OSGi container.
+ */
+public class CallbackServiceNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = -7518524483057358206L;
+
+    /**
+     * @param callbackName the callback name used in {@link org.motechproject.event.MotechEvent}
+     */
+    public CallbackServiceNotFoundException(String callbackName) {
+        super("Could not find OSGi service, acting as a callback for " + callbackName);
+    }
+}

--- a/platform/event/src/main/java/org/motechproject/event/listener/EventCallbackService.java
+++ b/platform/event/src/main/java/org/motechproject/event/listener/EventCallbackService.java
@@ -1,0 +1,35 @@
+package org.motechproject.event.listener;
+
+import org.motechproject.event.MotechEvent;
+
+/**
+ * Implementing {@link EventCallbackService} and exposing it as OSGi service allows to receive callbacks, after
+ * the events have been handled by their respective listener. In order to invoke a callback, the name of the callback service must be set in
+ * the {@link MotechEvent} and must match the name returned by the {@link #getName()} method.
+ */
+public interface EventCallbackService {
+
+    /**
+     * Callback method, invoked when the event handler method has thrown an exception.
+     *
+     * @param event the event that was being handled
+     * @param throwable the throwable that has caused the failure
+     * @return true, if the event system should proceed with retries; false otherwise
+     */
+    boolean failureCallback(MotechEvent event, Throwable throwable);
+
+    /**
+     * Callback method, invoked when the event handler method has executed successfully.
+     *
+     * @param event the event that has been handled
+     */
+    void successCallback(MotechEvent event);
+
+    /**
+     * The name of this callback. It must match the name set in the {@link MotechEvent#callbackName} in order to have
+     * the callbacks invoked.
+     *
+     * @return callback name
+     */
+    String getName();
+}

--- a/platform/event/src/main/java/org/motechproject/event/listener/impl/EventListenerTree.java
+++ b/platform/event/src/main/java/org/motechproject/event/listener/impl/EventListenerTree.java
@@ -21,7 +21,7 @@ public class EventListenerTree {
 
     private static final String SPLIT_REGEX = "\\.";
 
-    private List<EventListenerTree> children = new ArrayList<EventListenerTree>();
+    private List<EventListenerTree> children = new ArrayList<>();
     private EventListenerTree parent;
 
     private String pathElement;

--- a/platform/event/src/main/java/org/motechproject/event/listener/impl/ServerEventRelay.java
+++ b/platform/event/src/main/java/org/motechproject/event/listener/impl/ServerEventRelay.java
@@ -1,12 +1,18 @@
 package org.motechproject.event.listener.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.motechproject.event.MotechEvent;
+import org.motechproject.event.exception.CallbackServiceNotFoundException;
+import org.motechproject.event.listener.EventCallbackService;
 import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.messaging.MotechEventConfig;
 import org.motechproject.event.messaging.OutboundEventGateway;
 import org.motechproject.event.utils.MotechProxyUtils;
 import org.motechproject.server.osgi.event.OsgiEventProxy;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
@@ -15,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -33,14 +40,16 @@ public class ServerEventRelay implements EventRelay, EventHandler {
     private OutboundEventGateway outboundEventGateway;
     private MotechEventConfig motechEventConfig;
     private EventAdmin osgiEventAdmin;
+    private BundleContext bundleContext;
 
     @Autowired
     public ServerEventRelay(OutboundEventGateway outboundEventGateway, EventListenerRegistry eventListenerRegistry, MotechEventConfig motechEventConfig,
-                            EventAdmin osgiEventAdmin) {
+                            EventAdmin osgiEventAdmin, BundleContext bundleContext) {
         this.outboundEventGateway = outboundEventGateway;
         this.eventListenerRegistry = eventListenerRegistry;
         this.motechEventConfig = motechEventConfig;
         this.osgiEventAdmin = osgiEventAdmin;
+        this.bundleContext = bundleContext;
     }
 
     // @TODO either relayQueueEvent should be made private, or this method moved out to it's own class.
@@ -146,29 +155,63 @@ public class ServerEventRelay implements EventRelay, EventHandler {
     }
 
     private void handleQueueEvent(EventListener listener, MotechEvent event) {
+        EventCallbackService callbackService = findCallbackService(event.getCallbackName());
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+
         try {
             Object target = MotechProxyUtils.getTargetIfProxied(listener);
             Thread.currentThread().setContextClassLoader(target.getClass().getClassLoader());
             listener.handle(event);
-
+            if (callbackService != null) {
+                callbackService.successCallback(event);
+            }
         } catch (RuntimeException e) {
             LOGGER.error("Handling error for event with subject {}", event.getSubject(), e);
 
-            event.setInvalid(true);
-            event.setMessageDestination(listener.getIdentifier());
+            if (callbackService == null || callbackService.failureCallback(event, e.getCause())) {
+                event.setInvalid(true);
+                event.setMessageDestination(listener.getIdentifier());
 
-            if (event.getMessageRedeliveryCount() == motechEventConfig.getMessageMaxRedeliveryCount()) {
-                event.setDiscarded(true);
-                LOGGER.error("Discarding Motech event {}. Max retry count reached.", event);
-                throw e;
+                if (event.getMessageRedeliveryCount() == motechEventConfig.getMessageMaxRedeliveryCount()) {
+                    event.setDiscarded(true);
+                    LOGGER.error("Discarding Motech event {}. Max retry count reached.", event);
+                    throw e;
+                }
+
+                event.incrementMessageRedeliveryCount();
+                outboundEventGateway.sendEventMessage(event);
+            } else {
+                LOGGER.info("Event failure callback service {} has prevented redelivery of failed event with subject {}.",
+                        callbackService.getName(), event.getSubject());
             }
-
-            event.incrementMessageRedeliveryCount();
-            outboundEventGateway.sendEventMessage(event);
+            return;
         } finally {
             Thread.currentThread().setContextClassLoader(oldClassLoader);
         }
+    }
+
+    private EventCallbackService findCallbackService(String callbackName) {
+        if (StringUtils.isEmpty(callbackName)) {
+            return null;
+        }
+
+        try {
+            Collection<ServiceReference<EventCallbackService>> references = bundleContext.getServiceReferences(EventCallbackService.class, null);
+
+            for (ServiceReference<EventCallbackService> ref : references) {
+                EventCallbackService callback = bundleContext.getService(ref);
+                if (callback.getName().equals(callbackName)) {
+                    return callback;
+                }
+            }
+        } catch (InvalidSyntaxException e) {
+            //Should never happen
+            LOGGER.error("Passed filter expression is incorrect.");
+        }
+
+        // If a non-null callback name has been provided, yet it cannot be found in
+        // the running context, this indicates an error
+        throw new CallbackServiceNotFoundException(callbackName);
     }
 
     private void handleTopicEvent(EventListener listener, MotechEvent event) {
@@ -212,7 +255,8 @@ public class ServerEventRelay implements EventRelay, EventHandler {
         for (EventListener listener : listeners) {
             parameters = new HashMap<>();
             parameters.putAll(event.getParameters());
-            enrichedEventMessage = new MotechEvent(event.getSubject(), parameters);
+            enrichedEventMessage = new MotechEvent(event.getSubject(), parameters, event.getCallbackName());
+            enrichedEventMessage.setMetadata(event.getMetadata());
             enrichedEventMessage.setMessageDestination(listener.getIdentifier());
             outboundEventGateway.sendEventMessage(enrichedEventMessage);
         }
@@ -258,6 +302,8 @@ public class ServerEventRelay implements EventRelay, EventHandler {
         copy.setDiscarded(event.isDiscarded());
         copy.setBroadcast(event.isBroadcast());
         copy.setMessageDestination(event.getMessageDestination());
+        copy.setCallbackName(event.getCallbackName());
+        copy.setMetadata(event.getMetadata());
         return copy;
     }
 

--- a/platform/event/src/test/java/org/motechproject/event/it/EventBundleIT.java
+++ b/platform/event/src/test/java/org/motechproject/event/it/EventBundleIT.java
@@ -82,7 +82,7 @@ public class EventBundleIT extends BasePaxIT {
     }
 
     @Test
-    public void testEventListener_WithAnnotation() throws Exception {
+    public void testEventListenerWithAnnotation() throws Exception {
         final TestEventListenerOsgi testEventListenerOsgi = (TestEventListenerOsgi)
                 ServiceRetriever.getWebAppContext(bundleContext, bundleContext.getBundle().getSymbolicName())
                         .getBean("testEventListenerOsgi");
@@ -98,7 +98,7 @@ public class EventBundleIT extends BasePaxIT {
     }
 
     @Test
-    public void testEventWithTypedPayload() throws Exception {
+    public void testEventWithTypedPayloadAndMetadata() throws Exception {
         final ArrayList<MotechEvent> receivedEvents = new ArrayList<>();
 
         registry.registerListener(new EventListener() {
@@ -120,12 +120,26 @@ public class EventBundleIT extends BasePaxIT {
         Map<String, Object> params = new HashMap<>();
         params.put("foo", new TestEventPayload());
 
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("meta", new TestEventPayload());
+        metadata.put("theNumberSeven", 7);
+
         wait2s();
-        eventRelay.sendEventMessage(new MotechEvent("event", params));
+        MotechEvent testEvent = new MotechEvent("event", params);
+        testEvent.setMetadata(metadata);
+        eventRelay.sendEventMessage(testEvent);
         wait2s();
 
         assertEquals(1, receivedEvents.size());
-        assertTrue(receivedEvents.get(0).getParameters().get("foo") instanceof TestEventPayload);
+        MotechEvent receivedEvent = receivedEvents.get(0);
+        assertTrue(receivedEvent.getParameters().get("foo") instanceof TestEventPayload);
+
+        assertEquals(2, receivedEvent.getMetadata().size());
+        assertTrue(receivedEvent.getMetadata().containsKey("meta"));
+        assertTrue(receivedEvent.getMetadata().containsKey("theNumberSeven"));
+        assertTrue(receivedEvent.getMetadata().get("meta") instanceof TestEventPayload);
+        assertEquals(7, receivedEvent.getMetadata().get("theNumberSeven"));
+
     }
 
     @Test

--- a/platform/event/src/test/java/org/motechproject/event/listener/impl/ServerEventRelayTest.java
+++ b/platform/event/src/test/java/org/motechproject/event/listener/impl/ServerEventRelayTest.java
@@ -1,6 +1,5 @@
 package org.motechproject.event.listener.impl;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,11 +10,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.domain.BuggyListener;
+import org.motechproject.event.exception.CallbackServiceNotFoundException;
+import org.motechproject.event.listener.EventCallbackService;
 import org.motechproject.event.listener.EventListener;
-import org.motechproject.event.listener.impl.EventListenerRegistry;
-import org.motechproject.event.listener.impl.ServerEventRelay;
 import org.motechproject.event.messaging.MotechEventConfig;
 import org.motechproject.event.messaging.OutboundEventGateway;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 
@@ -44,6 +45,8 @@ public class ServerEventRelayTest {
     public static final String SECONDARY_LISTENER_IDENTIFIER = "secondary-test-identifier";
     public static final String SUBJECT = "org.motechproject.server.someevent";
 
+    private static final String TEST_SERVICE_CALLBACK = "TestServiceCallback";
+
     @Mock
     private OutboundEventGateway outboundEventGateway;
 
@@ -62,11 +65,20 @@ public class ServerEventRelayTest {
     @Mock
     private EventListenerRegistry registry;
 
+    @Mock
+    private BundleContext bundleContext;
+
+    @Mock
+    private ServiceReference<EventCallbackService> serviceReference;
+
+    @Mock
+    private EventCallbackService callbackService;
+
     private ServerEventRelay eventRelay;
 
     @Before
     public void setUp() throws Exception {
-        eventRelay = new ServerEventRelay(outboundEventGateway, registry, motechEventConfig, eventAdmin);
+        eventRelay = new ServerEventRelay(outboundEventGateway, registry, motechEventConfig, eventAdmin, bundleContext);
 
         when(eventListener.getIdentifier()).thenReturn(LISTENER_IDENTIFIER);
         when(secondaryEventListener.getIdentifier()).thenReturn(SECONDARY_LISTENER_IDENTIFIER);
@@ -78,6 +90,53 @@ public class ServerEventRelayTest {
         setUpListeners(SUBJECT, eventListener);
         eventRelay.relayQueueEvent(motechEvent);
         verify(eventListener).handle(motechEvent);
+    }
+
+    @Test
+    public void shouldNotifyCallbackServiceOnSuccessfulEventHandling() throws Exception {
+        MotechEvent motechEvent = createEvent(LISTENER_IDENTIFIER);
+        motechEvent.setCallbackName(TEST_SERVICE_CALLBACK);
+        setUpListeners(SUBJECT, eventListener);
+
+        when(bundleContext.getServiceReferences(EventCallbackService.class, null)).thenReturn(Arrays.asList(serviceReference));
+        when(bundleContext.getService(serviceReference)).thenReturn(callbackService);
+        when(callbackService.getName()).thenReturn(TEST_SERVICE_CALLBACK);
+
+        eventRelay.relayQueueEvent(motechEvent);
+
+        verify(eventListener).handle(motechEvent);
+        verify(callbackService).successCallback(motechEvent);
+    }
+
+    @Test(expected = CallbackServiceNotFoundException.class)
+    public void shouldThrowExceptionWhenCallbackServiceOfTheGivenNameIsNotFound() throws Exception {
+        MotechEvent motechEvent = createEvent(LISTENER_IDENTIFIER);
+        motechEvent.setCallbackName(TEST_SERVICE_CALLBACK);
+        setUpListeners(SUBJECT, eventListener);
+
+        eventRelay.relayQueueEvent(motechEvent);
+
+        verify(eventListener).handle(motechEvent);
+        verify(callbackService).successCallback(motechEvent);
+    }
+
+    @Test
+    public void shouldNotifyCallbackServiceOnFailedEventHandling() throws Exception {
+        MotechEvent motechEvent = createEvent(LISTENER_IDENTIFIER);
+        motechEvent.setCallbackName(TEST_SERVICE_CALLBACK);
+        setUpListeners(SUBJECT, eventListener);
+
+        when(bundleContext.getServiceReferences(EventCallbackService.class, null)).thenReturn(Arrays.asList(serviceReference));
+        when(bundleContext.getService(serviceReference)).thenReturn(callbackService);
+        when(callbackService.getName()).thenReturn(TEST_SERVICE_CALLBACK);
+
+        RuntimeException initCause = new RuntimeException();
+        doThrow(new RuntimeException("Failed", initCause)).when(eventListener).handle(any(MotechEvent.class));
+
+        eventRelay.relayQueueEvent(motechEvent);
+
+        verify(eventListener).handle(motechEvent);
+        verify(callbackService).failureCallback(motechEvent, initCause);
     }
 
     @Test


### PR DESCRIPTION
This commit adds the ability to register callback services, that
will be invoked when the execution of a MotechEvent is finished.
The service must implement the EventCallbackService and provide
a callback name, that must be also included in the MotechEvent.
The interface provides two methods - one for success callbacks
and another one for failure callbacks.