### PR TITLE
MOTECH-2296: Task retries for event-based actions 0.29.X Port

### DIFF
--- a/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/listener/MotechSchedulerListener.java
+++ b/modules/scheduler/scheduler/src/main/java/org/motechproject/scheduler/listener/MotechSchedulerListener.java
@@ -43,7 +43,8 @@ public class MotechSchedulerListener {
 
         MotechEvent jobEvent = new MotechEvent(jobSubject, parameters, null, metadata);
 
-        RepeatingSchedulableJob repeatingJob = new RepeatingSchedulableJob(jobEvent, repeatCount, repeatIntervalInSeconds, DateTime.now(), null, false);
+        RepeatingSchedulableJob repeatingJob = new RepeatingSchedulableJob(jobEvent, repeatCount - 1, repeatIntervalInSeconds,
+                DateTime.now().plusSeconds(repeatIntervalInSeconds), null, false);
 
         schedulerService.scheduleRepeatingJob(repeatingJob);
     }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/constants/EventDataKeys.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/constants/EventDataKeys.java
@@ -29,4 +29,7 @@ public final class EventDataKeys {
     public static final String REPEAT_INTERVAL_TIME = "repeatIntervalInSeconds";
     public static final String JOB_SUBJECT = "jobSubject";
     public static final String TASK_ID = "task_ID";
+    public static final String TASK_ACTIVITY_ID = "task_activity_ID";
+    public static final String TASK_RETRY = "taskRetry";
+
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskActivity.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskActivity.java
@@ -25,6 +25,9 @@ import java.util.Objects;
 @Access(value = SecurityMode.PERMISSIONS, members = {TasksRoles.MANAGE_TASKS})
 public class TaskActivity implements Comparable<TaskActivity> {
 
+    @Field
+    private Long id;
+
     @Field(displayName = "Message")
     private String message;
 
@@ -39,6 +42,9 @@ public class TaskActivity implements Comparable<TaskActivity> {
 
     @Field(displayName = "Activity Type")
     private TaskActivityType activityType;
+
+    @Field(displayName = "Task execution progress")
+    private TaskExecutionProgress executionProgress;
 
     @Field(displayName = "StackTrace element", type = "text")
     private String stackTraceElement;
@@ -61,7 +67,7 @@ public class TaskActivity implements Comparable<TaskActivity> {
      * @param activityType  the activity type
      */
     public TaskActivity(String message, Long task, TaskActivityType activityType) {
-        this(message, new ArrayList<String>(), task, activityType);
+        this(message, new ArrayList<>(), task, activityType, (TaskExecutionProgress) null);
     }
 
     /**
@@ -73,7 +79,7 @@ public class TaskActivity implements Comparable<TaskActivity> {
      * @param activityType  the activity type
      */
     public TaskActivity(String message, String field, Long task, TaskActivityType activityType) {
-        this(message, new ArrayList<>(Arrays.asList(field)), task, activityType);
+        this(message, new ArrayList<>(Arrays.asList(field)), task, activityType, (TaskExecutionProgress) null);
     }
 
     /**
@@ -83,9 +89,10 @@ public class TaskActivity implements Comparable<TaskActivity> {
      * @param fields  the field names
      * @param task  the activity task ID
      * @param activityType  the activity type
+     * @param executionProgress the progress of task action executions
      */
-    public TaskActivity(String message, List<String> fields, Long task, TaskActivityType activityType) {
-        this(message, fields, task, activityType, null, null);
+    public TaskActivity(String message, List<String> fields, Long task, TaskActivityType activityType, TaskExecutionProgress executionProgress) {
+        this(message, fields, task, activityType, null, null, executionProgress);
     }
 
     /**
@@ -98,7 +105,7 @@ public class TaskActivity implements Comparable<TaskActivity> {
      * @param stackTraceElement  the stack trace that caused the task failure
      */
     public TaskActivity(String message, List<String> fields, Long task, TaskActivityType activityType, String stackTraceElement) {
-        this(message, fields, task, activityType, stackTraceElement, null);
+        this(message, fields, task, activityType, stackTraceElement, null, null);
     }
 
     /**
@@ -110,9 +117,10 @@ public class TaskActivity implements Comparable<TaskActivity> {
      * @param activityType  the activity type
      * @param stackTraceElement  the stack trace that caused the task failure
      * @param parameters the parameters used by the task in this execution
+     * @param executionProgress the progress of task action executions
      */
     public TaskActivity(String message, List<String> fields, Long task, TaskActivityType activityType, String stackTraceElement,
-                        Map<String, Object> parameters) {
+                        Map<String, Object> parameters, TaskExecutionProgress executionProgress) {
         this.message = message;
         this.fields = fields;
         this.task = task;
@@ -120,6 +128,15 @@ public class TaskActivity implements Comparable<TaskActivity> {
         this.activityType = activityType;
         this.stackTraceElement = stackTraceElement;
         this.parameters = parameters;
+        this.executionProgress = executionProgress;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getMessage() {
@@ -186,6 +203,14 @@ public class TaskActivity implements Comparable<TaskActivity> {
 
     public void setParameters(Map<String, Object> parameters) {
         this.parameters = parameters;
+    }
+
+    public TaskExecutionProgress getTaskExecutionProgress() {
+        return executionProgress;
+    }
+
+    public void setTaskExecutionProgress(TaskExecutionProgress executionProgress) {
+        this.executionProgress = executionProgress;
     }
 
     @Override

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskActivityType.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskActivityType.java
@@ -11,7 +11,8 @@ public enum TaskActivityType {
 
     ERROR("ERROR"),
     WARNING("WARNING"),
-    SUCCESS("SUCCESS");
+    SUCCESS("SUCCESS"),
+    IN_PROGRESS("IN PROGRESS");
 
     private final String value;
 
@@ -20,7 +21,7 @@ public enum TaskActivityType {
         return value;
     }
 
-    private TaskActivityType(String value) {
+    TaskActivityType(String value) {
         this.value = value;
     }
 

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskExecutionProgress.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/domain/mds/task/TaskExecutionProgress.java
@@ -1,0 +1,57 @@
+package org.motechproject.tasks.domain.mds.task;
+
+import org.motechproject.mds.annotations.Entity;
+import org.motechproject.mds.annotations.Field;
+
+import java.util.Objects;
+
+/**
+ * A domain object that keeps track of the task execution progress.
+ */
+@Entity
+public class TaskExecutionProgress {
+
+    @Field
+    private int totalActions;
+
+    @Field
+    private int actionsSucceeded;
+
+    public TaskExecutionProgress(int totalActions) {
+        this.totalActions = totalActions;
+    }
+
+    public int getTotalActions() {
+        return totalActions;
+    }
+
+    public void setTotalActions(int totalActions) {
+        this.totalActions = totalActions;
+    }
+
+    public int getActionsSucceeded() {
+        return actionsSucceeded;
+    }
+
+    public void addSuccess() {
+        actionsSucceeded++;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TaskExecutionProgress)) {
+            return false;
+        }
+        TaskExecutionProgress that = (TaskExecutionProgress) o;
+        return totalActions == that.totalActions &&
+                actionsSucceeded == that.actionsSucceeded;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalActions, actionsSucceeded);
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskActivityService.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/TaskActivityService.java
@@ -4,39 +4,48 @@ import org.motechproject.mds.query.QueryParams;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskActivityType;
-import org.motechproject.tasks.exception.TaskHandlerException;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Service for managing task activities. Task activities are used for storing information about past task executions.
+ * Service for managing task activities. Task activities are used for storing information about current and past task executions.
  */
 public interface TaskActivityService {
 
     /**
-     * Logs an execution error for the given task.
+     * Adds a new task activity log and marks it as "In Progress".
      *
-     * @param task  the failed task, not null
-     * @param e  the cause of the error, not null
-     * @param parameters the parameters used by the task when it failed
+     * @param task The task to add the log for
+     * @param parameters The event trigger parameters the task was initiated with
+     * @return id of the created activity log
      */
-    void addError(Task task, TaskHandlerException e, Map<String, Object> parameters);
+    long addTaskStarted(Task task, Map<String, Object> parameters);
 
     /**
-     * Logs an execution success for the given task.
+     * Adds successful execution to the activity of the provided id. If all the task actions are executed, it marks
+     * the activity as "SUCCESS".
      *
-     * @param task  the succeeded task, not null
+     * @param activityId the id of the activity
+     * @return whether the task is finished
      */
-    void addSuccess(Task task);
+    boolean addSuccessfulExecution(Long activityId);
+
+    /**
+     * Adds failed execution to the activity of the provided id, which in consequence marks it as "FAILED".
+     *
+     * @param activityId the id of the activity
+     * @param e the throwable that has caused the task execution failure
+     */
+    void addFailedExecution(Long activityId, Throwable e);
 
     /**
      * Logs a warning for the given task.
      *
      * @param task  the task, not null
      */
-    void addWarning(Task task);
+    void addTaskDisabledWarning(Task task);
 
     /**
      * Logs a warning for the given task.
@@ -55,7 +64,7 @@ public interface TaskActivityService {
      * @param field  the name of the failed that caused the warning, not null
      * @param e  the exception that caused the warning, not null
      */
-    void addWarning(Task task, String key, String field, Exception e);
+    void addWarningWithException(Task task, String key, String field, Exception e);
 
     /**
      * Deletes all activities for the task with the given ID.

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActionExecutor.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActionExecutor.java
@@ -4,18 +4,18 @@ import com.google.common.collect.Multimap;
 import org.motechproject.commons.api.MotechException;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventRelay;
-import org.motechproject.tasks.domain.mds.channel.ActionEvent;
-import org.motechproject.tasks.domain.mds.channel.ActionParameter;
 import org.motechproject.tasks.domain.KeyInformation;
 import org.motechproject.tasks.domain.mds.ParameterType;
+import org.motechproject.tasks.domain.mds.channel.ActionEvent;
+import org.motechproject.tasks.domain.mds.channel.ActionParameter;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActionInformation;
 import org.motechproject.tasks.exception.ActionNotFoundException;
 import org.motechproject.tasks.exception.TaskHandlerException;
-import org.motechproject.tasks.service.util.KeyEvaluator;
 import org.motechproject.tasks.service.TaskActivityService;
-import org.motechproject.tasks.service.util.TaskContext;
 import org.motechproject.tasks.service.TaskService;
+import org.motechproject.tasks.service.util.KeyEvaluator;
+import org.motechproject.tasks.service.util.TaskContext;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
-import static org.motechproject.tasks.domain.mds.ParameterType.LIST;
-import static org.motechproject.tasks.domain.mds.ParameterType.MAP;
 import static org.motechproject.tasks.constants.TaskFailureCause.ACTION;
 import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
+import static org.motechproject.tasks.domain.mds.ParameterType.LIST;
+import static org.motechproject.tasks.domain.mds.ParameterType.MAP;
 
 
 /**
@@ -50,13 +50,15 @@ public class TaskActionExecutor {
 
     private TaskService taskService;
     private TaskActivityService activityService;
+    private TasksPostExecutionHandler postExecutionHandler;
 
     @Autowired
     public TaskActionExecutor(TaskService taskService, TaskActivityService activityService,
-                       EventRelay eventRelay) {
+                       EventRelay eventRelay, TasksPostExecutionHandler postExecutionHandler) {
         this.eventRelay = eventRelay;
         this.taskService = taskService;
         this.activityService = activityService;
+        this.postExecutionHandler = postExecutionHandler;
     }
 
     /**
@@ -64,29 +66,35 @@ public class TaskActionExecutor {
      *
      * @param task  the task for which its action should be executed, not null
      * @param actionInformation  the information about the action, not null
+     * @param actionIndex the order of the task action
      * @param taskContext  the context of the current task execution, not null
+     * @param activityId the ID of the activity associated with this execution
      * @throws TaskHandlerException when the task couldn't be executed
      */
-    public void execute(Task task, TaskActionInformation actionInformation, Integer actionIndex, TaskContext taskContext) throws TaskHandlerException {
+    public void execute(Task task, TaskActionInformation actionInformation, Integer actionIndex, TaskContext taskContext, long activityId) throws TaskHandlerException {
         LOGGER.info("Executing task action: {} from task: {}", actionInformation.getName(), task.getName());
         KeyEvaluator keyEvaluator = new KeyEvaluator(taskContext);
 
         ActionEvent action = getActionEvent(actionInformation);
         Map<String, Object> parameters = createParameters(actionInformation, action, keyEvaluator);
+        addTriggerParameters(task, action, parameters, taskContext.getTriggerParameters());
+
         LOGGER.debug("Parameters created: {} for task action: {}", parameters.toString(), action.getName());
         if (action.hasService() && bundleContext != null) {
             if (callActionServiceMethod(action, actionIndex, parameters, taskContext)) {
                 LOGGER.info("Action: {} from task: {} was executed through an OSGi service call", actionInformation.getName(), task.getName());
+                postExecutionHandler.handleActionExecuted(taskContext.getTriggerParameters(), taskContext.getMetadata(), activityId);
                 return;
             }
             LOGGER.info("There is no service: {}", action.getServiceInterface());
+
             activityService.addWarning(task, "task.warning.serviceUnavailable", action.getServiceInterface());
         }
         if (!action.hasSubject()) {
             throw new TaskHandlerException(ACTION, "task.error.cantExecuteAction");
         } else {
+            eventRelay.sendEventMessage(new MotechEvent(action.getSubject(), parameters, TasksEventCallbackService.TASKS_EVENT_CALLBACK_NAME, taskContext.getMetadata()));
             LOGGER.info("Event: {} was sent", action.getSubject());
-            eventRelay.sendEventMessage(new MotechEvent(action.getSubject(), parameters));
         }
     }
 
@@ -251,6 +259,16 @@ public class TaskActionExecutor {
         }
 
         return serviceAvailable;
+    }
+
+    private void addTriggerParameters(Task task, ActionEvent action, Map<String, Object> parameters, Map<String, Object> triggerParameters) {
+        if (task.getNumberOfRetries() > 0 && !action.hasService()) {
+            for (Map.Entry<String, Object> entry : triggerParameters.entrySet()) {
+                if (! parameters.containsKey(entry.getKey())) {
+                    parameters.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
     }
 
     private void addPostActionParametersToTaskContext(ActionEvent action, Integer actionIndex, TaskContext taskContext, Object object) throws TaskHandlerException {

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActivityServiceImpl.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskActivityServiceImpl.java
@@ -6,11 +6,14 @@ import org.motechproject.mds.util.Order;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskActivityType;
+import org.motechproject.tasks.domain.mds.task.TaskExecutionProgress;
 import org.motechproject.tasks.exception.TaskHandlerException;
 import org.motechproject.tasks.repository.TaskActivitiesDataService;
 import org.motechproject.tasks.service.TaskActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +25,10 @@ import java.util.Set;
 @Service
 public class TaskActivityServiceImpl implements TaskActivityService {
 
+    private static final String TASK_IN_PROGRESS = "task.inProgress";
+    private static final String TASK_SUCCEEDED = "task.success.ok";
+    private static final String TASK_DISABLED = "task.warning.taskDisabled";
+
     private TaskActivitiesDataService taskActivitiesDataService;
 
     @Autowired
@@ -30,36 +37,82 @@ public class TaskActivityServiceImpl implements TaskActivityService {
     }
 
     @Override
-    public void addError(Task task, TaskHandlerException e, Map<String, Object> parameters) {
-        taskActivitiesDataService.create(new TaskActivity(e.getMessage(), e.getArgs(), task.getId(),
-                TaskActivityType.ERROR, ExceptionUtils.getStackTrace(e), parameters));
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public long addTaskStarted(Task task, Map<String, Object> parameters) {
+        int totalActions = task.getActions().size();
+        TaskActivity activity = taskActivitiesDataService.create(
+                new TaskActivity(TASK_IN_PROGRESS, Arrays.asList("0", String.valueOf(totalActions)), task.getId(),
+                        TaskActivityType.IN_PROGRESS, null, parameters, new TaskExecutionProgress(totalActions)));
+        return activity.getId();
     }
 
     @Override
-    public void addSuccess(Task task) {
-        taskActivitiesDataService.create(new TaskActivity("task.success.ok", task.getId(),
-                TaskActivityType.SUCCESS));
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean addSuccessfulExecution(Long activityId) {
+        TaskActivity activity = taskActivitiesDataService.findById(activityId);
+        if (activity == null) {
+            return false;
+        }
+
+        TaskExecutionProgress progress = activity.getTaskExecutionProgress();
+        progress.addSuccess();
+        boolean taskFinished = progress.getActionsSucceeded() == progress.getTotalActions();
+
+        if (taskFinished) {
+            activity.setActivityType(TaskActivityType.SUCCESS);
+            activity.setMessage(TASK_SUCCEEDED);
+            activity.getFields().clear();
+        }
+
+        updateTaskInProgressMessage(activity);
+        taskActivitiesDataService.update(activity);
+
+        return taskFinished;
     }
 
     @Override
-    public void addWarning(Task task) {
-        taskActivitiesDataService.create(new TaskActivity("task.warning.taskDisabled", task.getId(),
-                TaskActivityType.WARNING));
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void addFailedExecution(Long activityId, Throwable e) {
+        TaskActivity activity = taskActivitiesDataService.findById(activityId);
+
+        if (activity == null){
+            return;
+        }
+
+        if (activity.getActivityType() != TaskActivityType.ERROR) {
+            activity.setMessage(e.getMessage());
+            activity.setActivityType(TaskActivityType.ERROR);
+
+            if (e instanceof TaskHandlerException) {
+                activity.setFields(((TaskHandlerException) e).getArgs());
+            }
+
+            activity.setStackTraceElement(ExceptionUtils.getStackTrace(e));
+            taskActivitiesDataService.update(activity);
+        }
     }
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void addTaskDisabledWarning(Task task) {
+        taskActivitiesDataService.create(new TaskActivity(TASK_DISABLED, task.getId(), TaskActivityType.WARNING));
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void addWarning(Task task, String key, String field) {
-        taskActivitiesDataService.create(new TaskActivity(key, field, task.getId(),
-                TaskActivityType.WARNING));
+        taskActivitiesDataService.create(new TaskActivity(key, field, task.getId(), TaskActivityType.WARNING));
     }
 
     @Override
-    public void addWarning(Task task, String key, String field, Exception e) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void addWarningWithException(Task task, String key, String field, Exception e) {
         taskActivitiesDataService.create(new TaskActivity(key, new ArrayList<>(Arrays.asList(field)),
                 task.getId(), TaskActivityType.WARNING, ExceptionUtils.getStackTrace(e.getCause())));
     }
 
     @Override
+    @Transactional
     public void deleteActivitiesForTask(Long taskId) {
         for (TaskActivity msg : taskActivitiesDataService.byTask(taskId)) {
             taskActivitiesDataService.delete(msg);
@@ -67,27 +120,38 @@ public class TaskActivityServiceImpl implements TaskActivityService {
     }
 
     @Override
+    @Transactional
     public TaskActivity getTaskActivityById(Long activityId) {
         return taskActivitiesDataService.findById(activityId);
     }
 
     @Override
+    @Transactional
     public List<TaskActivity> getLatestActivities() {
         return taskActivitiesDataService.retrieveAll(new QueryParams(1, 10, new Order("date", Order.Direction.DESC)));
     }
 
     @Override
+    @Transactional
     public List<TaskActivity> getTaskActivities(Long taskId, Set<TaskActivityType> activityTypes, QueryParams queryParams) {
         return taskActivitiesDataService.byTaskAndActivityTypes(taskId, activityTypes, queryParams);
     }
 
     @Override
+    @Transactional
     public long getTaskActivitiesCount(Long taskId, Set<TaskActivityType> activityTypes) {
         return taskActivitiesDataService.countByTaskAndActivityTypes(taskId, activityTypes);
     }
 
     @Override
+    @Transactional
     public long getTaskActivitiesCount(Long taskId, TaskActivityType type) {
         return taskActivitiesDataService.countByTaskAndActivityTypes(taskId, new HashSet<>(Arrays.asList(type)));
+    }
+
+    private void updateTaskInProgressMessage(TaskActivity activity) {
+        if (TASK_IN_PROGRESS.equals(activity.getMessage())) {
+            activity.getFields().set(0, String.valueOf(activity.getTaskExecutionProgress().getActionsSucceeded()));
+        }
     }
 }

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskRetryHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskRetryHandler.java
@@ -1,0 +1,80 @@
+package org.motechproject.tasks.service.impl;
+
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.EventRelay;
+import org.motechproject.tasks.domain.mds.task.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.motechproject.tasks.constants.EventDataKeys.JOB_SUBJECT;
+import static org.motechproject.tasks.constants.EventDataKeys.REPEAT_COUNT;
+import static org.motechproject.tasks.constants.EventDataKeys.REPEAT_INTERVAL_TIME;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_ID;
+import static org.motechproject.tasks.constants.EventSubjects.SCHEDULE_REPEATING_JOB;
+import static org.motechproject.tasks.constants.EventSubjects.UNSCHEDULE_REPEATING_JOB;
+
+/**
+ * This class is responsible for managing, scheduling and unscheduling jobs, connected to
+ * repeating the task executions.
+ */
+@Component
+public class TaskRetryHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskRetryHandler.class);
+
+    @Autowired
+    private EventRelay eventRelay;
+
+    /**
+     * Takes necessary actions (schedule/unschedule) for the given task, based on its settings and status of the
+     * execution. It makes sure that the retry job is scheduled only once and that it gets unscheduled when the task
+     * executes successfully.
+     *
+     * @param task the task to handle repeat jobs for
+     * @param parameters trigger event parameters
+     * @param success whether the execution was successful
+     * @param retryScheduled whether the tak retry is currently scheduled
+     */
+    public void handleTaskRetries(Task task, Map<String, Object> parameters, boolean success, boolean retryScheduled) {
+        if (task.retryTaskOnFailure()) {
+            if (success && retryScheduled) {
+                LOGGER.info("Unscheduling the task retries, due to successful execution.");
+                unscheduleTaskRetry(task.getTrigger().getEffectiveListenerRetrySubject());
+            } else if (!success && !retryScheduled) {
+                LOGGER.info("Scheduling task retries, since the execution of a task failed.");
+                scheduleTaskRetry(task, parameters);
+            }
+        }
+    }
+
+    /**
+     * Unschedules the task repeat job of the given subject.
+     *
+     * @param jobSubject the subject of a job to unschedule
+     */
+    public void unscheduleTaskRetry(String jobSubject) {
+        LOGGER.info("Unscheduling the task retries.");
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(JOB_SUBJECT, jobSubject);
+
+        eventRelay.sendEventMessage(new MotechEvent(UNSCHEDULE_REPEATING_JOB, new HashMap<>(), null, metadata));
+    }
+
+    private void scheduleTaskRetry(Task task, Map<String, Object> parameters) {
+        Map<String, Object> eventParameters = new HashMap<>();
+        eventParameters.putAll(parameters);
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(TASK_ID, task.getId());
+        metadata.put(REPEAT_COUNT, task.getNumberOfRetries());
+        metadata.put(REPEAT_INTERVAL_TIME, task.getRetryIntervalInMilliseconds() / 1000);
+        metadata.put(JOB_SUBJECT, task.getTrigger().getEffectiveListenerRetrySubject());
+
+        eventRelay.sendEventMessage(new MotechEvent(SCHEDULE_REPEATING_JOB, eventParameters, null, metadata));
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskTriggerHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TaskTriggerHandler.java
@@ -2,28 +2,24 @@ package org.motechproject.tasks.service.impl;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.joda.time.DateTime;
 import org.motechproject.commons.api.DataProvider;
 import org.motechproject.commons.api.TasksEventParser;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventListenerRegistryService;
-import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.listener.annotations.MotechListenerEventProxy;
-import org.motechproject.config.SettingsFacade;
+import org.motechproject.tasks.constants.EventDataKeys;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.exception.TaskHandlerException;
 import org.motechproject.tasks.service.TaskActivityService;
-import org.motechproject.tasks.service.util.TaskContext;
 import org.motechproject.tasks.service.TaskService;
 import org.motechproject.tasks.service.TriggerHandler;
+import org.motechproject.tasks.service.util.TaskContext;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ReflectionUtils;
@@ -35,24 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.motechproject.tasks.service.util.HandlerPredicates.withServiceName;
-import static org.motechproject.tasks.constants.EventDataKeys.HANDLER_ERROR_PARAM;
 import static org.motechproject.tasks.constants.EventDataKeys.JOB_SUBJECT;
-import static org.motechproject.tasks.constants.EventDataKeys.REPEAT_COUNT;
-import static org.motechproject.tasks.constants.EventDataKeys.REPEAT_INTERVAL_TIME;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_FAILURE_DATE;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_FAILURE_NUMBER;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_MESSAGE;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_STACK_TRACE;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TASK_ID;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TASK_NAME;
-import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TRIGGER_DISABLED;
 import static org.motechproject.tasks.constants.EventDataKeys.TASK_ID;
-import static org.motechproject.tasks.constants.EventSubjects.SCHEDULE_REPEATING_JOB;
-import static org.motechproject.tasks.constants.EventSubjects.UNSCHEDULE_REPEATING_JOB;
-import static org.motechproject.tasks.constants.EventSubjects.createHandlerFailureSubject;
-import static org.motechproject.tasks.constants.EventSubjects.createHandlerSuccessSubject;
 import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
+import static org.motechproject.tasks.service.util.HandlerPredicates.withServiceName;
 
 /**
  * The <code>TaskTriggerHandler</code> receives events and executes tasks for which the trigger
@@ -62,8 +44,6 @@ import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
 public class TaskTriggerHandler implements TriggerHandler {
 
     private static final String BEAN_NAME = "taskTriggerHandler";
-
-    private static final String TASK_POSSIBLE_ERRORS_KEY = "task.possible.errors";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskTriggerHandler.class);
 
@@ -77,14 +57,13 @@ public class TaskTriggerHandler implements TriggerHandler {
     private EventListenerRegistryService registryService;
 
     @Autowired
-    private EventRelay eventRelay;
-
-    @Autowired
-    @Qualifier("tasksSettings")
-    private SettingsFacade settings;
-
-    @Autowired
     private TaskActionExecutor executor;
+
+    @Autowired
+    private TaskRetryHandler taskRetryHandler;
+
+    @Autowired
+    private TasksPostExecutionHandler postExecutionHandler;
 
     private Map<String, DataProvider> dataProviders;
 
@@ -155,7 +134,7 @@ public class TaskTriggerHandler implements TriggerHandler {
 
         // Handle all tasks one by one
         for (Task task : tasks) {
-            handleTask(task, parameters);
+            handleTask(task, parameters, false);
         }
     }
 
@@ -165,14 +144,13 @@ public class TaskTriggerHandler implements TriggerHandler {
 
         Map<String, Object> eventParams = event.getParameters();
         Map<String, Object> eventMetadata = event.getMetadata();
-        eventParams.putAll(eventMetadata);
 
-        Task task = taskService.getTask((Long) eventParams.get(TASK_ID));
+        Task task = taskService.getTask((Long) eventMetadata.get(TASK_ID));
 
         if (task == null || !task.isEnabled()) {
-            unscheduleTaskRetry((String) eventParams.get(JOB_SUBJECT));
+            taskRetryHandler.unscheduleTaskRetry((String) eventMetadata.get(JOB_SUBJECT));
         } else {
-            handleTask(task, eventParams);
+            handleTask(task, eventParams, true);
         }
     }
 
@@ -180,119 +158,29 @@ public class TaskTriggerHandler implements TriggerHandler {
     @Transactional
     public void retryTask(Long activityId) {
         TaskActivity activity = activityService.getTaskActivityById(activityId);
-        handleTask(taskService.getTask(activity.getTask()), activity.getParameters());
+        handleTask(taskService.getTask(activity.getTask()), activity.getParameters(), true);
     }
 
-    private boolean isTaskRetryAlreadyScheduled(Map<String, Object> eventParams) {
-        return eventParams.get(TASK_ID) != null;
-    }
+    private void handleTask(Task task, Map<String, Object> parameters, boolean isRetry) {
+        long activityId = activityService.addTaskStarted(task, parameters);
+        Map<String, Object> metadata = prepareTaskMetadata(task.getId(), activityId, isRetry);
 
-    private void handleTask(Task task, Map<String, Object> parameters) {
-
-        TaskContext taskContext = new TaskContext(task, parameters, activityService);
+        TaskContext taskContext = new TaskContext(task, parameters, metadata, activityService);
         TaskInitializer initializer = new TaskInitializer(taskContext);
-
-        boolean success = true;
 
         try {
             LOGGER.info("Executing all actions from task: {}", task.getName());
             if (initializer.evalConfigSteps(dataProviders)) {
                 for (int i = 0; i < task.getActions().size(); i++) {
-                    executor.execute(task, task.getActions().get(i), i, taskContext);
+                    executor.execute(task, task.getActions().get(i), i, taskContext, activityId);
                 }
-                handleSuccess(parameters, task);
             }
             LOGGER.warn("Actions from task: {} weren't executed, because config steps didn't pass the evaluation", task.getName());
         } catch (TaskHandlerException e) {
-            handleError(parameters, task, e);
-            success = false;
+            postExecutionHandler.handleError(parameters, metadata, task, e, activityId);
         } catch (RuntimeException e) {
-            handleError(parameters, task, new TaskHandlerException(TRIGGER, "task.error.unrecognizedError", e));
-            success = false;
+            postExecutionHandler.handleError(parameters, metadata, task, new TaskHandlerException(TRIGGER, "task.error.unrecognizedError", e), activityId);
         }
-
-        if (task.retryTaskOnFailure()) {
-            if (success && isTaskRetryAlreadyScheduled(parameters)) {
-                unscheduleTaskRetry(task.getTrigger().getEffectiveListenerRetrySubject());
-            } else if (!success && !isTaskRetryAlreadyScheduled(parameters)) {
-                scheduleTaskRetry(task, parameters);
-            }
-        }
-    }
-
-    private void scheduleTaskRetry(Task task, Map<String, Object> parameters) {
-        Map<String, Object> eventParameters = new HashMap<>();
-        Map<String, Object> eventMetadata = new HashMap<>();
-
-        eventParameters.putAll(parameters);
-
-        eventMetadata.put(TASK_ID, task.getId());
-        eventMetadata.put(REPEAT_COUNT, task.getNumberOfRetries());
-        eventMetadata.put(REPEAT_INTERVAL_TIME, task.getRetryIntervalInMilliseconds() / 1000);
-        eventMetadata.put(JOB_SUBJECT, task.getTrigger().getEffectiveListenerRetrySubject());
-
-        eventRelay.sendEventMessage(new MotechEvent(SCHEDULE_REPEATING_JOB, eventParameters, null, eventMetadata));
-    }
-
-    private void unscheduleTaskRetry(String jobSubject) {
-        Map<String, Object> eventParameters = new HashMap<>();
-        Map<String, Object> eventMetadata = new HashMap<>();
-
-        eventMetadata.put(JOB_SUBJECT, jobSubject);
-
-        eventRelay.sendEventMessage(new MotechEvent(UNSCHEDULE_REPEATING_JOB, eventParameters, null, eventMetadata));
-    }
-
-    private void handleError(Map<String, Object> params, Task task, TaskHandlerException e) {
-        LOGGER.warn("Omitted task: {} with ID: {} because: {}", task.getName(), task.getId(), e);
-
-        activityService.addError(task, e, params);
-        task.incrementFailuresInRow();
-
-        LOGGER.warn("The number of failures for task: {} is: {}", task.getName(), task.getFailuresInRow());
-
-        int failureNumber = task.getFailuresInRow();
-        int possibleErrorsNumber = getPossibleErrorsNumber();
-
-        if (failureNumber >= possibleErrorsNumber) {
-            task.setEnabled(false);
-
-            activityService.addWarning(task);
-            publishTaskDisabledMessage(task.getName());
-        }
-
-        taskService.save(task);
-
-        Map<String, Object> errorParam = new HashMap<>();
-        errorParam.put(TASK_FAIL_MESSAGE, e.getMessage());
-        errorParam.put(TASK_FAIL_STACK_TRACE, ExceptionUtils.getStackTrace(e));
-        errorParam.put(TASK_FAIL_FAILURE_DATE, DateTime.now());
-        errorParam.put(TASK_FAIL_FAILURE_NUMBER, failureNumber);
-        errorParam.put(TASK_FAIL_TRIGGER_DISABLED, task.isEnabled());
-        errorParam.put(TASK_FAIL_TASK_ID, task.getId());
-        errorParam.put(TASK_FAIL_TASK_NAME, task.getName());
-
-        Map<String, Object> errorEventParam = new HashMap<>();
-        errorEventParam.putAll(params);
-        errorEventParam.put(HANDLER_ERROR_PARAM, errorParam);
-
-        eventRelay.sendEventMessage(new MotechEvent(
-            createHandlerFailureSubject(task.getName(), e.getFailureCause()),
-            errorEventParam
-        ));
-    }
-
-    private void handleSuccess(Map<String, Object> params, Task task) {
-        LOGGER.debug("All actions from task: {} with ID: {} were successfully executed", task.getName(), task.getId());
-
-        activityService.addSuccess(task);
-        task.resetFailuresInRow();
-        taskService.save(task);
-
-        eventRelay.sendEventMessage(new MotechEvent(
-            createHandlerSuccessSubject(task.getName()),
-            params
-        ));
     }
 
     @Override
@@ -311,35 +199,17 @@ public class TaskTriggerHandler implements TriggerHandler {
         }
     }
 
-
     void setDataProviders(Map<String, DataProvider> dataProviders) {
         this.dataProviders = dataProviders;
     }
 
-    private void publishTaskDisabledMessage(String taskName) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("message", "Task disabled automatically: " + taskName);
-        params.put("level", "CRITICAL");
-        params.put("moduleName", settings.getBundleSymbolicName());
+    private Map<String, Object> prepareTaskMetadata(Long taskId, long activityId, Boolean isRetry) {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(EventDataKeys.TASK_ID, taskId);
+        metadata.put(EventDataKeys.TASK_ACTIVITY_ID, activityId);
+        metadata.put(EventDataKeys.TASK_RETRY, isRetry);
 
-        eventRelay.sendEventMessage(new MotechEvent("org.motechproject.message", params));
-    }
-
-    private int getPossibleErrorsNumber() {
-        String property = settings.getProperty(TASK_POSSIBLE_ERRORS_KEY);
-        int number;
-
-        try {
-            number = Integer.parseInt(property);
-        } catch (NumberFormatException e) {
-            LOGGER.error(String.format(
-                    "The value of key: %s is not a number. Possible errors number is set to zero.",
-                    TASK_POSSIBLE_ERRORS_KEY
-            ));
-            number = 0;
-        }
-
-        return number;
+        return metadata;
     }
 
     @Autowired(required = false)

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TasksEventCallbackService.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TasksEventCallbackService.java
@@ -1,0 +1,58 @@
+package org.motechproject.tasks.service.impl;
+
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.EventCallbackService;
+import org.motechproject.tasks.constants.EventDataKeys;
+import org.motechproject.tasks.constants.TaskFailureCause;
+import org.motechproject.tasks.domain.mds.task.Task;
+import org.motechproject.tasks.exception.TaskHandlerException;
+import org.motechproject.tasks.service.TaskService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * Implementation of the {@link EventCallbackService} that allows to receive callbacks after the handler methods have
+ * executed the events. This allows to handle task retries and keep track of the executions of the event-based task actions.
+ */
+@Service("tasksEventCallbackService")
+public class TasksEventCallbackService implements EventCallbackService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TasksEventCallbackService.class);
+    public static final String TASKS_EVENT_CALLBACK_NAME = "TasksEventCallback";
+
+    @Autowired
+    private TasksPostExecutionHandler postExecutionHandler;
+
+    @Autowired
+    private TaskService taskService;
+
+    @Override
+    public boolean failureCallback(MotechEvent event, Throwable throwable) {
+        LOGGER.debug("Received failure callback for event subject {}", event.getSubject());
+
+        Map<String, Object> metadata = event.getMetadata();
+        Long activityId = (Long) metadata.get(EventDataKeys.TASK_ACTIVITY_ID);
+        Task task = taskService.getTask((Long) metadata.get(EventDataKeys.TASK_ID));
+
+        postExecutionHandler.handleError(event.getParameters(), metadata, task, new TaskHandlerException(TaskFailureCause.ACTION, "task.error.eventHandlerFailed", throwable), activityId);
+
+        return false;
+    }
+
+    @Override
+    public void successCallback(MotechEvent event) {
+        LOGGER.debug("Received success callback for event subject {}", event.getSubject());
+        Long activityId = (Long) event.getMetadata().get(EventDataKeys.TASK_ACTIVITY_ID);
+
+        postExecutionHandler.handleActionExecuted(event.getParameters(), event.getMetadata(), activityId);
+    }
+
+    @Override
+    public String getName() {
+        return TASKS_EVENT_CALLBACK_NAME;
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TasksPostExecutionHandler.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/impl/TasksPostExecutionHandler.java
@@ -1,0 +1,177 @@
+package org.motechproject.tasks.service.impl;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.joda.time.DateTime;
+import org.motechproject.config.SettingsFacade;
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.EventRelay;
+import org.motechproject.tasks.domain.mds.task.Task;
+import org.motechproject.tasks.exception.TaskHandlerException;
+import org.motechproject.tasks.service.TaskActivityService;
+import org.motechproject.tasks.service.TaskService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.motechproject.tasks.constants.EventDataKeys.HANDLER_ERROR_PARAM;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_FAILURE_DATE;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_FAILURE_NUMBER;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_MESSAGE;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_STACK_TRACE;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TASK_ID;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TASK_NAME;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_FAIL_TRIGGER_DISABLED;
+import static org.motechproject.tasks.constants.EventDataKeys.TASK_RETRY;
+import static org.motechproject.tasks.constants.EventSubjects.createHandlerFailureSubject;
+import static org.motechproject.tasks.constants.EventSubjects.createHandlerSuccessSubject;
+
+/**
+ * This class is responsible for management of the tasks after their execution (both successfuland failed).
+ * It manages task activities, disables task upon reaching error threshold and sends events informing about
+ * success and failures of the tasks. The {@link TaskRetryHandler} is invoked from here to manage the Task
+ * retries, baed on the task settings.
+ */
+@Component
+public class TasksPostExecutionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TasksPostExecutionHandler.class);
+    private static final String TASK_POSSIBLE_ERRORS_KEY = "task.possible.errors";
+
+    @Autowired
+    private TaskService taskService;
+
+    @Autowired
+    private TaskActivityService activityService;
+
+    @Autowired
+    private EventRelay eventRelay;
+
+    @Autowired
+    private TaskRetryHandler retryHandler;
+
+    @Autowired
+    @Qualifier("tasksSettings")
+    private SettingsFacade settings;
+
+    /**
+     * Handles successful execution of a single task action. If all actions of the task have been successfully executed,
+     * it sends an event with the message about successful execution, resets the task failures in row count and passes the
+     * info about successful execution to {@link TaskRetryHandler}.
+     *
+     * @param params trigger event parameters that invoked the task
+     * @param activityId the id of an activity
+     */
+    public void handleActionExecuted(Map<String, Object> params, Map<String, Object> metadata, Long activityId) {
+        boolean taskFinished = activityService.addSuccessfulExecution(activityId);
+        if (taskFinished) {
+            Long taskId = activityService.getTaskActivityById(activityId).getTask();
+            Task task = taskService.getTask(taskId);
+
+            handleSuccess(params, metadata, task);
+        }
+    }
+
+    /**
+     * Handles task action failure. It sets the specified task activity as failed and raises the failures in a row count of
+     * a task. If the failure threshold is reached, it disables the task and publishes an event. It passes the
+     * info about failed execution to {@link TaskRetryHandler}.
+     *
+     * @param params trigger event parameters that invoked the task
+     * @param task the task that has failed
+     * @param e the exception that caused the failure
+     * @param activityId the id of an activity
+     */
+    public void handleError(Map<String, Object> params, Map<String, Object> metadata, Task task, TaskHandlerException e, Long activityId) {
+        LOGGER.warn("Omitted task: {} with ID: {} because: {}", task.getName(), task.getId(), e);
+
+        activityService.addFailedExecution(activityId, e);
+        task.incrementFailuresInRow();
+
+        LOGGER.info("The number of failures for task: {} is: {}", task.getName(), task.getFailuresInRow());
+
+        int failureNumber = task.getFailuresInRow();
+        int possibleErrorsNumber = getPossibleErrorsNumber();
+
+        if (failureNumber >= possibleErrorsNumber) {
+            task.setEnabled(false);
+
+            activityService.addTaskDisabledWarning(task);
+            publishTaskDisabledMessage(task.getName());
+        }
+
+        taskService.save(task);
+
+        Map<String, Object> errorParam = new HashMap<>();
+        errorParam.put(TASK_FAIL_MESSAGE, e.getMessage());
+        errorParam.put(TASK_FAIL_STACK_TRACE, ExceptionUtils.getStackTrace(e));
+        errorParam.put(TASK_FAIL_FAILURE_DATE, DateTime.now());
+        errorParam.put(TASK_FAIL_FAILURE_NUMBER, failureNumber);
+        errorParam.put(TASK_FAIL_TRIGGER_DISABLED, task.isEnabled());
+        errorParam.put(TASK_FAIL_TASK_ID, task.getId());
+        errorParam.put(TASK_FAIL_TASK_NAME, task.getName());
+
+        Map<String, Object> errorEventParam = new HashMap<>();
+        errorEventParam.putAll(params);
+        errorEventParam.put(HANDLER_ERROR_PARAM, errorParam);
+
+        eventRelay.sendEventMessage(new MotechEvent(
+                createHandlerFailureSubject(task.getName(), e.getFailureCause()),
+                errorEventParam
+        ));
+
+        boolean retryScheduled = isRetryScheduled(metadata);
+
+        retryHandler.handleTaskRetries(task, params, false, retryScheduled);
+    }
+
+    private void handleSuccess(Map<String, Object> params, Map<String, Object> metadata, Task task) {
+        LOGGER.debug("All actions from task: {} with ID: {} were successfully executed", task.getName(), task.getId());
+
+        task.resetFailuresInRow();
+        taskService.save(task);
+
+        eventRelay.sendEventMessage(new MotechEvent(
+                createHandlerSuccessSubject(task.getName()),
+                params
+        ));
+
+        boolean retryScheduled = isRetryScheduled(metadata);
+
+        retryHandler.handleTaskRetries(task, params, true, retryScheduled);
+    }
+
+    private void publishTaskDisabledMessage(String taskName) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("message", "Task disabled automatically: " + taskName);
+        params.put("level", "CRITICAL");
+        params.put("moduleName", settings.getBundleSymbolicName());
+
+        eventRelay.sendEventMessage(new MotechEvent("org.motechproject.message", params));
+    }
+
+    private int getPossibleErrorsNumber() {
+        String property = settings.getProperty(TASK_POSSIBLE_ERRORS_KEY);
+        int number;
+
+        try {
+            number = Integer.parseInt(property);
+        } catch (NumberFormatException e) {
+            LOGGER.error(String.format(
+                    "The value of key: %s is not a number. Possible errors number is set to zero.",
+                    TASK_POSSIBLE_ERRORS_KEY
+            ));
+            number = 0;
+        }
+
+        return number;
+    }
+
+    private boolean isRetryScheduled(Map<String, Object> metadata) {
+        return metadata.get(TASK_RETRY) != null && (boolean) metadata.get(TASK_RETRY);
+    }
+}

--- a/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/TaskContext.java
+++ b/modules/tasks/tasks/src/main/java/org/motechproject/tasks/service/util/TaskContext.java
@@ -24,6 +24,7 @@ public class TaskContext {
 
     private Task task;
     private Map<String, Object> parameters;
+    private Map<String, Object> metadata;
     private TaskActivityService activityService;
     private Set<DataSourceObject> dataSourceObjects;
     private Set<PostActionParameterObject> postActionParameters;
@@ -35,9 +36,10 @@ public class TaskContext {
      * @param parameters  the task parameters
      * @param activityService  the activity service, not null
      */
-    public TaskContext(Task task, Map<String, Object> parameters, TaskActivityService activityService) {
+    public TaskContext(Task task, Map<String, Object> parameters, Map<String, Object> metadata, TaskActivityService activityService) {
         this.task = task;
         this.parameters = parameters;
+        this.metadata = metadata;
         this.activityService = activityService;
         this.dataSourceObjects = new HashSet<>();
         this.postActionParameters = new HashSet<>();
@@ -164,6 +166,14 @@ public class TaskContext {
 
     public Map<String, Object> getTriggerParameters() {
         return parameters;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
     }
 
     private DataSourceObject getDataSourceObject(String objectId) {

--- a/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
+++ b/modules/tasks/tasks/src/main/resources/META-INF/spring/blueprint.xml
@@ -78,4 +78,7 @@
 
     <osgi:service id="taskTriggerHandlerOsgi" auto-export="interfaces" ref="taskTriggerHandler"
                   interface="org.motechproject.tasks.service.TriggerHandler"/>
+
+    <osgi:service id="tasksEventCallbackServiceOSGi" auto-export="interfaces" ref="tasksEventCallbackService"
+                  interface="org.motechproject.event.listener.EventCallbackService"/>
 </beans>

--- a/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/controllers.js
@@ -1116,7 +1116,8 @@
         var data, task;
 
         $scope.taskId = $stateParams.taskId;
-        $scope.activityTypes = ['All', 'Warning', 'Success', 'Error'];
+        $scope.activityTypes = ['All', 'In progress', 'Success', 'Warning', 'Error'];
+
         $scope.selectedActivityType = 'All';
 
         innerLayout({
@@ -1159,7 +1160,7 @@
             $('#taskHistoryTable').jqGrid('setGridParam', {
                 page: 1,
                 postData: {
-                    activityType: ($scope.selectedActivityType === 'All') ? '' : $scope.selectedActivityType.toUpperCase()
+                    activityType: ($scope.selectedActivityType === 'All') ? '' : $scope.selectedActivityType.toUpperCase().replace(/ /g, "_")
                 }}).trigger('reloadGrid');
         };
 

--- a/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
+++ b/modules/tasks/tasks/src/main/resources/webapp/js/directives.js
@@ -92,6 +92,8 @@
                                     $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType','<img src="../tasks/img/icon-ok.png" class="recent-activity-task-img"/>','ok',{ },'');
                                 } else if (activity === 'warning') {
                                     $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType','<img src="../tasks/img/icon-question.png" class="recent-activity-task-img"/>','ok',{ },'');
+                                } else if (activity === 'in progress') {
+                                    $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType','<img src="../tasks/img/icon-info.png" class="recent-activity-task-img"/>','ok',{ },'');
                                 } else if (activity === 'error') {
                                     activityId = $("#taskHistoryTable").getCell(rows[k],"id");
                                     $("#taskHistoryTable").jqGrid('setCell',rows[k],'activityType',

--- a/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
+++ b/modules/tasks/tasks/src/main/resources/webapp/messages/messages.properties
@@ -195,7 +195,8 @@ task.number.equals==
 
 task.fileChosen=File chosen
 
-task.success.ok=Action was performed correctly
+task.inProgress=The task is currently being executed. {0} out of {1} actions have been executed.
+task.success.ok=All task actions were executed correctly
 task.warning.taskDisabled=Task was disabled because number of possible errors was exceeded
 task.warning.manipulation=Unknown manipulation format\: {0}
 task.warning.serviceUnavailable=Service\: {0} is currently unavailable. Trying to send action as MOTECH event.
@@ -203,6 +204,7 @@ task.warning.notFoundObjectForType=Not found object for type {0}
 task.warning.objectDoesNotContainField=Object not contains field {0}
 task.warning.keysInMapCouldBeOverriden=Keys in the new map could be overriden
 task.warning.fieldNotInTrigger=Data input contains fields that are not defined in the trigger
+task.error.eventHandlerFailed=The task action has failed, because the handler method has thrown an exception
 task.error.actionNotFound=Action for task not found
 task.error.wrongActionInputFields=One of the action fields is null or empty
 task.error.templateNull=Action field {0} in action {1} has null template

--- a/modules/tasks/tasks/src/main/resources/webapp/partials/recent-task-activity.html
+++ b/modules/tasks/tasks/src/main/resources/webapp/partials/recent-task-activity.html
@@ -34,6 +34,7 @@
                             <img ng-show="activity.type == 'SUCCESS'" src="../tasks/img/icon-ok.png" class="recent-activity-icon"/>
                             <img ng-show="activity.type == 'ERROR'" src="../tasks/img/icon-exclamation.png" class="recent-activity-icon"/>
                             <img ng-show="activity.type == 'WARNING'" src="../tasks/img/icon-question.png" class="recent-activity-icon"/>
+                            <img ng-show="activity.type == 'IN PROGRESS'" src="../tasks/img/icon-info.png" class="recent-activity-icon"/>
                         </a>
                     </div>
                 </td>

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/it/TaskActivitiesDataServiceBundleIT.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/it/TaskActivitiesDataServiceBundleIT.java
@@ -9,6 +9,7 @@ import org.motechproject.mds.query.QueryParams;
 import org.motechproject.mds.util.Order;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskActivityType;
+import org.motechproject.tasks.domain.mds.task.TaskExecutionProgress;
 import org.motechproject.tasks.repository.TaskActivitiesDataService;
 import org.motechproject.testing.osgi.BasePaxIT;
 import org.motechproject.testing.osgi.container.MotechNativeTestContainerFactory;
@@ -49,7 +50,7 @@ public class TaskActivitiesDataServiceBundleIT extends BasePaxIT {
 
     @Test
     public void shouldFindTaskActivitiesByTaskId() {
-        TaskActivity errorMsg = new TaskActivity(ERROR.getValue(), FIELD, TASK_ID_1, ERROR);
+        TaskActivity errorMsg = new TaskActivity(ERROR.getValue(), FIELD, TASK_ID_1, ERROR, new TaskExecutionProgress(1));
         TaskActivity successMsg = new TaskActivity(SUCCESS.getValue(), TASK_ID_1, SUCCESS);
         TaskActivity warningMsg = new TaskActivity(WARNING.getValue(), TASK_ID_2, WARNING);
 

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskActivityServiceImplTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskActivityServiceImplTest.java
@@ -9,6 +9,7 @@ import org.motechproject.mds.util.Order;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskActivityType;
+import org.motechproject.tasks.domain.mds.task.TaskExecutionProgress;
 import org.motechproject.tasks.exception.TaskHandlerException;
 import org.motechproject.tasks.repository.TaskActivitiesDataService;
 import org.motechproject.tasks.service.TaskActivityService;
@@ -16,7 +17,6 @@ import org.motechproject.tasks.service.TaskActivityService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,14 +32,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
 import static org.motechproject.tasks.domain.mds.task.TaskActivityType.ERROR;
 import static org.motechproject.tasks.domain.mds.task.TaskActivityType.SUCCESS;
 import static org.motechproject.tasks.domain.mds.task.TaskActivityType.WARNING;
-import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
 
 public class TaskActivityServiceImplTest {
 
     private static final Long TASK_ID = 12345l;
+    private static final Long TASK_ACTIVITY_ID  = 11L;
     private static final List<String> ERROR_FIELD = asList("phone");
 
     private List<TaskActivity> activities;
@@ -65,32 +66,35 @@ public class TaskActivityServiceImplTest {
 
     @Test
     public void shouldAddErrorActivityWithTaskException() {
+        when(taskActivitiesDataService.findById(TASK_ACTIVITY_ID)).thenReturn(createInProgress());
         String messageKey = "error.notFoundTrigger";
         TaskHandlerException exception = new TaskHandlerException(TRIGGER, messageKey, ERROR_FIELD.get(0));
-        Map<String, Object> errorParameters = new HashMap<>();
-        errorParameters.put("errorKey", "errorValue");
 
         ArgumentCaptor<TaskActivity> captor = ArgumentCaptor.forClass(TaskActivity.class);
 
-        activityService.addError(task, exception, errorParameters);
+        activityService.addFailedExecution(TASK_ACTIVITY_ID, exception);
 
-        verify(taskActivitiesDataService).create(captor.capture());
+        verify(taskActivitiesDataService).update(captor.capture());
 
-        assertActivity(messageKey, ERROR_FIELD, TASK_ID, TaskActivityType.ERROR, getStackTrace(exception), errorParameters, captor.getValue());
+        assertActivity(messageKey, ERROR_FIELD, TASK_ID, TaskActivityType.ERROR, getStackTrace(exception), null, captor.getValue());
     }
 
     @Test
     public void shouldAddTaskSuccessActivity() {
+        when(taskActivitiesDataService.findById(TASK_ACTIVITY_ID)).thenReturn(createInProgress());
         String messageKey = "task.success.ok";
 
         ArgumentCaptor<TaskActivity> captor = ArgumentCaptor.forClass(TaskActivity.class);
 
-        activityService.addSuccess(task);
+        activityService.addSuccessfulExecution(TASK_ACTIVITY_ID);
 
-        verify(taskActivitiesDataService).create(captor.capture());
+        verify(taskActivitiesDataService).findById(TASK_ACTIVITY_ID);
+        verify(taskActivitiesDataService).update(captor.capture());
 
-        assertActivity(messageKey, Collections.<String>emptyList(), TASK_ID,
-                TaskActivityType.SUCCESS, null, null, captor.getValue());
+        TaskActivity activity = captor.getValue();
+
+        assertEquals(1, activity.getTaskExecutionProgress().getActionsSucceeded());
+        assertActivity(messageKey, Collections.<String>emptyList(), TASK_ID, TaskActivityType.SUCCESS, null, null, activity);
     }
 
     @Test
@@ -99,7 +103,7 @@ public class TaskActivityServiceImplTest {
 
         ArgumentCaptor<TaskActivity> captor = ArgumentCaptor.forClass(TaskActivity.class);
 
-        activityService.addWarning(task);
+        activityService.addTaskDisabledWarning(task);
 
         verify(taskActivitiesDataService).create(captor.capture());
 
@@ -127,7 +131,7 @@ public class TaskActivityServiceImplTest {
 
         ArgumentCaptor<TaskActivity> captor = ArgumentCaptor.forClass(TaskActivity.class);
 
-        activityService.addWarning(task, messageKey, ERROR_FIELD.get(0), exception);
+        activityService.addWarningWithException(task, messageKey, ERROR_FIELD.get(0), exception);
 
         verify(taskActivitiesDataService).create(captor.capture());
 
@@ -145,7 +149,7 @@ public class TaskActivityServiceImplTest {
 
     @Test
     public void shouldNotRemoveAnyActivitiesWhenTaskHasNotActivities() {
-        when(taskActivitiesDataService.byTask(TASK_ID)).thenReturn(new ArrayList<TaskActivity>());
+        when(taskActivitiesDataService.byTask(TASK_ID)).thenReturn(new ArrayList<>());
 
         activityService.deleteActivitiesForTask(TASK_ID);
 
@@ -191,12 +195,17 @@ public class TaskActivityServiceImplTest {
         messages.add(createError());
         messages.add(createError());
         messages.add(createError());
+        messages.add(createInProgress());
 
         return messages;
     }
 
+    private TaskActivity createInProgress() {
+        return new TaskActivity("", new ArrayList<>(), TASK_ID, TaskActivityType.IN_PROGRESS, new TaskExecutionProgress(1));
+    }
+
     private TaskActivity createError() {
-        return new TaskActivity(ERROR.getValue(), ERROR_FIELD, TASK_ID, ERROR);
+        return new TaskActivity(ERROR.getValue(), ERROR_FIELD, TASK_ID, ERROR, new TaskExecutionProgress(1));
     }
 
     private TaskActivity createSuccess() {

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskRetryHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskRetryHandlerTest.java
@@ -1,0 +1,142 @@
+package org.motechproject.tasks.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.EventRelay;
+import org.motechproject.tasks.constants.EventDataKeys;
+import org.motechproject.tasks.domain.mds.task.TaskActionInformation;
+import org.motechproject.tasks.service.TaskService;
+
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.motechproject.tasks.constants.EventSubjects.SCHEDULE_REPEATING_JOB;
+import static org.motechproject.tasks.constants.EventSubjects.UNSCHEDULE_REPEATING_JOB;
+
+public class TaskRetryHandlerTest extends TasksTestBase {
+
+    @Mock
+    private TaskService taskService;
+
+    @Mock
+    private EventRelay eventRelay;
+
+    @InjectMocks
+    private TaskRetryHandler taskRetryHandler = new TaskRetryHandler();
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        initTask();
+    }
+
+    @Test
+    public void shouldScheduleTaskRetriesOnFailure() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+
+        task.setNumberOfRetries(5);
+        task.setRetryIntervalInMilliseconds(5000);
+
+        actionEvent.setServiceInterface("TestService");
+        actionEvent.setServiceMethod("abc");
+
+        when(taskService.findActiveTasksForTriggerSubject(triggerEvent.getSubject())).thenReturn(tasks);
+        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
+
+        taskRetryHandler.handleTaskRetries(task, createEventParameters(), false, false);
+        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
+
+        MotechEvent scheduleJobEvent = captorEvent.getValue();
+        assertEquals(SCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
+
+        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
+        assertEquals(5, metadata.get(EventDataKeys.REPEAT_COUNT));
+        // We send repeat interval time in seconds
+        assertEquals(5, metadata.get(EventDataKeys.REPEAT_INTERVAL_TIME));
+        assertEquals(task.getId(), metadata.get(EventDataKeys.TASK_ID));
+        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
+    }
+
+    @Test
+    public void shouldNotScheduleTaskRetriesAgainOnFailure() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+
+        task.setNumberOfRetries(5);
+        task.setRetryIntervalInMilliseconds(5000);
+
+        actionEvent.setServiceInterface("TestService");
+        actionEvent.setServiceMethod("abc");
+
+        when(taskService.getTask(5L)).thenReturn(task);
+        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
+
+        MotechEvent event = createEvent();
+
+        taskRetryHandler.handleTaskRetries(task, event.getParameters(), false, true);
+
+        // since we already scheduled task retries, we should not send once again schedule job event
+        verify(eventRelay, never()).sendEventMessage(any(MotechEvent.class));
+    }
+
+    @Test
+    public void shouldNotScheduleTaskRetryOnFailureWhenNumberOfRetriesIsZero() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+
+        task.setNumberOfRetries(0);
+        task.setRetryIntervalInMilliseconds(0);
+
+        actionEvent.setServiceInterface("TestService");
+        actionEvent.setServiceMethod("abc");
+
+        when(taskService.findActiveTasksForTriggerSubject(triggerEvent.getSubject())).thenReturn(tasks);
+        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
+
+        MotechEvent event = createEvent();
+        taskRetryHandler.handleTaskRetries(task, event.getParameters(), false, false);
+        // task number of retries is 0, we should not send schedule job event
+        verify(eventRelay, never()).sendEventMessage(any(MotechEvent.class));
+    }
+
+    @Test
+    public void shouldUnscheduleTaskRetriesWhenSuccess() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+
+        task.setNumberOfRetries(5);
+        task.setRetryIntervalInMilliseconds(5000);
+
+        actionEvent.setServiceInterface("TestService");
+        actionEvent.setServiceMethod("abc");
+
+        when(taskService.getTask(5L)).thenReturn(task);
+        when(taskService.getActionEventFor(any(TaskActionInformation.class))).thenReturn(actionEvent);
+
+        MotechEvent event = createEvent();
+
+        taskRetryHandler.handleTaskRetries(task, event.getParameters(), true, true);
+
+        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
+
+        MotechEvent scheduleJobEvent = captorEvent.getValue();
+        assertEquals(UNSCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
+
+        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
+        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskTriggerHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TaskTriggerHandlerTest.java
@@ -1,7 +1,5 @@
 package org.motechproject.tasks.service.impl;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
@@ -13,29 +11,28 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.motechproject.commons.api.DataProvider;
-import org.motechproject.commons.api.TasksEventParser;
 import org.motechproject.config.SettingsFacade;
 import org.motechproject.event.MotechEvent;
 import org.motechproject.event.listener.EventListener;
 import org.motechproject.event.listener.EventListenerRegistryService;
 import org.motechproject.event.listener.EventRelay;
 import org.motechproject.event.listener.annotations.MotechListenerEventProxy;
-import org.motechproject.tasks.domain.mds.channel.ActionEvent;
-import org.motechproject.tasks.domain.mds.channel.builder.ActionEventBuilder;
-import org.motechproject.tasks.domain.mds.channel.ActionParameter;
-import org.motechproject.tasks.domain.mds.channel.builder.ActionParameterBuilder;
 import org.motechproject.tasks.constants.EventDataKeys;
-import org.motechproject.tasks.domain.mds.task.DataSource;
+import org.motechproject.tasks.constants.TaskFailureCause;
+import org.motechproject.tasks.domain.mds.channel.ActionEvent;
+import org.motechproject.tasks.domain.mds.channel.ActionParameter;
 import org.motechproject.tasks.domain.mds.channel.EventParameter;
+import org.motechproject.tasks.domain.mds.channel.TriggerEvent;
+import org.motechproject.tasks.domain.mds.channel.builder.ActionEventBuilder;
+import org.motechproject.tasks.domain.mds.channel.builder.ActionParameterBuilder;
+import org.motechproject.tasks.domain.mds.task.DataSource;
 import org.motechproject.tasks.domain.mds.task.Filter;
 import org.motechproject.tasks.domain.mds.task.FilterSet;
 import org.motechproject.tasks.domain.mds.task.Lookup;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActionInformation;
-import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskConfig;
 import org.motechproject.tasks.domain.mds.task.TaskTriggerInformation;
-import org.motechproject.tasks.domain.mds.channel.TriggerEvent;
 import org.motechproject.tasks.exception.ActionNotFoundException;
 import org.motechproject.tasks.exception.TaskHandlerException;
 import org.motechproject.tasks.service.SampleTasksEventParser;
@@ -46,7 +43,6 @@ import org.osgi.framework.ServiceReference;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +55,6 @@ import java.util.TreeSet;
 import static ch.lambdaj.Lambda.extract;
 import static ch.lambdaj.Lambda.on;
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
@@ -73,22 +68,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.motechproject.tasks.constants.EventSubjects.SCHEDULE_REPEATING_JOB;
-import static org.motechproject.tasks.constants.EventSubjects.UNSCHEDULE_REPEATING_JOB;
-import static org.motechproject.tasks.constants.EventSubjects.createHandlerFailureSubject;
-import static org.motechproject.tasks.constants.EventSubjects.createHandlerSuccessSubject;
-import static org.motechproject.tasks.constants.TaskFailureCause.ACTION;
-import static org.motechproject.tasks.constants.TaskFailureCause.DATA_SOURCE;
-import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.CONTAINS;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.ENDSWITH;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.EQUALS;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.EQUALS_IGNORE_CASE;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.EQ_NUMBER;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.EXIST;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.GT;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.LT;
-import static org.motechproject.tasks.domain.mds.task.OperatorType.STARTSWITH;
 import static org.motechproject.tasks.domain.mds.ParameterType.BOOLEAN;
 import static org.motechproject.tasks.domain.mds.ParameterType.DATE;
 import static org.motechproject.tasks.domain.mds.ParameterType.DOUBLE;
@@ -99,14 +78,19 @@ import static org.motechproject.tasks.domain.mds.ParameterType.MAP;
 import static org.motechproject.tasks.domain.mds.ParameterType.TEXTAREA;
 import static org.motechproject.tasks.domain.mds.ParameterType.TIME;
 import static org.motechproject.tasks.domain.mds.ParameterType.UNICODE;
-import static org.motechproject.tasks.domain.mds.task.TaskActivityType.ERROR;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.CONTAINS;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.ENDSWITH;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.EQUALS;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.EQUALS_IGNORE_CASE;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.EQ_NUMBER;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.EXIST;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.GT;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.LT;
+import static org.motechproject.tasks.domain.mds.task.OperatorType.STARTSWITH;
 import static org.springframework.aop.support.AopUtils.getTargetClass;
 import static org.springframework.util.ReflectionUtils.findMethod;
 
-public class TaskTriggerHandlerTest {
-    private static final String TRIGGER_SUBJECT = "APPOINTMENT_CREATE_EVENT_SUBJECT";
-    private static final String ACTION_SUBJECT = "SEND_SMS";
-    private static final String TASK_DATA_PROVIDER_NAME = "12345L";
+public class TaskTriggerHandlerTest extends TasksTestBase {
 
     public class TestObjectField {
         private int id = 6789;
@@ -135,57 +119,57 @@ public class TaskTriggerHandlerTest {
     }
 
     @Mock
-    TaskService taskService;
+    private TaskService taskService;
 
     @Mock
-    TaskActivityService taskActivityService;
+    private TaskActivityService taskActivityService;
 
     @Mock
-    EventListenerRegistryService registryService;
+    private EventListenerRegistryService registryService;
 
     @Mock
-    EventRelay eventRelay;
+    private EventRelay eventRelay;
 
     @Mock
-    SettingsFacade settingsFacade;
+    private SettingsFacade settingsFacade;
 
     @Mock
-    DataProvider dataProvider;
+    private DataProvider dataProvider;
 
     @Mock
-    BundleContext bundleContext;
+    private BundleContext bundleContext;
 
     @Mock
-    ServiceReference serviceReference;
+    private ServiceReference serviceReference;
 
     @Mock
-    Exception exception;
+    private TasksPostExecutionHandler postExecutionHandler;
+
+    @Mock
+    private TaskRetryHandler retryHandler;
+
+    @Mock
+    private Exception exception;
 
     @Spy
     @InjectMocks
-    TaskActionExecutor taskActionExecutor = new TaskActionExecutor(taskService, taskActivityService, eventRelay);
+    private TaskActionExecutor taskActionExecutor = new TaskActionExecutor(taskService, taskActivityService, eventRelay, postExecutionHandler);
 
     @Captor
-    ArgumentCaptor<TaskHandlerException> exceptionCaptor;
+    private ArgumentCaptor<TaskHandlerException> exceptionCaptor;
 
     @InjectMocks
-    TaskTriggerHandler handler = new TaskTriggerHandler();
-
-    List<Task> tasks = new ArrayList<>(1);
-    List<TaskActivity> taskActivities;
-
-    Task task;
-    TriggerEvent triggerEvent;
-    ActionEvent actionEvent;
+    private TaskTriggerHandler handler = new TaskTriggerHandler();
 
     @Before
-    public void setup() throws Exception {
+    public void setUp() throws Exception {
         initMocks(this);
         initTask();
 
         when(taskService.getAllTasks()).thenReturn(tasks);
         when(settingsFacade.getProperty("task.possible.errors")).thenReturn("5");
         when(dataProvider.getName()).thenReturn(TASK_DATA_PROVIDER_NAME);
+        when(taskActivityService.addTaskStarted(any(Task.class), anyMap())).thenReturn(TASK_ACTIVITY_ID);
 
         // do the initialization, normally called by Spring as @PostConstruct
         handler.init();
@@ -200,7 +184,7 @@ public class TaskTriggerHandlerTest {
     public void shouldNotRegisterHandler() {
         EventListenerRegistryService eventListenerRegistryService = mock(EventListenerRegistryService.class);
 
-        when(taskService.getAllTasks()).thenReturn(new ArrayList<Task>());
+        when(taskService.getAllTasks()).thenReturn(new ArrayList<>());
 
         handler.init();
         verify(eventListenerRegistryService, never()).registerListener(any(EventListener.class), anyString());
@@ -260,7 +244,7 @@ public class TaskTriggerHandlerTest {
     }
 
     @Test
-    public void shouldNotSendEventWhenActionNotFound() throws Exception {
+    public void shouldHandleErrorWhenActionIsNotFound() throws Exception {
         setTriggerEvent();
 
         when(taskService.findActiveTasksForTriggerSubject(TRIGGER_SUBJECT)).thenReturn(tasks);
@@ -268,20 +252,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.actionNotFound", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.actionNotFound");
     }
 
     @Test
-    public void shouldNotSendEventWhenActionEventParameterNotContainValue() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterDoesNotContainValue() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
@@ -292,46 +267,25 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.taskActionNotContainsField", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.taskActionNotContainsField");
     }
 
     @Test
-    public void shouldNotSendEventWhenActionEventParameterHasNotValue() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterTemplateIsNull() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
         when(taskService.findActiveTasksForTriggerSubject(TRIGGER_SUBJECT)).thenReturn(tasks);
         when(taskService.getActionEventFor(task.getActions().get(0))).thenReturn(actionEvent);
-
         task.getActions().get(0).getValues().put("phone", null);
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.templateNull", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.templateNull");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToInteger() throws Exception {
+    public void shouldHandleErrorWhenEventParameterCanNotBeConvertedToInteger() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
@@ -342,21 +296,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToInteger", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToInteger");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToLong() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterCanNotBeConvertedToLong() throws Exception {
         setTriggerEvent();
         setActionEvent();
         setLongField();
@@ -368,21 +312,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToLong", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToLong");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToDouble() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterCanNotBeConvertedToDouble() throws Exception {
         setTriggerEvent();
         setActionEvent();
         setDoubleField();
@@ -394,21 +328,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToDouble", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToDouble");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToBoolean() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterCanNotBeConvertedToBoolean() throws Exception {
         setTriggerEvent();
         setActionEvent();
         setBooleanField();
@@ -420,21 +344,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToBoolean", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToBoolean");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToTime() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterCanNotBeConvertedToTime() throws Exception {
         setTriggerEvent();
         setActionEvent();
         setTimeField();
@@ -446,21 +360,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToTime", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToTime");
     }
 
     @Test
-    public void shouldNotSendEventIfActionEventParameterCanNotBeConvertedToDate() throws Exception {
+    public void shouldHandleErrorWhenActionEventParameterCanNotBeConvertedToDate() throws Exception {
         setTriggerEvent();
         setActionEvent();
         setDateField();
@@ -472,109 +376,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("task.error.convertToDate", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.convertToDate");
     }
 
     @Test
-    public void shouldSendEventAndConverseDateWithAndWithoutManipulation() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-
-        when(taskService.findActiveTasksForTriggerSubject(TRIGGER_SUBJECT)).thenReturn(tasks);
-        when(taskService.getActionEventFor(task.getActions().get(0))).thenReturn(actionEvent);
-
-        task.getActions().get(0).getValues().put("date1", "2012-12-21 21:21 +0100");
-        actionEvent.addParameter(new ActionParameterBuilder().setDisplayName("Date1").setKey("date1")
-                .setType(DATE).build(), true);
-        task.getActions().get(0).getValues().put("date2", "{{trigger.startDate?datetime(yyyyy.MMMMM.dd GGG hh:mm aaa)}}");
-        actionEvent.addParameter(new ActionParameterBuilder().setDisplayName("Date2").setKey("date2")
-                .setType(UNICODE).build(), true);
-
-        handler.handle(createEvent());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addSuccess(eq(task));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-
-        assertEquals(createHandlerSuccessSubject(task.getName()), captorEvent.getValue().getSubject());
-
-        List<MotechEvent> events = captorEvent.getAllValues();
-
-        assertEquals(asList(ACTION_SUBJECT, createHandlerSuccessSubject(task.getName())),
-                extract(events, on(MotechEvent.class).getSubject()));
-
-        MotechEvent motechEvent = (MotechEvent) CollectionUtils.find(events, new Predicate() {
-            @Override
-            public boolean evaluate(Object object) {
-                return object instanceof MotechEvent && ((MotechEvent) object).getSubject().equalsIgnoreCase(ACTION_SUBJECT);
-            }
-        });
-
-        assertEquals(ACTION_SUBJECT, motechEvent.getSubject());
-
-        Map<String, Object> motechEventParameters = motechEvent.getParameters();
-
-        assertNotNull(motechEventParameters);
-
-        assertEquals(task.getActions().get(0).getValues().get("phone"), motechEventParameters.get("phone").toString());
-        assertEquals(4, motechEventParameters.size());
-        assertNotNull(motechEventParameters.get("date1"));
-        assertNotNull(motechEventParameters.get("date2"));
-    }
-
-    @Test
-    public void shouldDisableTaskWhenNumberPossibleErrorsIsExceeded() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-        setTaskActivities();
-        task.setFailuresInRow(taskActivities.size());
-
-        when(taskService.findActiveTasksForTriggerSubject(TRIGGER_SUBJECT)).thenReturn(tasks);
-        when(taskService.getActionEventFor(task.getActions().get(0))).thenReturn(actionEvent);
-        task.getActions().get(0).getValues().put("message", null);
-
-        assertTrue(task.isEnabled());
-
-        handler.handle(createEvent());
-
-        assertEquals(5, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-        verify(taskService).save(task);
-        verify(taskActivityService).addWarning(task);
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
-
-        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), TRIGGER)),
-                extract(capturedEvents, on(MotechEvent.class).getSubject()));
-
-        assertFalse(task.isEnabled());
-        assertEquals("task.error.templateNull", exceptionCaptor.getValue().getMessage());
-    }
-
-    @Test
-    public void shouldDisableTaskWhenActionDoesNotFindDataSource_WithFailIfDataNotFoundSelected() throws Exception {
+    public void shouldTriggerErrorWhenActionDoesNotFindDataSourceWithFailIfDataNotFoundSelected() throws Exception {
         Map<String , DataProvider> providers = new HashMap<>();
         DataProvider provider = mock(DataProvider.class);
         Map<String, String> lookup = new HashMap<>();
@@ -620,18 +426,14 @@ public class TaskTriggerHandlerTest {
 
         Map<String, Object> param = new HashMap<>(4);
         param.put("patientId", "123");
+
         handler.handle(new MotechEvent("trigger", param));
 
-        verify(taskService).save(task);
-        ArgumentCaptor<Task> taskArgumentCaptor = ArgumentCaptor.forClass(Task.class);
-        assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(taskArgumentCaptor.capture());
-        Task actualTask = taskArgumentCaptor.getValue();
-        assertFalse(actualTask.isEnabled());
+        verify(postExecutionHandler).handleError(anyMap(), anyMap(), eq(task), any(TaskHandlerException.class), eq(TASK_ACTIVITY_ID));
     }
 
     @Test
-    public void shouldNotDisableTaskWhenActionDoesNotFindDataSource_WithFailIfDataNotFoundNotSelected() throws Exception {
+    public void shouldNotTriggerErrorWhenActionDoesNotFindDataSourceWithFailIfDataNotFoundNotSelected() throws Exception {
         Map<String, DataProvider> providers = new HashMap<>();
         DataProvider provider = mock(DataProvider.class);
         Map<String, String> lookup = new HashMap<>();
@@ -678,13 +480,12 @@ public class TaskTriggerHandlerTest {
         param.put("patientId", "123");
         handler.handle(new MotechEvent("trigger", param));
 
-        assertEquals(0, task.getFailuresInRow());
-        verify(taskService).save(task);
-        verify(taskActivityService).addSuccess(task);
+        verify(postExecutionHandler, never()).handleError(anyMap(), anyMap(), eq(task), any(TaskHandlerException.class), eq(TASK_ACTIVITY_ID));
+        verify(taskActivityService).addWarning(eq(task), eq("task.warning.notFoundObjectForType"), eq("Patient"));
     }
 
     @Test
-    public void shouldDisableTaskWhenFilterDoesNotFindDataSource_WithFailIfDataNotFoundSelected() throws Exception {
+    public void shouldTriggerErrorWhenFilterDoesNotFindDataSourceWithFailIfDataNotFoundSelected() throws Exception {
         Map<String, DataProvider> providers = new HashMap<>();
         DataProvider provider = mock(DataProvider.class);
         Map<String, String> lookup = new HashMap<>();
@@ -723,16 +524,11 @@ public class TaskTriggerHandlerTest {
         param.put("patientId", "123");
         handler.handle(new MotechEvent("trigger", param));
 
-        ArgumentCaptor<Task> taskArgumentCaptor = ArgumentCaptor.forClass(Task.class);
-        assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(task);
-        verify(taskService).save(taskArgumentCaptor.capture());
-        Task actualTask = taskArgumentCaptor.getValue();
-        assertFalse(actualTask.isEnabled());
+        verify(postExecutionHandler).handleError(anyMap(), anyMap(), eq(task), any(TaskHandlerException.class), eq(TASK_ACTIVITY_ID));
     }
 
     @Test
-    public void shouldNotDisableTaskWhenFilterDoesNotFindDataSource_WithFailIfDataNotFoundNotSelected() throws Exception {
+    public void shouldNotTriggerErrorWhenFilterDoesNotFindDataSourceWithFailIfDataNotFoundNotSelected() throws Exception {
         Map<String , DataProvider> providers = new HashMap<>();
         DataProvider provider = mock(DataProvider.class);
         Map<String, String> lookup = new HashMap<>();
@@ -771,9 +567,43 @@ public class TaskTriggerHandlerTest {
         param.put("patientId", "123");
         handler.handle(new MotechEvent("trigger", param));
 
-        assertEquals(0, task.getFailuresInRow());
-        verify(taskService).save(task);
-        verify(taskActivityService).addSuccess(task);
+        verify(postExecutionHandler, never()).handleError(anyMap(), anyMap(), eq(task), any(TaskHandlerException.class), eq(TASK_ACTIVITY_ID));
+        verify(taskActivityService).addWarning(eq(task), eq("task.warning.notFoundObjectForType"), eq("Patient"));
+    }
+
+    @Test
+    public void shouldSendEventAndConvertDateWithAndWithoutManipulation() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+
+        when(taskService.findActiveTasksForTriggerSubject(TRIGGER_SUBJECT)).thenReturn(tasks);
+        when(taskService.getActionEventFor(task.getActions().get(0))).thenReturn(actionEvent);
+
+        task.getActions().get(0).getValues().put("date1", "2012-12-21 21:21 +0100");
+        actionEvent.addParameter(new ActionParameterBuilder().setDisplayName("Date1").setKey("date1")
+                .setType(DATE).build(), true);
+        task.getActions().get(0).getValues().put("date2", "{{trigger.startDate?datetime(yyyyy.MMMMM.dd GGG hh:mm aaa)}}");
+        actionEvent.addParameter(new ActionParameterBuilder().setDisplayName("Date2").setKey("date2")
+                .setType(UNICODE).build(), true);
+
+        handler.handle(createEvent());
+
+        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
+        verify(taskService).getActionEventFor(task.getActions().get(0));
+
+        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
+        MotechEvent motechEvent = captorEvent.getValue();
+
+        assertEquals(ACTION_SUBJECT, motechEvent.getSubject());
+
+        Map<String, Object> motechEventParameters = motechEvent.getParameters();
+        assertNotNull(motechEventParameters);
+
+        assertEquals(task.getActions().get(0).getValues().get("phone"), motechEventParameters.get("phone").toString());
+        assertEquals(4, motechEventParameters.size());
+        assertNotNull(motechEventParameters.get("date1"));
+        assertNotNull(motechEventParameters.get("date2"));
     }
 
     @Test
@@ -791,24 +621,12 @@ public class TaskTriggerHandlerTest {
         handler.setDataProviders(null);
         handler.handle(createEvent());
 
-        assertEquals(5, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionCaptor.capture(), eq(TASK_ACTIVITY_ID));
         verify(dataProvider, never()).supports(anyString());
         verify(dataProvider, never()).lookup(anyString(), anyString(), anyMap());
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
+        verify(postExecutionHandler, never()).handleActionExecuted(anyMap(), anyMap(), eq(TASK_ACTIVITY_ID));
 
-        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
-
-        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), DATA_SOURCE)),
-                extract(capturedEvents, on(MotechEvent.class).getSubject()));
-
-        assertFalse(task.isEnabled());
         assertEquals("task.error.notFoundDataProvider", exceptionCaptor.getValue().getMessage());
     }
 
@@ -824,26 +642,15 @@ public class TaskTriggerHandlerTest {
 
         assertTrue(task.isEnabled());
 
-        handler.setDataProviders(new HashMap<String, DataProvider>());
+        handler.setDataProviders(new HashMap<>());
         handler.handle(createEvent());
 
-        assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionCaptor.capture(), eq(TASK_ACTIVITY_ID));
 
         verify(dataProvider, never()).supports(anyString());
         verify(dataProvider, never()).lookup(anyString(), anyString(), anyMap());
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
 
-        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
-
-        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), DATA_SOURCE)),
-                extract(capturedEvents, on(MotechEvent.class).getSubject()));
-
-        assertFalse(task.isEnabled());
         assertEquals("task.error.notFoundDataProvider", exceptionCaptor.getValue().getMessage());
     }
 
@@ -869,22 +676,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(5, task.getFailuresInRow());
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(dataProvider).lookup("TestObjectField", "id", lookupFields);
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionCaptor.capture(), eq(TASK_ACTIVITY_ID));
+        verify(postExecutionHandler, never()).handleActionExecuted(eq(createEventParameters()), anyMap(), eq(TASK_ACTIVITY_ID));
 
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
-
-        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), DATA_SOURCE)),
-                extract(capturedEvents, on(MotechEvent.class).getSubject()));
-
-        assertFalse(task.isEnabled());
         assertEquals("task.error.objectOfTypeNotFound", exceptionCaptor.getValue().getMessage());
     }
 
@@ -910,23 +706,11 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(5, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(dataProvider).lookup("TestObjectField", "id", lookupFields);
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionCaptor.capture(), eq(TASK_ACTIVITY_ID));
+        verify(postExecutionHandler, never()).handleActionExecuted(anyMap(), anyMap(), eq(TASK_ACTIVITY_ID));
 
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
-
-        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), DATA_SOURCE)),
-                extract(capturedEvents, on(MotechEvent.class).getSubject()));
-
-        assertFalse(task.isEnabled());
         assertEquals("task.error.objectDoesNotContainField", exceptionCaptor.getValue().getMessage());
     }
 
@@ -943,19 +727,7 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(1, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
-        assertEquals("error.date.format", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("error.date.format");
     }
 
     @Test
@@ -970,13 +742,10 @@ public class TaskTriggerHandlerTest {
         task.getActions().get(0).getValues().put("manipulations", "{{trigger.eventName?toUper}}");
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
 
-        verify(eventRelay, times(2)).sendEventMessage(any(MotechEvent.class));
+        verify(eventRelay).sendEventMessage(any(MotechEvent.class));
         verify(taskActivityService).addWarning(task, "task.warning.manipulation", "toUper");
     }
 
@@ -991,13 +760,9 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(eventRelay, times(2)).sendEventMessage(any(MotechEvent.class));
-        verify(taskActivityService).addSuccess(task);
+        verify(eventRelay).sendEventMessage(any(MotechEvent.class));
     }
 
     @Test
@@ -1013,10 +778,7 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService, never()).save(task);
         verify(taskService, never()).getActionEventFor(task.getActions().get(0));
         verify(eventRelay, never()).sendEventMessage(any(MotechEvent.class));
     }
@@ -1063,26 +825,12 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
+        verify(taskActivityService).addTaskStarted(task, createEventParameters());
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(eventRelay, times(2)).sendEventMessage(captor.capture());
-        verify(taskActivityService).addSuccess(task);
+        verify(eventRelay).sendEventMessage(captor.capture());
 
-        List<MotechEvent> events = captor.getAllValues();
-
-        assertEquals(asList(ACTION_SUBJECT, createHandlerSuccessSubject(task.getName())),
-                extract(events, on(MotechEvent.class).getSubject()));
-
-        MotechEvent motechEvent = (MotechEvent) CollectionUtils.find(events, new Predicate() {
-            @Override
-            public boolean evaluate(Object object) {
-                return object instanceof MotechEvent && ((MotechEvent) object).getSubject().equalsIgnoreCase(ACTION_SUBJECT);
-            }
-        });
-
+        MotechEvent motechEvent = captor.getValue();
         assertEquals(ACTION_SUBJECT, motechEvent.getSubject());
 
         Map<String, Object> motechEventParameters = motechEvent.getParameters();
@@ -1117,19 +865,7 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(1, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), ACTION), captorEvent.getValue().getSubject());
-        assertEquals("task.error.cantExecuteAction", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.cantExecuteAction");
     }
 
     @Test
@@ -1148,20 +884,8 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(1, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskActivityService).addWarning(task, "task.warning.serviceUnavailable", "TestService");
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), ACTION), captorEvent.getValue().getSubject());
-        assertEquals("task.error.cantExecuteAction", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.cantExecuteAction");
     }
 
     @Test
@@ -1182,19 +906,7 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(1, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), ACTION), captorEvent.getValue().getSubject());
-        assertEquals("task.error.serviceMethodInvokeError", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.serviceMethodInvokeError");
     }
 
     @Test
@@ -1215,19 +927,7 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(1, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
-        verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addError(eq(task), exceptionCaptor.capture(), eq(createEventParameters()));
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
-
-        assertEquals(createHandlerFailureSubject(task.getName(), ACTION), captorEvent.getValue().getSubject());
-        assertEquals("task.error.notFoundMethodForService", exceptionCaptor.getValue().getMessage());
+        verifyErrorHandling("task.error.notFoundMethodForService");
     }
 
     @Test
@@ -1248,17 +948,9 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
-        verify(taskActivityService).addSuccess(task);
-
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-
-        assertEquals(createHandlerSuccessSubject(task.getName()), captorEvent.getValue().getSubject());
+        verify(postExecutionHandler).handleActionExecuted(anyMap(), anyMap(), eq(TASK_ACTIVITY_ID));
     }
 
     @Test
@@ -1277,20 +969,15 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskActivityService).addWarning(task, "task.warning.serviceUnavailable", actionEvent.getServiceInterface());
         verify(taskActivityService).addWarning(task, "task.warning.notFoundObjectForType", "TestObjectField");
-        verify(taskActivityService).addSuccess(task);
 
         ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
 
-        assertEquals(asList(ACTION_SUBJECT, createHandlerSuccessSubject(task.getName())),
-                extract(captorEvent.getAllValues(), on(MotechEvent.class).getSubject()));
+        assertEquals(ACTION_SUBJECT, captorEvent.getValue().getSubject());
     }
 
     @Test
@@ -1308,23 +995,18 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskActivityService).addWarning(task, "task.warning.serviceUnavailable", actionEvent.getServiceInterface());
-        verify(taskActivityService).addSuccess(task);
 
         ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
 
-        assertEquals(asList(ACTION_SUBJECT, createHandlerSuccessSubject(task.getName())),
-                extract(captorEvent.getAllValues(), on(MotechEvent.class).getSubject()));
+        assertEquals(ACTION_SUBJECT, captorEvent.getValue().getSubject());
     }
 
     @Test
-    public void shouldCaptureUnrecognizedError() throws Exception {
+    public void shouldHandleUnrecognizedError() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
@@ -1336,15 +1018,15 @@ public class TaskTriggerHandlerTest {
 
         handler.setBundleContext(bundleContext);
         handler.handle(createEvent());
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+        ArgumentCaptor<TaskHandlerException> exceptionArgumentCaptor = ArgumentCaptor.forClass(TaskHandlerException.class);
 
-        assertEquals(1, task.getFailuresInRow());
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionArgumentCaptor.capture(), eq(TASK_ACTIVITY_ID));
 
-        verify(taskService).save(task);
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-        verify(taskActivityService, never()).addSuccess(task);
+        TaskHandlerException handlerException = exceptionArgumentCaptor.getValue();
+        assertEquals("task.error.unrecognizedError", handlerException.getMessage());
+        assertEquals(TaskFailureCause.TRIGGER, handlerException.getFailureCause());
 
-        assertEquals(createHandlerFailureSubject(task.getName(), TRIGGER), captorEvent.getValue().getSubject());
+        verify(postExecutionHandler, never()).handleActionExecuted(eq(createEventParameters()), anyMap(), eq(TASK_ACTIVITY_ID));
     }
 
     @Test
@@ -1360,19 +1042,15 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
         verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
         verify(taskService).getActionEventFor(task.getActions().get(0));
         verify(taskService).getActionEventFor(task.getActions().get(1));
-        verify(eventRelay, times(3)).sendEventMessage(captor.capture());
-        verify(taskActivityService).addSuccess(task);
+        verify(eventRelay, times(2)).sendEventMessage(captor.capture());
 
         List<MotechEvent> events = captor.getAllValues();
 
         assertEquals(
-                asList(ACTION_SUBJECT, ACTION_SUBJECT, createHandlerSuccessSubject(task.getName())),
+                asList(ACTION_SUBJECT, ACTION_SUBJECT),
                 extract(events, on(MotechEvent.class).getSubject())
         );
 
@@ -1423,10 +1101,7 @@ public class TaskTriggerHandlerTest {
 
         handler.handle(createEvent());
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(eventRelay, times(2)).sendEventMessage(captor.capture());
+        verify(eventRelay).sendEventMessage(captor.capture());
 
         MotechEvent event = captor.getAllValues().get(0);
         assertEquals("123456789 || 6789 || YourName", event.getParameters().get("format"));
@@ -1441,18 +1116,12 @@ public class TaskTriggerHandlerTest {
         when(taskService.getActionEventFor(any(TaskActionInformation.class))).thenReturn(actionEvent);
         when(taskService.findCustomParser(SampleTasksEventParser.PARSER_NAME)).thenReturn(new SampleTasksEventParser());
 
-        ArgumentCaptor<MotechEvent> captor = ArgumentCaptor.forClass(MotechEvent.class);
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
 
         handler.handle(createEvent(true));
 
-        assertEquals(0, task.getFailuresInRow());
-
-        verify(taskService).save(task);
-        verify(eventRelay, times(2)).sendEventMessage(captor.capture());
-
-        MotechEvent event = captor.getAllValues().get(1);
-
-        Map<String, Object> paramsMap = event.getParameters();
+        verify(taskActivityService).addTaskStarted(eq(task), captor.capture());
+        Map<String, Object> paramsMap = captor.getValue();
 
         assertTrue(paramsMap.containsKey("eve"));
         assertTrue(paramsMap.containsKey("ext"));
@@ -1466,121 +1135,7 @@ public class TaskTriggerHandlerTest {
     }
 
     @Test
-    public void shouldScheduleTaskRetriesOnFailure() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-
-        task.setNumberOfRetries(5);
-        task.setRetryIntervalInMilliseconds(5000);
-
-        actionEvent.setServiceInterface("TestService");
-        actionEvent.setServiceMethod("abc");
-
-        when(taskService.findActiveTasksForTriggerSubject(triggerEvent.getSubject())).thenReturn(tasks);
-        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
-
-        MotechEvent event = createEvent();
-        handler.setBundleContext(bundleContext);
-        handler.handle(event);
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-
-        assertEquals(1, task.getFailuresInRow());
-        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
-
-        MotechEvent scheduleJobEvent = captorEvent.getAllValues().get(1);
-        assertEquals(SCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
-
-        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
-        assertEquals(5, metadata.get(EventDataKeys.REPEAT_COUNT));
-        // We send repeat interval time in seconds
-        assertEquals(5, metadata.get(EventDataKeys.REPEAT_INTERVAL_TIME));
-        assertEquals(task.getId(), metadata.get(EventDataKeys.TASK_ID));
-        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
-    }
-
-    @Test
-    public void shouldNotScheduleTaskRetriesAgainOnFailure() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-
-        task.setNumberOfRetries(5);
-        task.setRetryIntervalInMilliseconds(5000);
-
-        actionEvent.setServiceInterface("TestService");
-        actionEvent.setServiceMethod("abc");
-
-        when(taskService.getTask(5L)).thenReturn(task);
-        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
-
-        MotechEvent event = createEvent();
-        event.getMetadata().put(EventDataKeys.TASK_ID, 5L);
-
-        handler.setBundleContext(bundleContext);
-        handler.handleRetry(event);
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-
-        assertEquals(1, task.getFailuresInRow());
-        // since we already scheduled task retries, we should not send once again schedule job event
-        verify(eventRelay).sendEventMessage(any(MotechEvent.class));
-    }
-
-    @Test
-    public void shouldNotScheduleTaskRetryWhenNumberOfRetriesIsZero() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-
-        task.setNumberOfRetries(0);
-        task.setRetryIntervalInMilliseconds(0);
-
-        actionEvent.setServiceInterface("TestService");
-        actionEvent.setServiceMethod("abc");
-
-        when(taskService.findActiveTasksForTriggerSubject(triggerEvent.getSubject())).thenReturn(tasks);
-        when(taskService.getActionEventFor(task.getActions().get(0))).thenThrow(new RuntimeException());
-
-        MotechEvent event = createEvent();
-
-        handler.setBundleContext(bundleContext);
-        handler.handle(event);
-
-        assertEquals(1, task.getFailuresInRow());
-        // task number of retries is 0, we should not send schedule job event
-        verify(eventRelay).sendEventMessage(any(MotechEvent.class));
-    }
-
-    @Test
-    public void shouldUnscheduleTaskRetriesWhenSuccess() throws Exception {
-        setTriggerEvent();
-        setActionEvent();
-
-        task.setNumberOfRetries(5);
-        task.setRetryIntervalInMilliseconds(5000);
-
-        actionEvent.setServiceInterface("TestService");
-        actionEvent.setServiceMethod("abc");
-
-        when(taskService.getTask(5L)).thenReturn(task);
-        when(taskService.getActionEventFor(any(TaskActionInformation.class))).thenReturn(actionEvent);
-
-        MotechEvent event = createEvent();
-        event.getParameters().put(EventDataKeys.TASK_ID, 5L);
-
-        handler.setBundleContext(bundleContext);
-        handler.handleRetry(event);
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-
-        assertEquals(0, task.getFailuresInRow());
-        verify(eventRelay, times(3)).sendEventMessage(captorEvent.capture());
-
-        MotechEvent scheduleJobEvent = captorEvent.getAllValues().get(2);
-        assertEquals(UNSCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
-
-        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
-        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
-    }
-
-    @Test
-    public void shouldUnscheduleTaskRetriesWhenTaskDeleted() throws Exception {
+    public void shouldUnscheduleTaskRetriesWhenTaskIsDeleted() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
@@ -1594,23 +1149,17 @@ public class TaskTriggerHandlerTest {
 
         MotechEvent event = createEvent();
         event.getParameters().put(EventDataKeys.TASK_ID, 5L);
+        event.getParameters().put(EventDataKeys.TASK_RETRY, true);
         event.getParameters().put(EventDataKeys.JOB_SUBJECT, task.getTrigger().getEffectiveListenerRetrySubject());
 
         handler.setBundleContext(bundleContext);
         handler.handleRetry(event);
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
 
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-
-        MotechEvent scheduleJobEvent = captorEvent.getValue();
-        assertEquals(UNSCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
-
-        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
-        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
+        verify(retryHandler).unscheduleTaskRetry((String) event.getMetadata().get(EventDataKeys.JOB_SUBJECT));
     }
 
     @Test
-    public void shouldUnscheduleTaskRetriesWhenTaskDisabled() throws Exception {
+    public void shouldUnscheduleTaskRetriesWhenTaskIsDisabled() throws Exception {
         setTriggerEvent();
         setActionEvent();
 
@@ -1630,32 +1179,16 @@ public class TaskTriggerHandlerTest {
         handler.setBundleContext(bundleContext);
         handler.handleRetry(event);
 
-        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
-
-        verify(eventRelay).sendEventMessage(captorEvent.capture());
-
-        MotechEvent scheduleJobEvent = captorEvent.getValue();
-        assertEquals(UNSCHEDULE_REPEATING_JOB, scheduleJobEvent.getSubject());
-
-        Map<String, Object> metadata = scheduleJobEvent.getMetadata();
-        assertEquals(task.getTrigger().getEffectiveListenerRetrySubject(), metadata.get(EventDataKeys.JOB_SUBJECT));
+        verify(retryHandler).unscheduleTaskRetry((String) event.getMetadata().get(EventDataKeys.JOB_SUBJECT));
     }
 
-    private void initTask() throws Exception {
-        Map<String, String> actionValues = new HashMap<>();
-        actionValues.put("phone", "123456");
-        actionValues.put("message", "Hello {{trigger.externalId}}, You have an appointment on {{trigger.startDate}}");
+    private void verifyErrorHandling(String exceptionKey) throws ActionNotFoundException {
+        verify(taskService).findActiveTasksForTriggerSubject(TRIGGER_SUBJECT);
+        verify(taskService).getActionEventFor(task.getActions().get(0));
+        verify(postExecutionHandler).handleError(eq(createEventParameters()), anyMap(), eq(task), exceptionCaptor.capture(), eq(TASK_ACTIVITY_ID));
+        verify(postExecutionHandler, never()).handleActionExecuted(eq(createEventParameters()), anyMap(), eq(TASK_ACTIVITY_ID));
 
-        TaskTriggerInformation trigger = new TaskTriggerInformation("appointments", "Appointments", "appointments-bundle", "0.15", TRIGGER_SUBJECT, TRIGGER_SUBJECT);
-        TaskActionInformation action = new TaskActionInformation("sms", "SMS", "sms-bundle", "0.15", ACTION_SUBJECT, actionValues);
-
-        task = new Task();
-        task.setName("name");
-        task.setTrigger(trigger);
-        task.addAction(action);
-        task.setId(9l);
-        task.setHasRegisteredChannel(true);
-        tasks.add(task);
+        assertEquals(exceptionKey, exceptionCaptor.getValue().getMessage());
     }
 
     private void setSecondAction() {
@@ -1735,43 +1268,6 @@ public class TaskTriggerHandlerTest {
         handler.addDataProvider(dataProvider);
     }
 
-    private void setTriggerEvent() {
-        List<EventParameter> triggerEventParameters = new ArrayList<>();
-        triggerEventParameters.add(new EventParameter("ExternalID", "externalId"));
-        triggerEventParameters.add(new EventParameter("StartDate", "startDate", DATE));
-        triggerEventParameters.add(new EventParameter("EndDate", "endDate", DATE));
-        triggerEventParameters.add(new EventParameter("FacilityId", "facilityId"));
-        triggerEventParameters.add(new EventParameter("EventName", "eventName"));
-        triggerEventParameters.add(new EventParameter("List", "list", LIST));
-        triggerEventParameters.add(new EventParameter("Map", "map", MAP));
-
-        triggerEvent = new TriggerEvent();
-        triggerEvent.setSubject(TRIGGER_SUBJECT);
-        triggerEvent.setEventParameters(triggerEventParameters);
-    }
-
-    private void setActionEvent() {
-        SortedSet<ActionParameter> actionEventParameters = new TreeSet<>();
-
-        actionEventParameters.add(new ActionParameterBuilder().setDisplayName("Phone").setKey("phone")
-                .setType(INTEGER).setOrder(0).build());
-
-        actionEventParameters.add(new ActionParameterBuilder().setDisplayName("Message").setKey("message")
-                .setType(TEXTAREA).setOrder(1).build());
-
-        actionEvent = new ActionEventBuilder().build();
-        actionEvent.setSubject(ACTION_SUBJECT);
-        actionEvent.setActionParameters(actionEventParameters);
-    }
-
-    private void setTaskActivities() {
-        taskActivities = new ArrayList<>(5);
-        taskActivities.add(new TaskActivity("Error1", task.getId(), ERROR));
-        taskActivities.add(new TaskActivity("Error2", task.getId(), ERROR));
-        taskActivities.add(new TaskActivity("Error3", task.getId(), ERROR));
-        taskActivities.add(new TaskActivity("Error4", task.getId(), ERROR));
-    }
-
     private void setFilters() {
         List<Filter> filters = new ArrayList<>();
         filters.add(new Filter("EventName (Trigger)", "trigger.eventName", UNICODE, true, CONTAINS.getValue(), "ven"));
@@ -1794,34 +1290,6 @@ public class TaskTriggerHandlerTest {
                 .setType(DATE).setRequired(false).build(), true);
     }
 
-    private MotechEvent createEvent() {
-        return createEvent(false);
-    }
-
-    private MotechEvent createEvent(boolean withCustomParser) {
-        Map<String, Object> param = createEventParameters();
-
-        if (withCustomParser) {
-            param.put(TasksEventParser.CUSTOM_PARSER_EVENT_KEY, SampleTasksEventParser.PARSER_NAME);
-        }
-
-        return new MotechEvent(TRIGGER_SUBJECT, param);
-    }
-
-    private Map<String, Object> createEventParameters() {
-        Map<String, Object> param = new HashMap<>(4);
-        param.put("externalId", 123456789);
-        param.put("startDate", new LocalDate(2012, 11, 20));
-        param.put("map", new HashMap<>(param));
-        param.put("endDate", new LocalDate(2012, 11, 29));
-        param.put("facilityId", 987654321);
-        param.put("eventName", "event name");
-        param.put("list", asList(1, 2, 3));
-        param.put("format", "%s || %s || %s");
-
-        return param;
-    }
-
     private List<Object> getExpectedList() {
         List<Object> list = new ArrayList<>();
         list.addAll(asList("4", "5"));
@@ -1840,10 +1308,6 @@ public class TaskTriggerHandlerTest {
         map.put("event name", "6789");
 
         return map;
-    }
-
-    private static <T> List<T> asList(T... items) {
-        return new ArrayList<>(Arrays.asList(items));
     }
 
 }

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TasksPostExecutionHandlerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TasksPostExecutionHandlerTest.java
@@ -1,0 +1,137 @@
+package org.motechproject.tasks.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.motechproject.config.SettingsFacade;
+import org.motechproject.event.MotechEvent;
+import org.motechproject.event.listener.EventRelay;
+import org.motechproject.tasks.constants.EventSubjects;
+import org.motechproject.tasks.constants.TaskFailureCause;
+import org.motechproject.tasks.domain.mds.task.Task;
+import org.motechproject.tasks.domain.mds.task.TaskActivity;
+import org.motechproject.tasks.exception.TaskHandlerException;
+import org.motechproject.tasks.service.TaskActivityService;
+import org.motechproject.tasks.service.TaskService;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static ch.lambdaj.Lambda.extract;
+import static ch.lambdaj.Lambda.on;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.motechproject.tasks.constants.EventSubjects.createHandlerFailureSubject;
+import static org.motechproject.tasks.constants.TaskFailureCause.TRIGGER;
+
+public class TasksPostExecutionHandlerTest extends TasksTestBase {
+
+    @Mock
+    private TaskService taskService;
+
+    @Mock
+    private TaskActivityService taskActivityService;
+
+    @Mock
+    private EventRelay eventRelay;
+
+    @Mock
+    private TaskRetryHandler retryHandler;
+
+    @Mock
+    private SettingsFacade settingsFacade;
+
+    @Mock
+    private TaskHandlerException taskHandlerException;
+
+    @InjectMocks
+    private TasksPostExecutionHandler postExecutionHandler = new TasksPostExecutionHandler();
+
+    @Captor
+    private ArgumentCaptor<TaskHandlerException> exceptionCaptor;
+
+    private TaskActivity taskActivity;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        initTask();
+        initTaskActivity();
+
+        when(taskService.getAllTasks()).thenReturn(tasks);
+        when(settingsFacade.getProperty("task.possible.errors")).thenReturn("5");
+        when(taskActivityService.addTaskStarted(any(Task.class), anyMap())).thenReturn(TASK_ACTIVITY_ID);
+        when(taskHandlerException.getFailureCause()).thenReturn(TaskFailureCause.TRIGGER);
+    }
+
+    @Test
+    public void shouldResetTasksFailuresCountOnSuccess() {
+        when(taskActivityService.addSuccessfulExecution(TASK_ACTIVITY_ID)).thenReturn(true);
+        when(taskActivityService.getTaskActivityById(TASK_ACTIVITY_ID)).thenReturn(taskActivity);
+        when(taskService.getTask(task.getId())).thenReturn(task);
+
+        task.setFailuresInRow(4);
+
+        postExecutionHandler.handleActionExecuted(createEventParameters(), new HashMap<>(), TASK_ACTIVITY_ID);
+
+        assertEquals(0, task.getFailuresInRow());
+        verify(taskService).save(task);
+    }
+
+    @Test
+    public void shoulNotifyOnSuccessfulTask() {
+        when(taskActivityService.addSuccessfulExecution(TASK_ACTIVITY_ID)).thenReturn(true);
+        when(taskActivityService.getTaskActivityById(TASK_ACTIVITY_ID)).thenReturn(taskActivity);
+        when(taskService.getTask(task.getId())).thenReturn(task);
+        postExecutionHandler.handleActionExecuted(createEventParameters(), new HashMap<>(), TASK_ACTIVITY_ID);
+
+        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+        verify(eventRelay).sendEventMessage(captorEvent.capture());
+        verify(retryHandler).handleTaskRetries(task, createEventParameters(), true, false);
+
+        MotechEvent motechEvent = captorEvent.getValue();
+        assertEquals(EventSubjects.createHandlerSuccessSubject(task.getName()), motechEvent.getSubject());
+    }
+
+    @Test
+    public void shouldDisableTaskWhenNumberOfPossibleErrorsIsExceeded() throws Exception {
+        setTriggerEvent();
+        setActionEvent();
+        setTaskActivities();
+        task.setFailuresInRow(taskActivities.size());
+
+        assertTrue(task.isEnabled());
+        postExecutionHandler.handleError(createEventParameters(), new HashMap<>(), task, taskHandlerException, TASK_ACTIVITY_ID);
+
+        // The task should get disabled now
+        assertFalse(task.isEnabled());
+
+        assertEquals(5, task.getFailuresInRow());
+
+        verify(taskService).save(task);
+        verify(taskActivityService).addTaskDisabledWarning(task);
+
+        ArgumentCaptor<MotechEvent> captorEvent = ArgumentCaptor.forClass(MotechEvent.class);
+        verify(eventRelay, times(2)).sendEventMessage(captorEvent.capture());
+
+        List<MotechEvent> capturedEvents = captorEvent.getAllValues();
+        assertEquals(asList("org.motechproject.message", createHandlerFailureSubject(task.getName(), TRIGGER)),
+                extract(capturedEvents, on(MotechEvent.class).getSubject()));
+    }
+
+    private void initTaskActivity() {
+        taskActivity = new TaskActivity();
+        taskActivity.setId(TASK_ACTIVITY_ID);
+        taskActivity.setTask(task.getId());
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TasksTestBase.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/impl/TasksTestBase.java
@@ -1,0 +1,132 @@
+package org.motechproject.tasks.service.impl;
+
+import org.joda.time.LocalDate;
+import org.motechproject.commons.api.TasksEventParser;
+import org.motechproject.event.MotechEvent;
+import org.motechproject.tasks.domain.mds.channel.ActionEvent;
+import org.motechproject.tasks.domain.mds.channel.ActionParameter;
+import org.motechproject.tasks.domain.mds.channel.EventParameter;
+import org.motechproject.tasks.domain.mds.channel.TriggerEvent;
+import org.motechproject.tasks.domain.mds.channel.builder.ActionEventBuilder;
+import org.motechproject.tasks.domain.mds.channel.builder.ActionParameterBuilder;
+import org.motechproject.tasks.domain.mds.task.Task;
+import org.motechproject.tasks.domain.mds.task.TaskActionInformation;
+import org.motechproject.tasks.domain.mds.task.TaskActivity;
+import org.motechproject.tasks.domain.mds.task.TaskTriggerInformation;
+import org.motechproject.tasks.service.SampleTasksEventParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.motechproject.tasks.domain.mds.ParameterType.DATE;
+import static org.motechproject.tasks.domain.mds.ParameterType.INTEGER;
+import static org.motechproject.tasks.domain.mds.ParameterType.LIST;
+import static org.motechproject.tasks.domain.mds.ParameterType.MAP;
+import static org.motechproject.tasks.domain.mds.ParameterType.TEXTAREA;
+import static org.motechproject.tasks.domain.mds.task.TaskActivityType.ERROR;
+
+public abstract class TasksTestBase {
+
+    protected static final String TRIGGER_SUBJECT = "APPOINTMENT_CREATE_EVENT_SUBJECT";
+    protected static final String ACTION_SUBJECT = "SEND_SMS";
+    protected static final String TASK_DATA_PROVIDER_NAME = "12345L";
+    protected static final Long TASK_ACTIVITY_ID = 11L;
+
+    protected Task task;
+    protected List<Task> tasks = new ArrayList<>(1);
+
+    protected List<TaskActivity> taskActivities;
+    protected TriggerEvent triggerEvent;
+    protected ActionEvent actionEvent;
+
+    protected void initTask() throws Exception {
+        Map<String, String> actionValues = new HashMap<>();
+        actionValues.put("phone", "123456");
+        actionValues.put("message", "Hello {{trigger.externalId}}, You have an appointment on {{trigger.startDate}}");
+
+        TaskTriggerInformation trigger = new TaskTriggerInformation("appointments", "Appointments", "appointments-bundle", "0.15", TRIGGER_SUBJECT, TRIGGER_SUBJECT);
+        TaskActionInformation action = new TaskActionInformation("sms", "SMS", "sms-bundle", "0.15", ACTION_SUBJECT, actionValues);
+
+        task = new Task();
+        task.setName("name");
+        task.setTrigger(trigger);
+        task.addAction(action);
+        task.setId(9l);
+        task.setHasRegisteredChannel(true);
+        tasks.add(task);
+    }
+
+    protected void setTriggerEvent() {
+        List<EventParameter> triggerEventParameters = new ArrayList<>();
+        triggerEventParameters.add(new EventParameter("ExternalID", "externalId"));
+        triggerEventParameters.add(new EventParameter("StartDate", "startDate", DATE));
+        triggerEventParameters.add(new EventParameter("EndDate", "endDate", DATE));
+        triggerEventParameters.add(new EventParameter("FacilityId", "facilityId"));
+        triggerEventParameters.add(new EventParameter("EventName", "eventName"));
+        triggerEventParameters.add(new EventParameter("List", "list", LIST));
+        triggerEventParameters.add(new EventParameter("Map", "map", MAP));
+
+        triggerEvent = new TriggerEvent();
+        triggerEvent.setSubject(TRIGGER_SUBJECT);
+        triggerEvent.setEventParameters(triggerEventParameters);
+    }
+
+    protected void setActionEvent() {
+        SortedSet<ActionParameter> actionEventParameters = new TreeSet<>();
+
+        actionEventParameters.add(new ActionParameterBuilder().setDisplayName("Phone").setKey("phone")
+                .setType(INTEGER).setOrder(0).build());
+
+        actionEventParameters.add(new ActionParameterBuilder().setDisplayName("Message").setKey("message")
+                .setType(TEXTAREA).setOrder(1).build());
+
+        actionEvent = new ActionEventBuilder().build();
+        actionEvent.setSubject(ACTION_SUBJECT);
+        actionEvent.setActionParameters(actionEventParameters);
+    }
+
+    protected void setTaskActivities() {
+        taskActivities = new ArrayList<>(5);
+        taskActivities.add(new TaskActivity("Error1", task.getId(), ERROR));
+        taskActivities.add(new TaskActivity("Error2", task.getId(), ERROR));
+        taskActivities.add(new TaskActivity("Error3", task.getId(), ERROR));
+        taskActivities.add(new TaskActivity("Error4", task.getId(), ERROR));
+    }
+
+    protected MotechEvent createEvent() {
+        return createEvent(false);
+    }
+
+    protected MotechEvent createEvent(boolean withCustomParser) {
+        Map<String, Object> param = createEventParameters();
+
+        if (withCustomParser) {
+            param.put(TasksEventParser.CUSTOM_PARSER_EVENT_KEY, SampleTasksEventParser.PARSER_NAME);
+        }
+
+        return new MotechEvent(TRIGGER_SUBJECT, param);
+    }
+
+    protected Map<String, Object> createEventParameters() {
+        Map<String, Object> param = new HashMap<>(4);
+        param.put("externalId", 123456789);
+        param.put("startDate", new LocalDate(2012, 11, 20));
+        param.put("map", new HashMap<>(param));
+        param.put("endDate", new LocalDate(2012, 11, 29));
+        param.put("facilityId", 987654321);
+        param.put("eventName", "event name");
+        param.put("list", asList(1, 2, 3));
+        param.put("format", "%s || %s || %s");
+
+        return param;
+    }
+
+    protected static <T> List<T> asList(T... items) {
+        return new ArrayList<>(Arrays.asList(items));
+    }
+}

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/util/TaskContextTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/util/TaskContextTest.java
@@ -62,7 +62,7 @@ public class TaskContextTest {
     @Test
     public void shouldThrowExceptionWhenAccessingUnconfiguredDataSource() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", new TestDataSourceObject(), false);
 
         KeyInformation key = parse("ad.1.Integer#2.id");
@@ -75,7 +75,7 @@ public class TaskContextTest {
     @Test
     public void shouldThrowExceptionWhenDataSourceIsNull() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", null, true);
 
         KeyInformation key = parse("ad.1.Integer#1.id");
@@ -88,7 +88,7 @@ public class TaskContextTest {
     @Test
     public void shouldNotThrowExceptionWhenDataSourceIsNull_IfFailNotFoundIsFalse() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", null, false);
 
         KeyInformation key = parse("ad.1.Integer#1.id");
@@ -99,7 +99,7 @@ public class TaskContextTest {
     @Test
     public void shouldThrowExceptionWhenDataSourceFieldValueEvaluationThrowsException() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", new TestDataSourceObject(), true);
 
         KeyInformation key = parse("ad.1.Integer#1.providerId");
@@ -112,7 +112,7 @@ public class TaskContextTest {
     @Test
     public void shouldNotThrowExceptionWhenDataSourceFieldValueEvaluationThrowsException_IfFailNotFoundIsFalse() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", new TestDataSourceObject(), false);
 
         KeyInformation key = parse("ad.1.Integer#1.providerId");
@@ -123,7 +123,7 @@ public class TaskContextTest {
     @Test
     public void testGetDataSourceValue() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", new TestDataSourceObject(), true);
 
         KeyInformation key = parse("ad.1.Integer#1.id");
@@ -134,7 +134,7 @@ public class TaskContextTest {
     @Test
     public void testGetDataSourceValueForBooleanWithGetterIs() throws Exception {
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         taskContext.addDataSourceObject("1", new TestDataSourceObject(), true);
 
         KeyInformation key = parse("ad.1.Boolean#1.checked");
@@ -147,7 +147,7 @@ public class TaskContextTest {
         Map<String, Object> parameters = new HashMap<>();
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
 
         KeyInformation key = parse(String.format("%s.%s", TRIGGER_PREFIX, EVENT_KEY));
         assertEquals(null, taskContext.getTriggerValue(key.getKey()));
@@ -156,7 +156,7 @@ public class TaskContextTest {
         child.put("key", EVENT_KEY_VALUE);
         parameters.put("event", child);
 
-        taskContext = new TaskContext(task, parameters, activityService);
+        taskContext = new TaskContext(task, parameters, null, activityService);
 
         assertEquals(EVENT_KEY_VALUE, taskContext.getTriggerValue(key.getKey()));
     }
@@ -164,12 +164,12 @@ public class TaskContextTest {
     @Test(expected = IllegalStateException.class)
     public void testGetTriggerKeyShouldThrowException() throws Exception {
         MotechEvent event = mock(MotechEvent.class);
-        when(event.getParameters()).thenReturn(new HashMap<String, Object>());
+        when(event.getParameters()).thenReturn(new HashMap<>());
 
         KeyInformation key = parse(String.format("%s.%s", TRIGGER_PREFIX, EVENT_KEY));
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        new TaskContext(task, event.getParameters(), activityService).getTriggerValue(key.getKey());
+        new TaskContext(task, event.getParameters(), null, activityService).getTriggerValue(key.getKey());
     }
 
     @Test
@@ -186,10 +186,10 @@ public class TaskContextTest {
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
 
-        assertEquals(null, new TaskContext(task, parameters, activityService).getTriggerValue(key.getKey()));
+        assertEquals(null, new TaskContext(task, parameters, null, activityService).getTriggerValue(key.getKey()));
 
         // should not throw any exceptions
-        assertNull(new TaskContext(task, parameters, activityService).getTriggerValue(key.getKey()));
+        assertNull(new TaskContext(task, parameters, null, activityService).getTriggerValue(key.getKey()));
     }
 
     private class TaskHandlerExceptionMatcher extends TypeSafeMatcher<Object> {

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/util/TaskFilterExecutorTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/service/util/TaskFilterExecutorTest.java
@@ -67,7 +67,7 @@ public class TaskFilterExecutorTest {
         when(taskConfig.getDataSource(anyString(), anyLong(), anyString())).thenReturn(dataSource);
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, null, activityService);
+        TaskContext taskContext = new TaskContext(task, null, null, activityService);
         TaskFilterExecutor taskFilterExecutor = new TaskFilterExecutor();
 
         assertTrue(taskFilterExecutor.checkFilters(null, null, taskContext));
@@ -106,7 +106,7 @@ public class TaskFilterExecutorTest {
         filters.add(new Filter("MRS.Person#1.Dead", "ad.2.Person#1.dead", BOOLEAN, false, AND.getValue(), "false"));
         filters.add(new Filter("MRS.Person#1.Dead", "ad.2.Person#1.dead", BOOLEAN, true, OR.getValue(), "true"));
 
-        taskContext = new TaskContext(task, new HashMap<>(), activityService);
+        taskContext = new TaskContext(task, new HashMap<>(), new HashMap<>(), activityService);
         assertFalse(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.OR, taskContext));
 
@@ -114,7 +114,7 @@ public class TaskFilterExecutorTest {
         triggerParameters.put("eventName", "etName");
         triggerParameters.put("externalId", "12345");
 
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("Eman"), false);
         taskContext.addDataSourceObject("1", new Person(150, true), false);
         assertFalse(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -122,7 +122,7 @@ public class TaskFilterExecutorTest {
 
         triggerParameters.put("eventName", "event name");
         triggerParameters.put("externalId", "123456789");
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, false), false);
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -145,7 +145,7 @@ public class TaskFilterExecutorTest {
         filters.add(moreDays);
 
         triggerParameters.put("test_date", dateTime.toString());
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, false), false);
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -165,7 +165,7 @@ public class TaskFilterExecutorTest {
         dateTime = DateTime.now().minusMonths(3);
 
         triggerParameters.put("test_date", dateTime.toString());
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, false), false);
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -173,7 +173,7 @@ public class TaskFilterExecutorTest {
         dateTime = dateTime.plusMonths(6);
 
         triggerParameters.put("test_date", dateTime.toString());
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, false), false);
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -184,7 +184,7 @@ public class TaskFilterExecutorTest {
         before.setNegationOperator(!before.isNegationOperator());
         beforeNow.setNegationOperator(!beforeNow.isNegationOperator());
 
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, false), false);
         assertTrue(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -194,7 +194,7 @@ public class TaskFilterExecutorTest {
         Filter additionalDataFilter = new Filter("CMS Lite.StreamContent#0.Name", "ad.1.StreamContent#0.name", UNICODE, true, "abc", "");
         filters.add(additionalDataFilter);
 
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, true), false);
         assertFalse(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -205,7 +205,7 @@ public class TaskFilterExecutorTest {
         filters.remove(additionalDataFilter);
         filters.add(new Filter("MRS.Person#1.Age", "ad.2.Person#1.age", INTEGER, true, "abc", ""));
 
-        taskContext = new TaskContext(task, triggerParameters, activityService);
+        taskContext = new TaskContext(task, triggerParameters, new HashMap<>(), activityService);
         taskContext.addDataSourceObject("0", new StreamContent("name"), false);
         taskContext.addDataSourceObject("1", new Person(46, true), false);
         assertFalse(taskFilterExecutor.checkFilters(filters, LogicalOperator.AND, taskContext));
@@ -218,7 +218,7 @@ public class TaskFilterExecutorTest {
         filters.add(new Filter("MRS.Person#2.Age", "ad.2.Person#2.age", INTEGER, false, EXIST.getValue(), ""));
 
         Task task = new TaskBuilder().addAction(new TaskActionInformation()).build();
-        TaskContext taskContext = new TaskContext(task, new HashMap<>(), activityService);
+        TaskContext taskContext = new TaskContext(task, new HashMap<>(), new HashMap<>(), activityService);
         new TaskFilterExecutor().checkFilters(filters, LogicalOperator.AND, taskContext);
     }
 

--- a/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/ActivityControllerTest.java
+++ b/modules/tasks/tasks/src/test/java/org/motechproject/tasks/web/ActivityControllerTest.java
@@ -7,6 +7,7 @@ import org.motechproject.mds.query.QueryParams;
 import org.motechproject.tasks.domain.mds.task.Task;
 import org.motechproject.tasks.domain.mds.task.TaskActivity;
 import org.motechproject.tasks.domain.mds.task.TaskActivityType;
+import org.motechproject.tasks.domain.mds.task.TaskExecutionProgress;
 import org.motechproject.tasks.service.TaskActivityService;
 import org.motechproject.tasks.service.impl.TaskTriggerHandler;
 
@@ -64,7 +65,7 @@ public class ActivityControllerTest {
         expected.add(new TaskActivity(SUCCESS.getValue(), TASK_ID, SUCCESS));
         expected.add(new TaskActivity(WARNING.getValue(), TASK_ID, WARNING));
         expected.add(new TaskActivity(ERROR.getValue(), TASK_ID, ERROR));
-        expected.add(new TaskActivity(ERROR.getValue(), new ArrayList<String>(), TASK_ID, ERROR, null, params));
+        expected.add(new TaskActivity(ERROR.getValue(), new ArrayList<>(), TASK_ID, ERROR, null, params, new TaskExecutionProgress(1)));
 
         activityTypes = new HashSet<>();
         activityTypes.addAll(Arrays.asList(TaskActivityType.values()));

--- a/platform/event/src/main/java/org/motechproject/event/listener/impl/ServerEventRelay.java
+++ b/platform/event/src/main/java/org/motechproject/event/listener/impl/ServerEventRelay.java
@@ -206,7 +206,7 @@ public class ServerEventRelay implements EventRelay, EventHandler {
             }
         } catch (InvalidSyntaxException e) {
             //Should never happen
-            LOGGER.error("Passed filter expression is incorrect.");
+            LOGGER.error("Passed filter expression is incorrect.", e);
         }
 
         // If a non-null callback name has been provided, yet it cannot be found in

--- a/platform/event/src/test/java/org/motechproject/event/listener/impl/ServerEventRelayTest.java
+++ b/platform/event/src/test/java/org/motechproject/event/listener/impl/ServerEventRelayTest.java
@@ -129,7 +129,6 @@ public class ServerEventRelayTest {
         when(bundleContext.getServiceReferences(EventCallbackService.class, null)).thenReturn(Arrays.asList(serviceReference));
         when(bundleContext.getService(serviceReference)).thenReturn(callbackService);
         when(callbackService.getName()).thenReturn(TEST_SERVICE_CALLBACK);
-
         RuntimeException initCause = new RuntimeException();
         doThrow(new RuntimeException("Failed", initCause)).when(eventListener).handle(any(MotechEvent.class));
 


### PR DESCRIPTION
* MOTECH-2296 Task retries for event-based actions

This commit enhances the task retries for the event-based
task actions. Default event system retries are no longer
invoked for task actions. The event module allows to register
event callbacks now, that will be invoked when the event
is handled. Moreover, the Task module now keeps the track
of the task executions.

* MOTECH-2296 Review comments incorporation

* MOTECH-2296 Small refactor

* MOTECH-2296 Test fixes

* MOTECH-2296 Resolved conflicts and small fixes

* MOTECH-2296: Fixed multiply reply count and bubbles parameters

* MOTECH-2296: Changed condition

* MOTECH-2296: Checkstyle...

* MOTECH-2296: Added trigger params to event - without fixed tests

* MOTECH-2296: Added condition to adding task params only for events