### PR TITLE
Use node-sass 3.8.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "gulp-watch": "^4.3.5",
     "mkdirp": "~0.5.1",
     "node-bourbon": "4.2.3",
+    "node-sass": "3.8.0",
     "nunjucks": "~2.2.0",
     "path": "~0.12.7",
     "promise": "^7.1.1",


### PR DESCRIPTION
The latest node-sass does not seem to work with Node 4.x.
This is an attempt to get the build working until node-sass
fixes their isuses with Node 4.x