### PR TITLE
MOTECH-2622: Fixed concurrency issue in tasks

### DIFF
--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActionExecutor.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActionExecutor.java
@@ -49,7 +49,6 @@ public class TaskActionExecutor {
 
     private TaskService taskService;
     private TaskActivityService activityService;
-    private KeyEvaluator keyEvaluator;
 
     @Autowired
     public TaskActionExecutor(TaskService taskService, TaskActivityService activityService,
@@ -69,9 +68,9 @@ public class TaskActionExecutor {
      */
     public void execute(Task task, TaskActionInformation actionInformation, TaskContext taskContext) throws TaskHandlerException {
         LOGGER.info("Executing task action: {} from task: {}", actionInformation.getName(), task.getName());
-        this.keyEvaluator = new KeyEvaluator(taskContext);
+        KeyEvaluator keyEvaluator = new KeyEvaluator(taskContext);
         ActionEvent action = getActionEvent(actionInformation);
-        Map<String, Object> parameters = createParameters(actionInformation, action);
+        Map<String, Object> parameters = createParameters(actionInformation, action, keyEvaluator);
         LOGGER.debug("Parameters created: {} for task action: {}", parameters.toString(), action.getName());
 
         if (action.hasService() && bundleContext != null) {
@@ -105,7 +104,7 @@ public class TaskActionExecutor {
     }
 
     private Map<String, Object> createParameters(TaskActionInformation info,
-                                         ActionEvent action) throws TaskHandlerException {
+                                         ActionEvent action, KeyEvaluator keyEvaluator) throws TaskHandlerException {
         SortedSet<ActionParameter> actionParameters = action.getActionParameters();
         Map<String, Object> parameters = new HashMap<>(actionParameters.size());
 
@@ -123,10 +122,10 @@ public class TaskActionExecutor {
 
                 switch (actionParameter.getType()) {
                     case LIST:
-                        parameters.put(key, convertToList((List<String>) LIST.parse(template)));
+                        parameters.put(key, convertToList((List<String>) LIST.parse(template), keyEvaluator));
                         break;
                     case MAP:
-                        parameters.put(key, convertToMap(template));
+                        parameters.put(key, convertToMap(template, keyEvaluator));
                         break;
                     default:
                         try {
@@ -156,7 +155,7 @@ public class TaskActionExecutor {
         return parameters;
     }
 
-    private Map<Object, Object> convertToMap(String template) throws TaskHandlerException {
+    private Map<Object, Object> convertToMap(String template, KeyEvaluator keyEvaluator) throws TaskHandlerException {
         String[] rows = template.split("(\\r)?\\n");
         Map<Object, Object> tempMap = new HashMap<>(rows.length);
 
@@ -174,7 +173,7 @@ public class TaskActionExecutor {
                     );
                     break;
                 case 1:
-                    mapValue = getValue(array[0]);
+                    mapValue = getValue(array[0], keyEvaluator);
                     if (mapValue instanceof Multimap) {
                         tempMap.putAll(((Multimap) mapValue).asMap());
                     } else {
@@ -187,11 +186,11 @@ public class TaskActionExecutor {
         return tempMap;
     }
 
-    private List<Object> convertToList(List<String> templates) throws TaskHandlerException {
+    private List<Object> convertToList(List<String> templates, KeyEvaluator keyEvaluator) throws TaskHandlerException {
         List<Object> tempList = new ArrayList<>();
 
         for (String template : templates) {
-            Object value = getValue(template.trim());
+            Object value = getValue(template.trim(), keyEvaluator);
             if ( value != null) {
                 if (value instanceof Collection) {
                     tempList.addAll((Collection) value);
@@ -204,7 +203,7 @@ public class TaskActionExecutor {
         return tempList;
     }
 
-    private Object getValue(String row) throws TaskHandlerException {
+    private Object getValue(String row, KeyEvaluator keyEvaluator) throws TaskHandlerException {
         List<KeyInformation> keys = KeyInformation.parseAll(row);
 
         Object result;


### PR DESCRIPTION
KeyEvaluator holds the current task state - the task context, yet it
was stored as a variable by the task action executor which is a
Sprint singleton. This would cause concurrency issues.