### PR TITLE
MOTECH-2734 Changed NodeJS install version to 4.x

### DIFF
--- a/docs/source/development/dev_setup/dev_install.rst
+++ b/docs/source/development/dev_setup/dev_install.rst
@@ -22,7 +22,7 @@ The versions below may change, most likely the latest stable release will work f
 		.. code-block:: bash
 
 			sudo apt-get install curl git maven activemq npm
-			curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
+			curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 			sudo apt-get install -y nodejs
 			sudo npm install -g bower gulp
 


### PR DESCRIPTION
The NodeJS 5.x version we were recommending users install is deprecated. The current LTS is 4.x