### PR TITLE
MOTECH-2216: Lookup button is disabled when lookup filter is empty

### DIFF
--- a/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
+++ b/platform/mds/mds-web/src/main/resources/webapp/partials/widgets/entityInstances.html
@@ -34,7 +34,7 @@
             <button ng-show="showFilters && showFiltersButton" type="button" class="btn btn-default" id="mds-filters">
                 <i class="fa fa-filter"></i>&nbsp;{{msg('mds.filters')}}
             </button>
-            <button id="lookupDialogButton" ng-click="showLookupDialog()" type="button" class="btn btn-default" ng-show="showLookupButton">
+            <button id="lookupDialogButton" ng-click="showLookupDialog()" type="button" class="btn btn-default" ng-show="showLookupButton" ng-if="entityAdvanced.indexes != 0">
                 <i class="fa fa-lg fa-caret-down"></i>
                 {{msg('mds.btn.lookup')}}
             </button>


### PR DESCRIPTION
Fixed the issue where the lookup button is enabled even if the lookup filter is empty.