### PR TITLE
MOTECH-2627: Don't replace custom task fields with bubbles

### DIFF
--- a/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
@@ -989,10 +989,7 @@
                     });
 
                     if (!param) {
-                        param = {
-                            type: 'UNKNOWN',
-                            displayName: key
-                        };
+                        return data;
                     }
 
                     span = $scope.util.createDraggableSpan({
@@ -1037,10 +1034,7 @@
                     });
 
                     if (!param) {
-                        param = {
-                            type: 'UNKNOWN',
-                            displayName: field
-                        };
+                        return data;
                     }
 
                     span = $scope.util.createDraggableSpan({


### PR DESCRIPTION
These were improperly replaced, which caused issues on Chrome
and IE.