### PR TITLE
MOTECH-2336: Fixed error during deleting "Key/Value Pairs" from MDS

### DIFF
--- a/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
+++ b/platform/mds/mds-web/src/main/resources/webapp/js/directives.js
@@ -3266,9 +3266,7 @@
                         if ((value !== null && value.length === 0) || value === null) {
                             value = "";
                         }
-                        scope.safeApply(function () {
-                            scope.field.value = value;
-                        });
+                        scope.field.value = value;
                     }
                 });
             }


### PR DESCRIPTION
`scope.field.value = value;` could not pass function safeApply