### PR TITLE
Catch loss of authenticated session in UI

### DIFF
--- a/ui/src/js/auth-interceptor.js
+++ b/ui/src/js/auth-interceptor.js
@@ -1,0 +1,14 @@
+(function(open) {
+/*
+ * Catches all XMLHttpReqests, and if 302 to /login, sets window location to that page
+ */
+  XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+    var xhr = this;
+    this.onload = function(){
+        if(window.location.pathname.indexOf("server/login") < 0 && (xhr.status === 302 || xhr.status === 401)){
+        	document.location.reload();
+        }
+    }
+    open.call(this, method, url, async, user, pass);
+  };
+})(XMLHttpRequest.prototype.open);


### PR DESCRIPTION
I've started adding code to catch the loss of an authenticated session in MOTECH.

This solution works for Ajax queries, but I have not figured out how to make it work when resources are loaded -- as in the case of loading a new module with ocLazyLoad

The new MOTECH-UI uses a different process to authenticate a user, so this PR is targeting the 'legacy' UI and hopes to provide a better experience than the page simply breaking.

I would love opinions about:
(A) MOTECH should show an error message when a user's session is lost
(B) Where we should insert code in the module loading process to catch failed (redirected) resources
 -- 1) Before loading a module, ping getUser to verify session (easy, but makes code less specific)
 -- 2) See if ocLazyLoad promise knows the redirect happened (not sure this will work)
 -- 3) Catch resource redirected event in browser (not sure how to do this)
 -- 4) Change permissions for resource files so unauthenticated users can load them (I like this)
 -----> (4) will have effect of allowing user to browse around unauthenticated until any data is loaded from server side (which would happen immediately in most modules (not the email module))

@pgesek @wstrzelczyk @sebbrudzinski @jredlarski @llavoie @koshalt @frankhuster (or well anyone else)