### PR TITLE
Extented .gitignore about files which contains .log*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ maven-eclipse.xml
 *.ipr
 *.iws
 *.class
-*.log
+*.log*
 Motech.log*
 debug.txt
 out/


### PR DESCRIPTION
When I was doing some ticket I saw that file named velocity.log.1 is attached every time to my commit when I make push on github. Added .log* to .gitignore is repairing this problem.